### PR TITLE
K3b PoC (#216): kernel→kextd Mach load-request send (HOST_KEXTD_PORT)

### DIFF
--- a/src-overlay/conf/files.compat_mach
+++ b/src-overlay/conf/files.compat_mach
@@ -4,6 +4,7 @@
 compat/mach/clock_server.c                   optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
 compat/mach/compat_stubs.c                   optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
 compat/mach/host_priv_server.c               optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
+compat/mach/iokit_kextd.c                    optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
 compat/mach/ipc/ipc_entry.c                  optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
 compat/mach/ipc/ipc_hash.c                   optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
 compat/mach/ipc/ipc_init.c                   optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"

--- a/src-overlay/sys/compat/mach/iokit_kextd.c
+++ b/src-overlay/sys/compat/mach/iokit_kextd.c
@@ -1,0 +1,75 @@
+/*
+ * iokit_kextd.c — kernel->kextd Mach load-request send (K3b, #216).
+ *
+ * Builds and sends an iokit_kextd_load_msg_t to the kext daemon's receive
+ * right (registered as HOST_KEXTD_PORT). Modeled directly on the proven
+ * kernel-originated send in ipc/ipc_notify.c (ikm_alloc -> fill header ->
+ * ipc_mqueue_send_always); the destination send right is copied out of
+ * realhost.special[] the same way kern/ipc_tt.c copies HOST_BOOTSTRAP_PORT.
+ *
+ * See sys/sys/mach/iokit_kextd.h and
+ * pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html §9 (K3b).
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/systm.h>		/* strlcpy, errno values */
+
+#include <sys/mach/port.h>
+#include <sys/mach/message.h>
+#include <sys/mach/ndr.h>
+#include <sys/mach/host.h>
+#include <sys/mach/host_special_ports.h>
+
+#include <kern/assert.h>
+#include <kern/misc_protos.h>
+
+#include <sys/mach/ipc/ipc_kmsg.h>
+#include <sys/mach/ipc/ipc_mqueue.h>
+#include <sys/mach/ipc/ipc_port.h>
+
+#include <sys/mach/iokit_kextd.h>
+
+/* realhost is declared in <sys/mach/host.h>. */
+
+int
+iokit_kextd_send(const char *bundle, const char *device, uint32_t match_word)
+{
+	ipc_port_t port;
+	ipc_kmsg_t kmsg;
+	iokit_kextd_load_msg_t *m;
+
+	/* Copy a fresh send-right ref to kextd's port (same pattern as the
+	 * HOST_BOOTSTRAP_PORT fallback in kern/ipc_tt.c). */
+	host_lock(&realhost);
+	if (!IP_VALID(realhost.special[HOST_KEXTD_PORT])) {
+		host_unlock(&realhost);
+		return (ENXIO);		/* no kextd registered yet */
+	}
+	port = ipc_port_copy_send(realhost.special[HOST_KEXTD_PORT]);
+	host_unlock(&realhost);
+	if (!IP_VALID(port))
+		return (ENXIO);
+
+	kmsg = ikm_alloc(sizeof *m);
+	if (kmsg == IKM_NULL) {
+		ipc_port_release_send(port);
+		return (ENOMEM);
+	}
+	ikm_init(kmsg, sizeof *m);
+	m = (iokit_kextd_load_msg_t *) kmsg->ikm_header;
+
+	m->hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_PORT_SEND, 0);
+	m->hdr.msgh_local_port = MACH_PORT_NULL;
+	m->hdr.msgh_remote_port = (mach_port_t) port;	/* ref consumed by send */
+	m->hdr.msgh_id = IOKIT_KEXTD_LOAD_MSGID;
+	m->hdr.msgh_size = (mach_msg_size_t)
+	    (sizeof(*m) - sizeof(mach_msg_format_0_trailer_t));
+	m->NDR = NDR_record;
+	strlcpy(m->bundle_id, bundle, sizeof m->bundle_id);
+	strlcpy(m->device, device != NULL ? device : "", sizeof m->device);
+	m->match_word = match_word;
+
+	ipc_mqueue_send_always(kmsg);
+	return (0);
+}

--- a/src-overlay/sys/compat/mach/iokit_kextd.c
+++ b/src-overlay/sys/compat/mach/iokit_kextd.c
@@ -12,17 +12,16 @@
  */
 
 #include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/systm.h>		/* strlcpy, errno values */
+#include <sys/param.h>		/* proven to coexist with the ipc internals
+				 * (see ipc/ipc_kmsg.c); systm.h is NOT used by
+				 * any ipc file, so avoid it here. */
+#include <sys/errno.h>		/* ENXIO, ENOMEM */
 
 #include <sys/mach/port.h>
 #include <sys/mach/message.h>
 #include <sys/mach/ndr.h>
 #include <sys/mach/host.h>
 #include <sys/mach/host_special_ports.h>
-
-#include <kern/assert.h>
-#include <kern/misc_protos.h>
 
 #include <sys/mach/ipc/ipc_kmsg.h>
 #include <sys/mach/ipc/ipc_mqueue.h>
