### PR TITLE
patch: widen lkmnosys dynamic syscall band to 58 slots for mach.ko

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,23 @@ jobs:
             git apply "$GITHUB_WORKSPACE/patches/$p"
           done
 
+      # A syscalls.master patch changes the GENERATED syscall tables
+      # (init_sysent.c, sys/sys/syscall.h, sysproto.h, syscalls.c, ...).
+      # buildkernel compiles the committed generated files and does NOT
+      # regenerate them, so run the `sysent` target in the build env (where
+      # flua from the baked kernel-toolchain is on PATH) to regenerate them in
+      # the runner's /usr/src before building. No generated source is ever
+      # committed to this repo — it carries patches only. Idempotent when no
+      # patch touches syscalls.master.
+      - name: Regenerate syscall tables (sysent)
+        run: |
+          cd /usr/src
+          ./tools/build/make.py \
+            --cross-bindir="${CCACHE_CROSS_BINDIR}" \
+            TARGET="${{ matrix.target }}" \
+            TARGET_ARCH="${{ matrix.target_arch }}" \
+            buildenv BUILDENV_SHELL='make -C sys/kern sysent'
+
       - name: Copy kernel config
         run: cp "$GITHUB_WORKSPACE/config/NEXTBSD" /usr/src/sys/${{ matrix.target }}/conf/
 

--- a/patches/0001-NextBSD-widen-lkmnosys-dynamic-syscall-band-to-58-sl.patch
+++ b/patches/0001-NextBSD-widen-lkmnosys-dynamic-syscall-band-to-58-sl.patch
@@ -1,0 +1,82 @@
+From 1ba4633f09c1cb9656f0c145ee90af81b3d0845e Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 3 Jun 2026 15:09:50 -0500
+Subject: [PATCH] NextBSD: widen lkmnosys dynamic syscall band to 58 slots for
+ mach.ko
+
+Append 48 lkmnosys slots (599-646) so mach.ko can register each Mach trap as
+its own dynamically-allocated syscall instead of folding them behind the
+single-slot multiplexor. Tail-append only (ABI-additive; no renumbering).
+The generated companions (init_sysent.c, sys/sys/syscall.h, sysproto.h,
+syscalls.c, systrace_args.c, syscall.mk) are regenerated at build time via
+'make sysent' (see the build workflow's regenerate step).
+---
+ sys/kern/syscalls.master | 53 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 53 insertions(+)
+
+diff --git a/sys/kern/syscalls.master b/sys/kern/syscalls.master
+index 967af1f..36a1007 100644
+--- a/sys/kern/syscalls.master
++++ b/sys/kern/syscalls.master
+@@ -3393,5 +3393,58 @@
+ 		    int fd
+ 		);
+ 	}
++; NextBSD: widened loadable-syscall band for mach.ko. The stock 10
++; lkmnosys slots (210-219) are exhausted by the Mach trap set; these
++; give mach.ko room to register each Mach trap as its own syscall and
++; retire the single-slot multiplexor. Tail-appended (ABI-additive).
++599	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++600	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++601	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++602	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++603	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++604	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++605	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++606	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++607	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++608	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++609	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++610	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++611	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++612	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++613	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++614	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++615	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++616	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++617	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++618	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++619	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++620	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++621	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++622	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++623	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++624	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++625	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++626	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++627	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++628	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++629	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++630	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++631	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++632	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++633	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++634	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++635	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++636	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++637	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++638	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++639	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++640	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++641	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++642	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++643	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++644	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++645	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++646	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++
+ 
+ ; vim: syntax=off
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -1,0 +1,1 @@
+0001-NextBSD-widen-lkmnosys-dynamic-syscall-band-to-58-sl.patch


### PR DESCRIPTION
PR #1 of the two-PR rollout for nextbsd-redux/nextbsd#174 (the second drops the `mach.ko` multiplexor in `nextbsd`). Plan: https://pkgdemon.github.io/freebsd-mach-kmod-syscall-slots-impl-plan.html

## What
- **`patches/0001-...-widen-lkmnosys-...patch`** edits only `sys/kern/syscalls.master`, appending **48 `lkmnosys` slots (599–646)** at the tail. Combined with the stock 210–219 band that's **58** dynamically-claimable slots — comfortably above the measured ~32 Mach traps, with headroom so we never hit the `ENFILE` wall (and the multiplexor) again. Tail-append only → **ABI-additive, no renumbering**.
- **New build step "Regenerate syscall tables (sysent)"**: a `syscalls.master` change also drives the generated tables (`init_sysent.c`, `sys/sys/syscall.h`, `sysproto.h`, `syscalls.c`, …). `buildkernel` compiles the committed generated files and does **not** regenerate them, so the step runs `make sysent` in `buildenv` on the runner's `/usr/src` before building. **No generated source is committed** — this repo carries patches only.

## Why this is safe / in-bounds
- Authored against a throwaway **upstream** `releng/15.0` checkout; the `freebsd-src` fork is never touched, and no source tree is added to this repo (patches only).
- `git apply --check` verified clean against pristine `releng/15.0`.
- mach.ko auto-allocates and resolves by `sysctl mach.syscall.<name>`, so widening the band needs **zero userland change**; the mux-drop is a separate `nextbsd` PR.

## CI validation
- Builds both arches (amd64 + arm64) against the patched, regenerated table.
- The amd64 **boot smoke test** injects this kernel into the latest `continuous` NextBSD ISO and boots it — proving the wider-band kernel still boots (the shipped mach.ko keeps auto-allocating into 210–219; the new slots are exercised once PR #2's mach.ko lands).

⚠️ The `make sysent` regeneration step is the one piece not locally verifiable on a non-FreeBSD host — this PR's CI is its first real exercise. If `flua`/`buildenv` needs adjustment, I'll iterate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)