### PR TITLE
patch: reserve EVFILT_MACHPORT kqueue filter slot (-16)

### DIFF
--- a/patches/0003-kqueue-reserve-evfilt-machport.patch
+++ b/patches/0003-kqueue-reserve-evfilt-machport.patch
@@ -1,0 +1,36 @@
+From 3440c2cca309018dd72910abbfb07ee512c9bea4 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 3 Jun 2026 18:41:16 -0500
+Subject: [PATCH] kqueue: reserve EVFILT_MACHPORT filter slot (-16)
+
+Reserve a new kqueue filter number EVFILT_MACHPORT (-16) and bump
+EVFILT_SYSCOUNT 15 -> 16. This is an inert slot reservation only; the
+filter implementation is registered at runtime by mach.ko via
+kqueue_add_filteropts(9). No kern_event.c change is required: the
+sysfilt_ops[EVFILT_SYSCOUNT] table uses designated initializers, so the
+larger array leaves index [~EVFILT_MACHPORT] zero-initialized (for_fop ==
+NULL), which kqueue_fo_find() resolves to null_filtops until mach.ko
+registers the real filterops.
+
+Carried out-of-tree for NextBSD.
+---
+ sys/sys/event.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/sys/sys/event.h b/sys/sys/event.h
+index 084eaafc..5ebac606 100644
+--- a/sys/sys/event.h
++++ b/sys/sys/event.h
+@@ -47,7 +47,8 @@
+ #define EVFILT_EMPTY		(-13)	/* empty send socket buf */
+ #define EVFILT_JAIL		(-14)	/* attached to struct prison */
+ #define EVFILT_JAILDESC		(-15)	/* attached to jail descriptors */
+-#define EVFILT_SYSCOUNT		15
++#define EVFILT_MACHPORT		(-16)	/* Mach IPC port; registered by mach.ko */
++#define EVFILT_SYSCOUNT		16
+ 
+ #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+ #define	EV_SET(kevp_, a, b, c, d, e, f) do {	\
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -1,2 +1,3 @@
 0001-NextBSD-widen-lkmnosys-dynamic-syscall-band-to-58-sl.patch
 0002-newbus-device-match-quiesce-hook.patch
+0003-kqueue-reserve-evfilt-machport.patch


### PR DESCRIPTION
**Phase 1** kernel reservation for the device-matching convergence (nextbsd-redux/nextbsd#177 / #168). Lets a Mach receive port/pset later be registered in a `kqueue(2)` so a daemon (configd) can watch its Mach service port + device events in one loop.

## What
`patches/0003-kqueue-reserve-evfilt-machport.patch` — a 2-line `sys/sys/event.h` change: define `EVFILT_MACHPORT (-16)` and bump `EVFILT_SYSCOUNT` 15→16.

## Why this is the whole kernel change
**Inert reservation only** — the filter *implementation* is registered at runtime by **mach.ko** via `kqueue_add_filteropts(9)` (a follow-up `nextbsd` PR), reusing mach.ko's existing pset-signal seam. No `kern_event.c` change is needed: `sysfilt_ops[EVFILT_SYSCOUNT]` uses designated initializers, so the new index `[~EVFILT_MACHPORT]` is zero-filled and `kqueue_fo_find()` resolves the NULL slot to `null_filtops` (clean `ENXIO`) until mach.ko installs the real filterops. The `kqueue_add_filteropts`/`fo_find`/`fo_release` range checks are arithmetic on `EVFILT_SYSCOUNT` and correctly admit `-16`. Audited all 7 `EVFILT_SYSCOUNT` uses — nothing else breaks.

## In-bounds / validation
- Authored against a throwaway **upstream** `releng/15.0` checkout; the fork is never touched; repo carries patches only.
- `git apply --check` clean on pristine `releng/15.0`; plain `.h`, no regen.
- The reservation is inert with no consumer, so CI here proves the patched kernel still builds (amd64+arm64) and **boots** (PR smoke test). The mach.ko filter + a test land in a follow-up `nextbsd` PR after this merges and kernel `continuous` refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)