@@ -31,6 +30,20 @@
 #include <sys/mach/iokit_kextd.h>
 
 /* realhost is declared in <sys/mach/host.h>. */
+
+/* Local bounded, NUL-terminating copy — avoids pulling <sys/systm.h>/libkern
+ * (strlcpy) into a file that already includes the deep Mach ipc internals. */
+static void
+kextd_strcopy(char *dst, const char *src, size_t n)
+{
+	size_t i = 0;
+
+	if (n == 0)
+		return;
+	for (; i + 1 < n && src != NULL && src[i] != '\0'; i++)
+		dst[i] = src[i];
+	dst[i] = '\0';
+}
 
 int
 iokit_kextd_send(const char *bundle, const char *device, uint32_t match_word)
@@ -66,8 +79,8 @@ iokit_kextd_send(const char *bundle, const char *device, uint32_t match_word)
 	m->hdr.msgh_size = (mach_msg_size_t)
 	    (sizeof(*m) - sizeof(mach_msg_format_0_trailer_t));
 	m->NDR = NDR_record;
-	strlcpy(m->bundle_id, bundle, sizeof m->bundle_id);
-	strlcpy(m->device, device != NULL ? device : "", sizeof m->device);
+	kextd_strcopy(m->bundle_id, bundle, sizeof m->bundle_id);
+	kextd_strcopy(m->device, device, sizeof m->device);
 	m->match_word = match_word;
 
 	ipc_mqueue_send_always(kmsg);

