### PR TITLE
mach: UAF-safe pset kqueue-knote teardown (#168 Phase B prereq)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_pset.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_pset.c
@@ -456,6 +456,24 @@ ipc_pset_destroy(
 	}
 	ipc_pset_changed(pset, MACH_RCV_PORT_DIED);
 	ips_unlock(pset);
+
+	/*
+	 * Tear down any kqueue knotes (native EVFILT_MACHPORT / filt_machport)
+	 * watching this set BEFORE it is freed. ipc_pset_changed() above only
+	 * wakes blocked receiver threads — it does not touch the knlist. Fire
+	 * EV_EOF so watchers learn the set died, then clear + destroy the
+	 * knlist so a later kqueue teardown (filt_machportdetach) never
+	 * dereferences this freed pset. ips_note_lock is an sx (sleepable), so
+	 * this runs only after the pset lock is dropped; we still hold a
+	 * reference (released just below), so the pset is alive here. A no-op
+	 * for the common empty-knlist case (pre-native, all-pipe-bridge usage).
+	 */
+	sx_xlock(&pset->ips_note_lock);
+	KNOTE_LOCKED(&pset->ips_note, EV_EOF);
+	knlist_clear(&pset->ips_note, 1 /* islocked */);
+	sx_xunlock(&pset->ips_note_lock);
+	knlist_destroy(&pset->ips_note);
+
 	ips_release(pset);	/* consume the ref our caller gave us */
 }
 
@@ -563,29 +581,28 @@ extern void kdb_backtrace(void);
 static void
 filt_machportdetach(struct knote *kn)
 {
-	mach_port_name_t	name = (mach_port_name_t)kn->kn_kevent.ident;
-	ipc_pset_t		pset = IPS_NULL;
-	ipc_entry_t entry = NULL;;
+	ipc_pset_t	pset;
+	ipc_entry_t	entry;
 
-
-
-	if (kn->kn_fp->f_type != DTYPE_MACH_IPC)
-		goto fail;
-
+	/*
+	 * If ipc_pset_destroy already cleared this knote from the set's
+	 * knlist (kn_knlist == NULL), the pset — and the fp/entry backing it
+	 * — may already be freed; removing again would touch freed memory.
+	 * This is the normal teardown order once a native EVFILT_MACHPORT
+	 * knote can outlive a destroyed port set, so it is not an error.
+	 * Guard every dereference so any teardown order is UAF-safe.
+	 */
+	if (kn->kn_knlist == NULL)
+		return;
+	if (kn->kn_fp == NULL || kn->kn_fp->f_type != DTYPE_MACH_IPC)
+		return;
 	entry = kn->kn_fp->f_data;
-	if ((entry->ie_bits & MACH_PORT_TYPE_PORT_SET) == 0)
-		goto fail;
-	if ((pset = (ipc_pset_t)entry->ie_object) == NULL)
-		goto fail;
-
-
+	if (entry == NULL || (entry->ie_bits & MACH_PORT_TYPE_PORT_SET) == 0)
+		return;
+	pset = (ipc_pset_t)entry->ie_object;
+	if (pset == NULL)
+		return;
 	knlist_remove(&pset->ips_note, kn, 0);
-	return;
-fail:
-	if (mach_debug_enable) {
-		kdb_backtrace();
-		printf("kqdetach fail for: %d pset: %p entry: %p\n", name, pset, entry);
-	}
 }
 
 


### PR DESCRIPTION
Kernel prerequisite for #168 Phase B (routing libdispatch's `EVFILT_MACHPORT` through the **native** kernel filter instead of the `register_event_bell` pipe-bridge).

Today everything uses the pipe-bridge, so a port set's `ips_note` knlist is always empty and these paths are dormant. The moment a native `EVFILT_MACHPORT` knote attaches to a pset, two latent bugs bite:

1. **`ipc_pset_destroy()` leaked knotes onto freed memory.** It only woke blocked receiver threads (`ipc_pset_changed`); it never cleared the knlist. A knote on `ips_note` then outlived the freed pset → use-after-free when the kqueue later detached it. Fix: after dropping the pset lock (`ips_note_lock` is a sleepable `sx`) but while still holding a reference, fire `EV_EOF` to watchers, then `knlist_clear` + `knlist_destroy`.

2. **`filt_machportdetach()` was UAF-prone.** It unconditionally dereferenced `kn->kn_fp` and `knlist_remove`'d from the pset, with a `kdb_backtrace()` "fail" path (the noise seen in recent boot logs under `mach.debug_enable`, and a real UAF if the pset/fp was already gone). Rewritten to bail when the knote was already cleared (`kn_knlist == NULL`) or the fp/entry is invalid — any teardown order is now safe.

**Safe to land first:** no behavior change for current usage (empty knlist) — boots clean. It just makes the native `EVFILT_MACHPORT` teardown correct for the libmach reroute that follows.

Part of #168. Follows the proof that the native filter delivers (nextbsd #249, `EVFILT-MACHPORT-OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)