### PR TITLE
K3a (#216): in-kernel device_nomatch matcher + IOCATIOCLOOKUP

### DIFF
--- a/src-overlay/sys/dev/iokit/iokit_catalogue.c
+++ b/src-overlay/sys/dev/iokit/iokit_catalogue.c
@@ -17,10 +17,17 @@
 #include <sys/malloc.h>
 #include <sys/queue.h>
 #include <sys/sx.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
 #include <sys/conf.h>
 #include <sys/sbuf.h>
 #include <sys/sysctl.h>
+#include <sys/bus.h>
+#include <sys/eventhandler.h>
+#include <sys/taskqueue.h>
 #include <sys/iocatalogue.h>
+
+#include <dev/pci/pcivar.h>
 
 static MALLOC_DEFINE(M_IOCAT, "iocatalogue", "in-kernel IOKit catalogue");
 
@@ -118,6 +125,87 @@ iocat_lookup_pci(uint32_t match_word, char *buf, size_t buflen,
 	return (best != NULL ? 0 : ENOENT);
 }
 
+/* ---- K3 (#216): device_nomatch -> match -> request a load from userland ----
+ *
+ * When newbus probes a device no built-in driver claims, it fires the
+ * device_nomatch event. We capture the device's PCI id (a quick, non-sleeping
+ * ivar read) and defer the rest to a taskqueue — the Phase 0 PoC proved that
+ * deferring off the bus lock is deadlock-free, and iocat_lookup_pci() takes a
+ * sleepable sx, so it must run in thread context. On a catalogue hit the kernel
+ * decides the winner and asks userland (kextd) to load it by bundle id via a
+ * devctl notify ("system=IOKIT type=load"). kextd's listener (lands with the
+ * K3 userland half) loads the named bundle; kldload then re-probes the waiting
+ * device automatically. The kernel decides; userland fetches.
+ */
+struct iocat_match_work {
+	STAILQ_ENTRY(iocat_match_work) link;
+	uint32_t	match_word;		/* 0x<device><vendor> */
+	char		devname[64];
+};
+static STAILQ_HEAD(, iocat_match_work) iocat_work =
+    STAILQ_HEAD_INITIALIZER(iocat_work);
+static struct mtx iocat_work_mtx;
+static struct task iocat_match_task;
+static eventhandler_tag iocat_nomatch_tag;
+
+static void
+iocat_match_taskfn(void *ctx __unused, int pending __unused)
+{
+	struct iocat_match_work *w;
+	char bundle[IOCAT_BUNDLE_ID_MAX];
+	char data[256];
+	int32_t score;
+
+	for (;;) {
+		mtx_lock(&iocat_work_mtx);
+		w = STAILQ_FIRST(&iocat_work);
+		if (w != NULL)
+			STAILQ_REMOVE_HEAD(&iocat_work, link);
+		mtx_unlock(&iocat_work_mtx);
+		if (w == NULL)
+			break;
+
+		if (iocat_lookup_pci(w->match_word, bundle, sizeof(bundle),
+		    &score) == 0) {
+			snprintf(data, sizeof(data),
+			    "bundle=%s device=%s match=0x%08x score=%d",
+			    bundle, w->devname, w->match_word, score);
+			devctl_notify("IOKIT", "device", "load", data);
+			if (bootverbose)
+				printf("iokit: %s (0x%08x) -> load %s\n",
+				    w->devname, w->match_word, bundle);
+		}
+		free(w, M_IOCAT);
+	}
+}
+
+static void
+iocat_device_nomatch(void *arg __unused, device_t dev)
+{
+	struct iocat_match_work *w;
+	device_t parent;
+	const char *nu;
+
+	/* Only PCI nubs for now; pci_get_* reads ivars valid on a pci child. */
+	parent = device_get_parent(dev);
+	if (parent == NULL || strcmp(device_get_name(parent), "pci") != 0)
+		return;
+
+	w = malloc(sizeof(*w), M_IOCAT, M_NOWAIT | M_ZERO);
+	if (w == NULL)
+		return;
+	/* IOPCIPrimaryMatch form: device in the high 16 bits, vendor in low 16. */
+	w->match_word = ((uint32_t)pci_get_device(dev) << 16) |
+	    pci_get_vendor(dev);
+	nu = device_get_nameunit(dev);
+	strlcpy(w->devname, nu != NULL ? nu : "?", sizeof(w->devname));
+
+	mtx_lock(&iocat_work_mtx);
+	STAILQ_INSERT_TAIL(&iocat_work, w, link);
+	mtx_unlock(&iocat_work_mtx);
+	taskqueue_enqueue(taskqueue_thread, &iocat_match_task);
+}
+
 /* ---- /dev/iocatalogue: ioctl ingestion from userland (kextd) ---- */
 
 static d_ioctl_t iocat_ioctl;
@@ -138,6 +226,14 @@ iocat_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t data,
 	case IOCATIOCFLUSH:
 		iocat_flush();
 		return (0);
+	case IOCATIOCLOOKUP: {
+		struct iocat_lookup *lu = (struct iocat_lookup *)data;
+
+		lu->bundle_id[0] = '\0';
+		lu->score = 0;
+		return (iocat_lookup_pci(lu->match, lu->bundle_id,
+		    sizeof(lu->bundle_id), &lu->score));
+	}
 	default:
 		return (ENOTTY);
 	}