--- a/src-overlay/sys/compat/mach/mach_traps.c
+++ b/src-overlay/sys/compat/mach/mach_traps.c
@@ -302,10 +302,13 @@ sys_host_set_special_port_trap(struct thread *td,
 	ipc_port_t old;
 	kern_return_t kr;
 
-	/* Only HOST_BOOTSTRAP_PORT is settable from userland at the
-	 * moment — kernel-provided slots (HOST_PORT etc.) and other
-	 * Apple-defined slots are rejected. */
-	if (uap->which != HOST_BOOTSTRAP_PORT) {
+	/* Userland may set HOST_BOOTSTRAP_PORT (the bootstrap server) and
+	 * HOST_KEXTD_PORT (kextd's load-request receive right, K3b #216);
+	 * kernel-provided slots (HOST_PORT etc.) and other Apple-defined slots
+	 * are rejected. Registration is still gated by IPC-space ownership of
+	 * the port being installed (ipc_object_copyin below). */
+	if (uap->which != HOST_BOOTSTRAP_PORT &&
+	    uap->which != HOST_KEXTD_PORT) {
 		td->td_retval[0] = KERN_INVALID_ARGUMENT;
 		return (0);
 	}

--- a/src-overlay/sys/dev/iokit/iokit_catalogue.c
+++ b/src-overlay/sys/dev/iokit/iokit_catalogue.c
@@ -10,6 +10,8 @@
  * pkgdemon.github.io/nextbsd-inkernel-iokit-feasibility.html §9.
  */
 
+#include "opt_compat_mach.h"
+
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/kernel.h>
@@ -28,6 +30,14 @@
 #include <sys/iocatalogue.h>
 
 #include <dev/pci/pcivar.h>
+
+#ifdef COMPAT_MACH
+/* K3b (#216): the kernel->kextd Mach load-request send (compat/mach/iokit_kextd.c).
+ * Declared here rather than via <sys/mach/iokit_kextd.h> so this standard file
+ * pulls in no Mach headers. */
+extern int iokit_kextd_send(const char *bundle, const char *device,
+    uint32_t match_word);
+#endif
 
 static MALLOC_DEFINE(M_IOCAT, "iocatalogue", "in-kernel IOKit catalogue");
 
@@ -233,6 +243,19 @@ iocat_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t data,
 		lu->score = 0;
 		return (iocat_lookup_pci(lu->match, lu->bundle_id,
 		    sizeof(lu->bundle_id), &lu->score));
+	}
+	case IOCATIOCTESTSEND: {	/* K3b PoC: lookup + kernel->kextd Mach send */
+#ifdef COMPAT_MACH
+		uint32_t mw = *(uint32_t *)data;
+		char bundle[IOCAT_BUNDLE_ID_MAX];
+		int32_t score;
+
+		if (iocat_lookup_pci(mw, bundle, sizeof(bundle), &score) != 0)
+			return (ENOENT);
+		return (iokit_kextd_send(bundle, "iocat-test", mw));
+#else
+		return (ENOSYS);
+#endif
 	}
 	default:
 		return (ENOTTY);

--- a/src-overlay/sys/sys/iocatalogue.h
+++ b/src-overlay/sys/sys/iocatalogue.h
@@ -56,6 +56,14 @@ struct iocat_lookup {
 #define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)		/* add a personality */
 #define	IOCATIOCFLUSH	_IO('K', 2)				/* drop all (re-push) */
 #define	IOCATIOCLOOKUP	_IOWR('K', 3, struct iocat_lookup)	/* match a PCI word */
+/*
+ * K3b PoC (#216): look up a PCI match word and, on a hit, fire the kernel->kextd
+ * Mach load request (HOST_KEXTD_PORT) for the winning bundle — the de-risk test
+ * for the matcher's real send. Throwaway: the production matcher sends from its
+ * device_nomatch taskqueue, not via an ioctl. Returns 0 / ENOENT (no match) /
+ * ENXIO (no kextd registered) / ENOSYS (kernel built without COMPAT_MACH).
+ */
+#define	IOCATIOCTESTSEND	_IOW('K', 4, uint32_t)
 
 #ifdef _KERNEL
 #include <sys/queue.h>

--- a/src-overlay/sys/sys/mach/iokit_kextd.h
+++ b/src-overlay/sys/sys/mach/iokit_kextd.h
@@ -1,0 +1,46 @@
+/*
+ * iokit_kextd.h — kernel->kextd "load this bundle" Mach message (K3b, #216).
+ *
+ * The Apple-faithful kext load-request channel: the in-kernel IOKit matcher,
+ * on a device match, sends this message to the kext daemon's receive right,
+ * which it registered as the HOST_KEXTD_PORT host special port. kextd loads the
+ * named bundle (OSKext -> kld); newbus then re-probes and attaches the device.
+ * This replaces the K3a placeholder devctl_notify and retires devd from the
+ * match path. Mirrors XNU's HOST_KEXTD_PORT / kext request mechanism.
+ */
+#ifndef _SYS_MACH_IOKIT_KEXTD_H_
+#define _SYS_MACH_IOKIT_KEXTD_H_
+
+#include <sys/mach/message.h>
+#include <sys/mach/ndr.h>
+
+/* msgh_id for a load request — outside the MACH_NOTIFY_* range ("IOKT"). */
+#define	IOKIT_KEXTD_LOAD_MSGID	0x494f4b54
+
+#define	IOKIT_KEXTD_BUNDLE_MAX	128
+
+/*
+ * Wire format. Fixed-size, inline (no out-of-line/complex descriptors), so the
+ * kernel build is trivial and kextd reads it with a plain mach_msg. bundle_id
+ * is the CFBundleIdentifier the kernel decided; device/match are informational.
+ */
+typedef struct {
+	mach_msg_header_t		hdr;
+	NDR_record_t			NDR;
+	char				bundle_id[IOKIT_KEXTD_BUNDLE_MAX];
+	char				device[64];
+	uint32_t			match_word;	/* 0x<device><vendor> */
+	mach_msg_format_0_trailer_t	trailer;	/* appended on receive */
+} iokit_kextd_load_msg_t;
+
+#ifdef _KERNEL
+/*
+ * Send a load request for `bundle` to the registered HOST_KEXTD_PORT. Returns
+ * 0 on send, ENXIO if no kextd has registered, ENOMEM on kmsg exhaustion.
+ * Safe from kernel thread context (e.g. the matcher's taskqueue worker).
+ */
+int	iokit_kextd_send(const char *bundle, const char *device,
+	    uint32_t match_word);
+#endif
+
+#endif /* _SYS_MACH_IOKIT_KEXTD_H_ */


### PR DESCRIPTION
First K3b increment — the **kernel half** of the faithful kext load-request channel (umbrella #211). Kernel Mach message to kextd's receive right (`HOST_KEXTD_PORT`), replacing K3a's placeholder `devctl_notify`. **No devd, no /dev/devctl.**

Grounded by the freebsd-src + Mach-layer agent review (doc §9 K3b): `HOST_KEXTD_PORT=15` pre-defined; kernel-originated send proven by `ipc_notify`; the send right is copied from `realhost.special[]` exactly as `ipc_tt.c` does for `HOST_BOOTSTRAP_PORT`.

## In this PR (kernel side — keepers + a test hook)
- `iokit_kextd_send()` (`compat/mach/iokit_kextd.c`) — the real K3b send, modeled on `ipc_notify_port_deleted` (`ikm_alloc` → fill header → `ipc_mqueue_send_always`). **Keeper.**
- `HOST_KEXTD_PORT` whitelisted in `host_set_special_port` (`mach_traps.c`). **Keeper.**
- `IOCATIOCTESTSEND` ioctl — lookup a PCI word + fire the send for the winning bundle, so the round-trip can be driven from userland. **Throwaway** (the production matcher sends from its `device_nomatch` taskqueue).

## What CI proves here
Builds (both arches) + boots clean. The send is **inert at boot** (only `IOCATIOCTESTSEND` fires it), so this is the compile + boot-safety gate for the new kernel Mach code — the delicate part.

## Next (after merge + republish)
A nextbsd userland test: register a receive port as `HOST_KEXTD_PORT`, `ioctl(IOCATIOCTESTSEND, 0x24f38086)`, `mach_msg` receive, assert the message carries `org.nextbsd.kext.intelwifi` → proves the **kernel→userland Mach round-trip**. Then wire `iokit_kextd_send()` into the matcher (replacing `devctl_notify`) + push-triggers-match, and the 8260 auto-load is the t420 test.