### PR TITLE
iokit: gate present-scan printfs behind bootverbose

### DIFF
--- a/src-overlay/sys/dev/iokit/iokit_catalogue.c
+++ b/src-overlay/sys/dev/iokit/iokit_catalogue.c
@@ -306,9 +306,10 @@ iocat_rematch_present(void)
 			if (iocat_lookup_pci(mw, bundle, sizeof(bundle),
 			    &score) != 0)
 				continue;	/* no personality claims it */
-			printf("iokit: present-scan: %s (0x%08x) present + "
-			    "unmatched -> request load %s\n",
-			    device_get_nameunit(child), mw, bundle);
+			if (bootverbose)
+				printf("iokit: present-scan: %s (0x%08x) present + "
+				    "unmatched -> request load %s\n",
+				    device_get_nameunit(child), mw, bundle);
 			iocat_request_load(mw, device_get_nameunit(child),
 			    bundle, score);
 			requested++;
@@ -316,10 +317,15 @@ iocat_rematch_present(void)
 		free(kids, M_TEMP);
 	}
 	free(buses, M_TEMP);
-	/* One summary line so CI can confirm the scan ran even when every present
-	 * device is already attached (qemu) and no per-device line is printed. */
-	printf("iokit: present-scan: checked %d pci devices, %d unmatched, "
-	    "%d load(s) requested\n", checked, unmatched, requested);
+	/* One summary line, under bootverbose, so a verbose boot can confirm the
+	 * scan ran even when every present device is already attached (qemu) and
+	 * no per-device line is printed. Quiet on a normal boot so the autoload
+	 * scan doesn't paper over the console / getty login prompt; the data is
+	 * still in dmesg on a verbose boot. (CI verifies autoload via the
+	 * EM-AUTOLOAD / IOCATALOGUE / kextstat markers, not this line.) */
+	if (bootverbose)
+		printf("iokit: present-scan: checked %d pci devices, %d unmatched, "
+		    "%d load(s) requested\n", checked, unmatched, requested);
 }
 
 static void


### PR DESCRIPTION
## Problem

`iocat_rematch_present()` emits two **unconditional** kernel `printf()` lines on every boot:

```
iokit: present-scan: (null) (0x24f38086) present + unmatched -> request load org.nextbsd.kext.intelwifi
iokit: present-scan: checked 17 pci devices, 9 unmatched, 2 load(s) requested
```

These go straight to `/dev/console`. The present-scan fires late — on kextd's IOKitPersonalities push, concurrent with getty bringing up the login prompt — so the lines paper over the prompt, interleaved with the drivers' attach banners.

## Change

Wrap both `printf`s in `if (bootverbose)`, matching the sibling load-request lines already gated at `iokit_catalogue.c:201`/`:205`. `iocat_request_load()` itself stays unconditional — **autoload behavior is unchanged**, only the logging is gated.

- Normal boot: quiet console.
- `boot -v`: full scan trace on console + in dmesg, as before.

## Test impact

None. Nothing in the tree greps `present-scan` / `load(s) requested` / `present + unmatched`. The autoload path is verified via the `EM-AUTOLOAD` / `IOCATALOGUE` / `KEXTD-LOAD` markers, `hw.iokit.catalogue*` sysctls, `ioreg`, `kextstat`, and `/var/log/kextd.log` — never this line. CI also boots non-verbose, so the gate quiets exactly the CI/normal boot. The stale "so CI can confirm the scan ran" comment is corrected.

## Scope

This quiets the `iokit:` lines only. The `iwlwifi0:` / `em0:` driver-attach banners are standard FreeBSD `device_printf` from the imported drivers and are not touched here — see the discussion on the PR about whether/how to route those through a console log-level threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)