### PR TITLE
iokit_notify: remove temporary copyin diagnostic prints

### DIFF
--- a/src-overlay/sys/compat/mach/iokit_notify.c
+++ b/src-overlay/sys/compat/mach/iokit_notify.c
@@ -39,10 +39,6 @@
 
 #include <sys/mach/iokit_notify.h>
 
-/* Temporary diagnostic: localize why IOREGIOCWATCH's port copyin fails.
- * Local decl avoids pulling <sys/systm.h> into this deep-ipc-internals TU. */
-extern int printf(const char *, ...);
-
 /* Local bounded, NUL-terminating copy — avoids pulling <sys/systm.h>/libkern
  * (strlcpy) into a file that includes the deep Mach ipc internals (same reason
  * as iokit_kextd.c's kextd_strcopy). */
@@ -73,25 +69,15 @@ iokit_notify_copyin_port(uint32_t port_name, void **out)
 
 	if (out == NULL)
 		return (EINVAL);
-	if (port_name == 0 || task == NULL) {
-		printf("iokit_notify: copyin port_name=0x%x task=%p -> EINVAL (early)\n",
-		    port_name, (void *)task);
+	if (port_name == 0 || task == NULL)
 		return (EINVAL);
-	}
 
 	kr = ipc_object_copyin(task->itk_space, port_name,
 	    MACH_MSG_TYPE_COPY_SEND, (ipc_object_t *)&port);
-	if (kr != KERN_SUCCESS) {
-		printf("iokit_notify: copyin port_name=0x%x COPY_SEND kr=0x%x -> EINVAL\n",
-		    port_name, (unsigned)kr);
+	if (kr != KERN_SUCCESS)
 		return (EINVAL);
-	}
-	if (!IP_VALID(port)) {
-		printf("iokit_notify: copyin port_name=0x%x port invalid -> EINVAL\n",
-		    port_name);
+	if (!IP_VALID(port))
 		return (EINVAL);
-	}
-	printf("iokit_notify: copyin port_name=0x%x OK\n", port_name);
 
 	*out = (void *)port;
 	return (0);


### PR DESCRIPTION
Round-trip is proven (IOKITNOTIFY-OK in CI). Removes the temp copyin printf diagnostics + local printf decl. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)