### PR TITLE
mach: fix UAF in filt_machportattach under concurrent move_member (#253)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_pset.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_pset.c
@@ -564,15 +564,33 @@ filt_machportattach(struct knote *kn)
 	if (kr != KERN_SUCCESS)
 		return (kr == KERN_INVALID_NAME ? ENOENT : ENOTSUP);
 	note = &pset->ips_note;
+	/*
+	 * Hold a reference across knlist_add (#168 Stage 1b, the #250 UAF fix).
+	 * ips_unlock drops the pset lock, but with no reference a concurrent
+	 * mach_port_move_member / ipc_pset_signal can free + reallocate this
+	 * pset; knlist_add would then write into freed memory via &pset->ips_note
+	 * (observed as "page fault write 0x70" under launchd's concurrent
+	 * DispatchWorker load). Take the ref under the lock, then revalidate that
+	 * the name still maps to THIS pset after re-looking-up the entry — the
+	 * entry could also have been reused. The former KASSERT(ie_object==pset)
+	 * is now a real runtime check (it can legitimately race).
+	 */
+	ips_reference(pset);
 	ips_unlock(pset);
 
 	/* need the actual entry for knote */
-	if ((entry = ipc_entry_lookup(current_space(), name)) == NULL)
+	if ((entry = ipc_entry_lookup(current_space(), name)) == NULL) {
+		ips_release(pset);
 		return (ENOENT);
-	KASSERT(entry->ie_object == (ipc_object_t)pset, ("entry->ie_object == pset"));
+	}
+	if (entry->ie_object != (ipc_object_t)pset) {
+		ips_release(pset);
+		return (ENOENT);
+	}
 
 	kn->kn_fp = entry->ie_fp;
 	knlist_add(note, kn, 0);
+	ips_release(pset);
 	return (0);
 }
 


### PR DESCRIPTION
Fixes **#253** — the root cause of the PR nextbsd#250 boot panic (`page fault, write 0x70` in `filt_machportattach` ← `kqueue_register`, in launchd's `DispatchWorker`). Stage 1b of the [native EVFILT_MACHPORT plan](https://pkgdemon.github.io/nextbsd-evfilt-machport-native-plan.html) (#168).

### Bug
`filt_machportattach` dropped the pset lock (`ips_unlock`) **holding no reference**, then `knlist_add` reached back into `&pset->ips_note`. In that window a concurrent `mach_port_move_member` / `ipc_pset_signal` can free + reallocate the pset, so `knlist_add` writes into freed memory (offset ~`0x70`). The single-threaded probe (#249) never opens the window; launchd's concurrent dispatch workers do.

### Fix (Option C: reference + revalidate)
- `ips_reference(pset)` under the pset lock before `ips_unlock` → pset can't be freed across `knlist_add`.
- Revalidate `entry->ie_object == pset` after the entry re-lookup (the entry can be reused too) — the former `KASSERT` becomes a real runtime check (it legitimately races).
- `ips_release` after `knlist_add`; `ipc_pset_destroy` (#29) detaches the knote on teardown, so no standing reference is needed.

### Safety
No behavior change for current usage — nothing registers a native `EVFILT_MACHPORT` knote yet (everything still rides the pipe-bridge), so `ips_note` stays empty and this path is dormant. Boots clean; **unblocks the #250 native reroute**.

Pairs with **#252** (#148 `ith_messages` lazy-init) if a worker-thread fire-path fault surfaces once #250 re-runs against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)