### PR TITLE
NEXTBSD: bake ROOTDEVNAME + INIT_PATH into the kernel (#180)

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -5,3 +5,12 @@ ident	NEXTBSD
 # NextBSD kernel configuration.
 # Starts as stock GENERIC; add Mach/launchd-related options and devices below
 # as patches in ../patches/ introduce them.
+
+# Bake the root device and init path into the kernel so loader.conf doesn't
+# have to set vfs.root.mountfrom / init_path (#180, eliminating loader.conf).
+# Both are stock config options (sys/conf/options); the loader tunables still
+# override these when present, so they are a safe compiled-in default.
+#   ROOTDEVNAME -> a C string used by vfs_mountroot (quoted).
+#   INIT_PATH   -> stringified via __XSTRING in init_main.c (unquoted).
+options 	ROOTDEVNAME=\"ufs:/dev/ufs/ROOTFS\"
+options 	INIT_PATH=/sbin/launchd


### PR DESCRIPTION
Compile the root device (`ROOTDEVNAME="ufs:/dev/ufs/ROOTFS"`) and init path (`INIT_PATH=/sbin/launchd`) into the kernel so `loader.conf` needn't set `vfs.root.mountfrom` / `init_path` — next step of eliminating `loader.conf` (#180, after #181 mach-into-kernel).

Both are stock config options (`sys/conf/options`; `vfs_mountroot.c`/`init_main.c` already include the opt headers). The loader tunables **override** these when present, so this PR alone changes nothing at boot — it just adds safe compiled-in defaults. This PR's CI validates the config builds on both arches.

The proof comes in the **nextbsd follow-up** that drops the two `loader.conf` lines: its boot test then boots on the compiled-in ROOTDEVNAME/INIT_PATH. Modules build is unaffected (these are standard options; NO_KERNEL doesn't compile the consumers).