### PR TITLE
mach: fix ipc_kmsg_destroy page fault on DispatchWorker thread exit (fixes #148)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_kmsg.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_kmsg.c
@@ -557,9 +557,30 @@ ipc_kmsg_reap_delayed(void)
  *		No locks held.
  */
 
+/* On-demand per-thread Mach init (mach_thread.c); see #252. */
+extern int mach_thread_init_lazy(struct thread *td);
+
 void
 ipc_kmsg_destroy(ipc_kmsg_t	kmsg)
 {
+
+	/*
+	 *	DispatchWorker (libdispatch pthread-workqueue) threads reach here
+	 *	on exit — when the kernel walks their fd table to close Mach ports
+	 *	(mach_port_close -> ipc_port_destroy) — without ever having gone
+	 *	through mach.ko's thread-init path.  Their td_machdata is NULL, so
+	 *	the current_thread()->ith_messages deref in ipc_kmsg_delayed_destroy
+	 *	page-faults (#148; mirrors the #252 filt_machport fix).  Give the
+	 *	thread Mach state on demand.  If that allocation ever fails, destroy
+	 *	the message directly rather than via the per-thread delayed queue, so
+	 *	teardown can never fault.
+	 */
+	if (curthread->td_machdata == NULL &&
+	    mach_thread_init_lazy(curthread) != 0) {
+		ipc_kmsg_clean(kmsg);
+		ipc_kmsg_free(kmsg);
+		return;
+	}
 
 	/*
 	 *	ipc_kmsg_clean can cause more messages to be destroyed.


### PR DESCRIPTION
## Problem

`halt -p` / `reboot` / `shutdown -p now` page-fault the kernel instead of halting cleanly:

```
trap 12 (page fault), current process = DispatchWorker
ipc_kmsg_destroy+0x15
ipc_port_destroy+0x211
mach_port_close+0x1ab
_fdrop / kern_last_close / ipc_entry_list_close
exit1 -> sigexit -> postsig (SIGTERM at shutdown)
```

`DispatchWorker` (libdispatch pthread-workqueue) threads never go through mach.ko's thread-init path, so their `td_machdata` is NULL. When such a thread exits, the kernel walks its fd table closing Mach ports (`mach_port_close` → `ipc_port_destroy` → `ipc_kmsg_destroy`), and `ipc_kmsg_delayed_destroy` dereferences `current_thread()->ith_messages` (`current_thread()` == `curthread->td_machdata`) → NULL deref → panic.

Panic-recovery auto-reboots after 15s, and the CI boot test's clean-halt detection matched either way, so this was masked — but every shutdown was actually a panic. Confirmed present in unrelated green runs (e.g. the #219 build), so it is pre-existing and independent of the userland fixes landing this week.

## Fix

Same lazy-init pattern as #252 (PR #31): at the top of `ipc_kmsg_destroy`, if `td_machdata` is NULL, call `mach_thread_init_lazy(curthread)` (which runs `ipc_thread_init`, initializing `ith_messages`). If that allocation ever fails, destroy the message directly (`ipc_kmsg_clean` + `ipc_kmsg_free`) rather than via the per-thread delayed queue, so teardown can never fault.

Single chokepoint: `ipc_kmsg_delayed_destroy` and `ipc_kmsg_reap_delayed` are both reached only via `ipc_kmsg_destroy`, and they are the only consumers of `current_thread()->ith_messages` in this path.

Closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)