### PR TITLE
K2 (#215): in-kernel IOKit catalogue (store + ioctl + sysctl)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,21 @@ jobs:
             printf 'options\tCOMPAT_MACH\n' >> /usr/src/sys/${{ matrix.target }}/conf/NEXTBSD
           echo "==> mach wired in; compat/mach .c files: $(grep -c 'optional compat_mach' /usr/src/sys/conf/files)"
 
+      # In-kernel IOKit catalogue (K2, nextbsd#215). iokit_catalogue.c +
+      # sys/iocatalogue.h are laid into /usr/src/sys by the overlay cp above;
+      # here we just append its files fragment to the kernel source list. It is
+      # `standard` (always compiled) and needs no option/config line. Wired here
+      # (not in patches/series) for the same reason as mach: the modules build
+      # shares the series but does not lay in the overlay, so it must never see
+      # this source listed in sys/conf/files.
+      - name: Wire in-kernel IOKit catalogue (K2, #215)
+        run: |
+          set -eu
+          cat "$GITHUB_WORKSPACE/src-overlay/conf/files.iocatalogue" >> /usr/src/sys/conf/files
+          test -f /usr/src/sys/dev/iokit/iokit_catalogue.c
+          test -f /usr/src/sys/sys/iocatalogue.h
+          echo "==> iocatalogue wired: $(grep -c 'dev/iokit/iokit_catalogue.c' /usr/src/sys/conf/files) entry; source + header present"
+
       - name: Build kernel (no modules)
         run: |
           cd /usr/src

--- a/src-overlay/conf/files.iocatalogue
+++ b/src-overlay/conf/files.iocatalogue
@@ -1,0 +1,7 @@
+# NextBSD in-kernel IOKit catalogue (K2, nextbsd#215) — appended to
+# sys/conf/files by the kernel build. Source under sys/dev/iokit, laid in from
+# the nextbsd-kernel src-overlay. `standard`: always compiled into the kernel
+# (the store is inert until the K3 matcher, nextbsd#216, calls it). Wired in
+# build.yml, NOT in patches/series, so the modules build (which shares the
+# series but does not lay in the overlay) never sees an absent source.
+dev/iokit/iokit_catalogue.c	standard

--- a/src-overlay/sys/dev/iokit/iokit_catalogue.c
+++ b/src-overlay/sys/dev/iokit/iokit_catalogue.c
@@ -1,0 +1,202 @@
+/*
+ * NextBSD in-kernel IOKit catalogue (K2, nextbsd#215).
+ *
+ * Flat in-kernel store of IOKit driver personalities, pushed from userland
+ * (kextd) via ioctl on /dev/iocatalogue — mechanism (a): the kernel never
+ * parses XML. The K3 matcher (nextbsd#216) calls iocat_lookup_pci() from the
+ * device_nomatch path to find the driver bundle that claims an unmatched device.
+ *
+ * See sys/sys/iocatalogue.h and the design in
+ * pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html §9.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/malloc.h>
+#include <sys/queue.h>
+#include <sys/sx.h>
+#include <sys/conf.h>
+#include <sys/sbuf.h>
+#include <sys/sysctl.h>
+#include <sys/iocatalogue.h>
+
+static MALLOC_DEFINE(M_IOCAT, "iocatalogue", "in-kernel IOKit catalogue");
+
+static TAILQ_HEAD(, iocat_record) iocat_list =
+    TAILQ_HEAD_INITIALIZER(iocat_list);
+static struct sx iocat_lock;
+SX_SYSINIT(iocat_lock, &iocat_lock, "iocatalogue");
+static u_int iocat_count;	/* # records; mutated under iocat_lock */
+
+static void
+iocat_free_record(struct iocat_record *r)
+{
+	if (r->match != NULL)
+		free(r->match, M_IOCAT);
+	free(r, M_IOCAT);
+}
+
+static void
+iocat_flush(void)
+{
+	struct iocat_record *r;
+
+	sx_xlock(&iocat_lock);
+	while ((r = TAILQ_FIRST(&iocat_list)) != NULL) {
+		TAILQ_REMOVE(&iocat_list, r, link);
+		iocat_free_record(r);
+	}
+	iocat_count = 0;
+	sx_xunlock(&iocat_lock);
+}
+
+static int
+iocat_add(struct iocat_add *ua)
+{
+	struct iocat_record *r;
+	uint32_t *match;
+	size_t sz;
+	int error;
+
+	if (ua->nmatch == 0 || ua->nmatch > IOCAT_MAX_MATCH)
+		return (EINVAL);
+	/* Force a NUL terminator, then reject an empty bundle id. */
+	ua->bundle_id[IOCAT_BUNDLE_ID_MAX - 1] = '\0';
+	if (ua->bundle_id[0] == '\0')
+		return (EINVAL);
+
+	sz = (size_t)ua->nmatch * sizeof(uint32_t);
+	match = malloc(sz, M_IOCAT, M_WAITOK);
+	error = copyin((const void *)(uintptr_t)ua->match, match, sz);
+	if (error != 0) {
+		free(match, M_IOCAT);
+		return (error);
+	}
+
+	r = malloc(sizeof(*r), M_IOCAT, M_WAITOK | M_ZERO);
+	strlcpy(r->bundle_id, ua->bundle_id, sizeof(r->bundle_id));
+	r->provider_class = ua->provider_class;
+	r->probe_score = ua->probe_score;
+	r->nmatch = ua->nmatch;
+	r->match = match;
+
+	sx_xlock(&iocat_lock);
+	TAILQ_INSERT_TAIL(&iocat_list, r, link);
+	iocat_count++;
+	sx_xunlock(&iocat_lock);
+	return (0);
+}
+
+int
+iocat_lookup_pci(uint32_t match_word, char *buf, size_t buflen,
+    int32_t *score_out)
+{
+	struct iocat_record *r, *best;
+	uint32_t i;
+
+	best = NULL;
+	sx_slock(&iocat_lock);
+	TAILQ_FOREACH(r, &iocat_list, link) {
+		if (r->provider_class != IOCAT_PROVIDER_IOPCIDEVICE)
+			continue;
+		for (i = 0; i < r->nmatch; i++) {
+			if (r->match[i] != match_word)
+				continue;
+			if (best == NULL || r->probe_score > best->probe_score)
+				best = r;
+			break;
+		}
+	}
+	if (best != NULL) {
+		strlcpy(buf, best->bundle_id, buflen);
+		if (score_out != NULL)
+			*score_out = best->probe_score;
+	}
+	sx_sunlock(&iocat_lock);
+	return (best != NULL ? 0 : ENOENT);
+}
+
+/* ---- /dev/iocatalogue: ioctl ingestion from userland (kextd) ---- */
+
+static d_ioctl_t iocat_ioctl;
+static struct cdev *iocat_dev;
+static struct cdevsw iocat_cdevsw = {
+	.d_version = D_VERSION,
+	.d_ioctl   = iocat_ioctl,
+	.d_name    = "iocatalogue",
+};
+
+static int
+iocat_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t data,
+    int fflag __unused, struct thread *td __unused)
+{
+	switch (cmd) {
+	case IOCATIOCADD:
+		return (iocat_add((struct iocat_add *)data));
+	case IOCATIOCFLUSH:
+		iocat_flush();
+		return (0);
+	default:
+		return (ENOTTY);
+	}
+}
+
+/* ---- hw.iokit.catalogue: read-only text dump (debug + hwregd transition) ---- */
+
+static int
+iocat_sysctl_dump(SYSCTL_HANDLER_ARGS)
+{
+	struct iocat_record *r;
+	struct sbuf sb;
+	uint32_t i;
+	int error;
+
+	/* Build into auto-extending memory under the lock, copy out after. */
+	sbuf_new(&sb, NULL, 256, SBUF_AUTOEXTEND);
+	sx_slock(&iocat_lock);
+	TAILQ_FOREACH(r, &iocat_list, link) {
+		sbuf_printf(&sb, "%s provider=%u score=%d match=",
+		    r->bundle_id, r->provider_class, r->probe_score);
+		for (i = 0; i < r->nmatch; i++)
+			sbuf_printf(&sb, "%s0x%08x", i ? "," : "", r->match[i]);
+		sbuf_cat(&sb, "\n");
+	}
+	sx_sunlock(&iocat_lock);
+	error = sbuf_finish(&sb);
+	if (error == 0)
+		error = SYSCTL_OUT(req, sbuf_data(&sb), sbuf_len(&sb) + 1);
+	sbuf_delete(&sb);
+	return (error);
+}
+
+static SYSCTL_NODE(_hw, OID_AUTO, iokit, CTLFLAG_RD | CTLFLAG_MPSAFE, 0,
+    "NextBSD in-kernel IOKit");
+SYSCTL_PROC(_hw_iokit, OID_AUTO, catalogue,
+    CTLTYPE_STRING | CTLFLAG_RD | CTLFLAG_MPSAFE, NULL, 0,
+    iocat_sysctl_dump, "A", "IOKit catalogue (registered driver personalities)");
+SYSCTL_UINT(_hw_iokit, OID_AUTO, catalogue_count, CTLFLAG_RD,
+    &iocat_count, 0, "number of registered personalities");
+
+static int
+iocat_modevent(module_t mod __unused, int type, void *data __unused)
+{
+	switch (type) {
+	case MOD_LOAD:
+		iocat_dev = make_dev(&iocat_cdevsw, 0, UID_ROOT, GID_WHEEL,
+		    0600, "iocatalogue");
+		return (iocat_dev != NULL ? 0 : ENXIO);
+	case MOD_UNLOAD:
+		if (iocat_dev != NULL)
+			destroy_dev(iocat_dev);
+		iocat_flush();
+		return (0);
+	default:
+		return (EOPNOTSUPP);
+	}
+}
+
+static moduledata_t iocat_mod = { "iocatalogue", iocat_modevent, NULL };
+DECLARE_MODULE(iocatalogue, iocat_mod, SI_SUB_DRIVERS, SI_ORDER_ANY);
+MODULE_VERSION(iocatalogue, 1);

--- a/src-overlay/sys/sys/iocatalogue.h
+++ b/src-overlay/sys/sys/iocatalogue.h
@@ -1,0 +1,70 @@
+/*
+ * NextBSD in-kernel IOKit catalogue (K2, nextbsd#215).
+ *
+ * A flat, in-kernel database of IOKit driver personalities (device-id match
+ * records) — the Apple-faithful IOCatalogue. Userland (kextd) parses each kext
+ * bundle's Info.plist IOKitPersonalities and PUSHES a flat match-record per
+ * personality here via ioctl on /dev/iocatalogue. This is mechanism (a): the
+ * kernel never parses XML — userland owns plist parsing, the kernel owns the
+ * store + matching. The in-kernel matcher (K3, nextbsd#216) reads these records
+ * to bind an unmatched device to its driver bundle.
+ *
+ * See pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html §9.
+ */
+#ifndef _SYS_IOCATALOGUE_H_
+#define _SYS_IOCATALOGUE_H_
+
+#include <sys/types.h>
+#include <sys/ioccom.h>
+
+#define	IOCAT_BUNDLE_ID_MAX	128	/* max CFBundleIdentifier incl. NUL */
+#define	IOCAT_MAX_MATCH		512	/* max device-id entries per personality */
+
+/* IOProviderClass — stored opaque by K2; interpreted by the K3 matcher. */
+#define	IOCAT_PROVIDER_UNKNOWN		0
+#define	IOCAT_PROVIDER_IOPCIDEVICE	1
+
+/*
+ * One personality, as pushed from userland. `match` points at an array of
+ * `nmatch` uint32_t PCI match words, each encoded 0x<device><vendor> (device in
+ * the high 16 bits, vendor in the low 16) — the IOPCIPrimaryMatch form, e.g.
+ * 0x24f38086 for the Intel 8260. `match` is a uint64_t so the ABI is identical
+ * for 32- and 64-bit userland; `_pad` keeps it 8-byte aligned deterministically.
+ */
+struct iocat_add {
+	char		bundle_id[IOCAT_BUNDLE_ID_MAX];
+	uint32_t	provider_class;		/* IOCAT_PROVIDER_* */
+	int32_t		probe_score;		/* IOProbeScore; higher wins */
+	uint32_t	nmatch;			/* number of entries in match[] */
+	uint32_t	_pad;
+	uint64_t	match;			/* user ptr to uint32_t[nmatch] */
+};
+
+#define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)	/* add one personality */
+#define	IOCATIOCFLUSH	_IO('K', 2)			/* drop all (re-push) */
+
+#ifdef _KERNEL
+#include <sys/queue.h>
+
+/* In-kernel record (one personality). match[] is malloc'd, nmatch words. */
+struct iocat_record {
+	TAILQ_ENTRY(iocat_record) link;
+	char		bundle_id[IOCAT_BUNDLE_ID_MAX];
+	uint32_t	provider_class;
+	int32_t		probe_score;
+	uint32_t	nmatch;
+	uint32_t       *match;
+};
+
+/*
+ * K3 matcher entry point: find the best (highest probe_score) IOPCIDevice
+ * personality whose match table contains `match_word` (0x<device><vendor>).
+ * On a hit, copies the winning bundle id into buf and returns 0 (and the score
+ * via score_out if non-NULL); returns ENOENT if nothing matches. Takes its own
+ * lock; caller holds none.
+ */
+int	iocat_lookup_pci(uint32_t match_word, char *buf, size_t buflen,
+	    int32_t *score_out);
+#endif /* _KERNEL */
+
+#endif /* _SYS_IOCATALOGUE_H_ */


### PR DESCRIPTION
Part of umbrella #211 (Apple-faithful in-kernel IOKit matcher, Option B). First kernel slice on **mechanism (a)** — userland pushes personalities, the kernel never parses XML.

## What
A flat in-kernel database of IOKit driver personalities (the Apple IOCatalogue).
- `/dev/iocatalogue` (root-only) — `IOCATIOCADD` ingests one personality (CFBundleIdentifier, IOProviderClass, IOProbeScore, an `IOPCIPrimaryMatch` array of `0x<device><vendor>` words); `IOCATIOCFLUSH` clears for a re-push.
- `hw.iokit.catalogue` (text dump) + `hw.iokit.catalogue_count` sysctls.
- `iocat_lookup_pci()` — the K3 (#216) `device_nomatch` matcher's entry point: returns the highest-`IOProbeScore` bundle whose match table contains a given PCI key.

## How it's wired
New source lives in `src-overlay/` and is wired by `build.yml` (append `files.iocatalogue` to `sys/conf/files`), **not** `patches/series` — same pattern as the mach subsystem (#181), so the modules build (shares the series, doesn't lay in the overlay) never sees the source listed without it present. `standard`/always-compiled; the store is **inert until K3** calls `iocat_lookup_pci()`.

## Verification
- CI: builds both arches + the PR smoke-test boots the `continuous` ISO with this kernel (proves it compiles and is boot-safe — `make_dev`/sysctl registration at `SI_SUB_DRIVERS`).
- Functional round-trip (push a record, read it back via sysctl) lands with U1 (#217), the kextd push side, which exercises the ioctl.

Design doc: pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html §9.