@@ -182,14 +278,33 @@ SYSCTL_UINT(_hw_iokit, OID_AUTO, catalogue_count, CTLFLAG_RD,
 static int
 iocat_modevent(module_t mod __unused, int type, void *data __unused)
 {
+	struct iocat_match_work *w;
+
 	switch (type) {
 	case MOD_LOAD:
+		mtx_init(&iocat_work_mtx, "iocat_work", NULL, MTX_DEF);
+		TASK_INIT(&iocat_match_task, 0, iocat_match_taskfn, NULL);
 		iocat_dev = make_dev(&iocat_cdevsw, 0, UID_ROOT, GID_WHEEL,
 		    0600, "iocatalogue");
-		return (iocat_dev != NULL ? 0 : ENXIO);
+		if (iocat_dev == NULL) {
+			mtx_destroy(&iocat_work_mtx);
+			return (ENXIO);
+		}
+		/* Registered before SI_SUB_CONFIGURE, so it sees boot nomatches. */
+		iocat_nomatch_tag = EVENTHANDLER_REGISTER(device_nomatch,
+		    iocat_device_nomatch, NULL, EVENTHANDLER_PRI_ANY);
+		return (0);
 	case MOD_UNLOAD:
+		if (iocat_nomatch_tag != NULL)
+			EVENTHANDLER_DEREGISTER(device_nomatch, iocat_nomatch_tag);
+		taskqueue_drain(taskqueue_thread, &iocat_match_task);
 		if (iocat_dev != NULL)
 			destroy_dev(iocat_dev);
+		while ((w = STAILQ_FIRST(&iocat_work)) != NULL) {
+			STAILQ_REMOVE_HEAD(&iocat_work, link);
+			free(w, M_IOCAT);
+		}
+		mtx_destroy(&iocat_work_mtx);
 		iocat_flush();
 		return (0);
 	default:

--- a/src-overlay/sys/sys/iocatalogue.h
+++ b/src-overlay/sys/sys/iocatalogue.h
@@ -40,8 +40,22 @@ struct iocat_add {
 	uint64_t	match;			/* user ptr to uint32_t[nmatch] */
 };
 
-#define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)	/* add one personality */
-#define	IOCATIOCFLUSH	_IO('K', 2)			/* drop all (re-push) */
+/*
+ * Look up the best driver bundle for a PCI match word (0x<device><vendor>).
+ * Userland sets `match`; the kernel fills `bundle_id` + `score` and returns 0,
+ * or ENOENT if nothing matches. This is the same lookup the in-kernel
+ * device_nomatch matcher (K3) uses — exposed so userland can verify it
+ * deterministically (e.g. is the 8260 bound to IntelWiFi?).
+ */
+struct iocat_lookup {
+	uint32_t	match;				/* in: 0x<device><vendor> */
+	int32_t		score;				/* out: winning IOProbeScore */
+	char		bundle_id[IOCAT_BUNDLE_ID_MAX];	/* out: winning bundle */
+};
+
+#define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)		/* add a personality */
+#define	IOCATIOCFLUSH	_IO('K', 2)				/* drop all (re-push) */
+#define	IOCATIOCLOOKUP	_IOWR('K', 3, struct iocat_lookup)	/* match a PCI word */
 
 #ifdef _KERNEL
 #include <sys/queue.h>


### PR DESCRIPTION
The matcher half of the Apple-faithful in-kernel IOKit binding (umbrella #211, Option B). Builds on K2 (#15, merged).

## What
- **device_nomatch matcher**: when newbus finds no built-in driver for a PCI device, capture its `0x<device><vendor>` id and defer to a taskqueue (the Phase-0 PoC pattern — deferring off the bus lock is deadlock-free; `iocat_lookup_pci()` takes a sleepable sx so it must run in thread context). On a catalogue hit, the kernel asks userland to load the winning bundle via `devctl_notify("IOKIT","device","load", "bundle=<id> …")`. **The kernel decides; userland fetches.** `kldload` then re-probes the waiting device automatically.
- **IOCATIOCLOOKUP** ioctl: run the lookup for a given PCI word and return the winning bundle + score — lets userland verify the matcher deterministically (e.g. `0x24f38086` → `org.nextbsd.kext.intelwifi`) **without the physical device**.

## Verification
- CI: build (both arches) + boot smoke-test. The matcher is **inert in QEMU** — the catalogue is empty at boot (kextd is on-demand), so `device_nomatch` lookups return ENOENT and no notify fires. Proves it compiles + is boot-safe.
- The **lookup** gets exercised end-to-end by the K3 userland half (a `kextd --lookup` + run.sh assertion in nextbsd): push IntelWiFi → `IOCATIOCLOOKUP 0x24f38086` → expect `org.nextbsd.kext.intelwifi`.
- The actual **8260 auto-load** (device_nomatch → notify → kextd loads → bind) is the **t420 hardware test**.

## Next (K3 userland half)
kextd grows a `/dev/devctl` listener for the `IOKIT load` events (becomes persistent), plus the launchd boot ordering deferred from U1. Design: pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html §9.