### PR TITLE
ci: build kernel on PRs (no cascade to module build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
     types: [toolchain-updated]
   push:
     paths: ['patches/**', 'config/**']
+  pull_request:
+    # Validate the kernel build on PRs touching patches/config/workflow. PR
+    # runs never cascade — the module-build trigger is gated on
+    # github.event_name == 'repository_dispatch', which a pull_request is not.
+    paths: ['patches/**', 'config/**', '.github/workflows/build.yml']
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Adds a `pull_request` trigger so the kernel cross-build (amd64 + arm64) is validated before merge. Same pattern just proven in nextbsd-kernel-toolchain#7.

**No cascade:** the `Trigger module build` step is gated on `github.event_name == 'repository_dispatch'`. A `pull_request` event is not a `repository_dispatch`, so the modules dispatch is skipped on PRs.

**Nothing to leak:** the kernel job only uploads workflow artifacts (no GHCR push), and those are scoped to the PR run.

Path-filtered to `patches/**`, `config/**`, and the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)