### PR TITLE
config: nodevice em — auto-load Intel GbE as a kext (Step 3b of #219)

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -14,3 +14,14 @@ ident	NEXTBSD
 #   INIT_PATH   -> stringified via __XSTRING in init_main.c (unquoted).
 options 	ROOTDEVNAME=\"ufs:/dev/ufs/ROOTFS\"
 options 	INIT_PATH=/sbin/launchd
+
+# D1 (#219): drop the built-in Intel GbE driver so it auto-loads as a kext.
+# GENERIC's `device em` compiles the e1000 driver (if_em.c registers BOTH the
+# `em` and `igb` drivers — the whole Intel PRO/1000 GbE family) into the kernel.
+# Removing it makes the e1000 hit device_nomatch at attach, so the in-kernel
+# IOKit matcher (#211) -> kextd auto-loads IntelEthernet.kext (if_em, shipped by
+# nextbsd-kernel-modules) to bind it. iflib + miibus (if_em's load-time deps)
+# stay built in. NIC only -- not boot-critical (root is ahci/virtio). First
+# driver->kext conversion; ix/ixl/ice/igc stay built in (no qemu device to prove
+# their auto-load -- see nextbsd #245).
+nodevice 	em


### PR DESCRIPTION
Final step of nextbsd #219 (D1: first driver→kext conversion). Drops the built-in e1000 driver so it auto-loads as `IntelEthernet.kext`.

## The change
One line in `config/NEXTBSD`: `nodevice em`. GENERIC's `device em` compiles `if_em` (which registers **both** the `em` and `igb` drivers — the whole Intel PRO/1000 GbE family) into the kernel; `nodevice em` subtracts it from our `include GENERIC` (we can't edit GENERIC directly). `iflib` + `miibus` (if_em's load-time deps) stay built in. NIC only — **not boot-critical** (root is ahci/virtio).

## How it proves out (entirely in CI)
This PR's boot-smoke boots the nextbsd `continuous` ISO with this kernel injected. That ISO now ships **`IntelEthernet.kext`** (nextbsd #246, merged) and the **`EM-AUTOLOAD` gate** (nextbsd #247, merged). With `em` gone from the kernel:

1. the qemu e1000 (82540EM, `0x100e8086`) attaches → no built-in driver matches → `device_nomatch`
2. the in-kernel IOKit matcher (#211) → kextd `kldload`s `IntelEthernet.kext` (= `if_em`)
3. it binds the e1000 → `em0` → DHCP

Expected markers: **`EM-AUTOLOAD-OK`** (was `-SKIP` while em was built in), plus the existing `IPCFG-IPCONFIG-OK` / `MDNS-IFWATCH-OK` on `em0`. Unlike the 8260 wifi (no qemu device, hardware-gated), **qemu emulates the e1000**, so this is the full auto-load+attach proof with no hardware.

## Predecessors (all merged, in order)
- nextbsd-kernel-modules#10 — build/ship `IntelEthernet.kext` (189 GbE device ids) on modules `continuous`
- nextbsd#246 — ingest the kext into the image
- nextbsd#247 — explicit `EM-AUTOLOAD` gate (self-SKIP until this PR)

The other Intel NIC drivers (ix/ixl/ice/igc) stay built in — qemu emulates none, so their auto-load is hardware-gated (nextbsd #245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)