### PR TITLE
iokit: present-scan looks through vgapci to autoload the GPU DRM kext (#64)

### DIFF
--- a/src-overlay/sys/dev/iokit/iokit_catalogue.c
+++ b/src-overlay/sys/dev/iokit/iokit_catalogue.c
@@ -30,6 +30,7 @@
 #include <sys/iocatalogue.h>
 
 #include <dev/pci/pcivar.h>
+#include <dev/pci/pcireg.h>	/* PCIC_DISPLAY — vgapci look-through (#64) */
 
 #ifdef COMPAT_MACH
 /* K3b (#216): the kernel->kextd Mach load-request send (compat/mach/iokit_kextd.c).
@@ -268,8 +269,41 @@ iocat_rematch_pending(void)
  * hand loads them fine — the load path works, only the trigger was missed).
  * This active scan of the live device tree is the authoritative trigger: it does
  * not depend on the event firing, so it autoloads whatever is actually present.
- * Idempotent — devices that already have a driver are skipped.
+ * Idempotent — devices already bound to a real driver are skipped; a display
+ * device claimed by vgapci(4) is looked THROUGH to its (possibly still-unbound)
+ * drmn child, so the GPU's DRM kext is requested even though vgapci already owns
+ * the PCI function (#64).
  */
+
+/*
+ * True if a vgapci device already has an *attached* drmn (DRM/KMS) child.
+ * vga_pci_attach ALWAYS pre-creates a drmn child in DS_NOTPRESENT, so mere
+ * presence is not enough — only an *attached* drmn means KMS is actually bound,
+ * and only then is there nothing for the present-scan to do.
+ */
+static bool
+iocat_drmn_bound(device_t vga)
+{
+	device_t *kids = NULL;
+	int nkids = 0, k;
+	bool bound = false;
+
+	if (device_get_children(vga, &kids, &nkids) != 0)
+		return (false);
+	for (k = 0; k < nkids; k++) {
+		devclass_t dc = device_get_devclass(kids[k]);
+		const char *n = dc != NULL ? devclass_get_name(dc) : NULL;
+
+		if (n != NULL && strcmp(n, "drmn") == 0 &&
+		    device_is_attached(kids[k])) {
+			bound = true;
+			break;
+		}
+	}
+	free(kids, M_TEMP);
+	return (bound);
+}
+
 static void
 iocat_rematch_present(void)
 {
@@ -296,9 +330,29 @@ iocat_rematch_present(void)
 			uint32_t mw;
 
 			checked++;
-			/* Already claimed by a driver — nothing to do. */
-			if (device_get_driver(child) != NULL)
-				continue;
+			/*
+			 * Skip devices already bound to a real driver — EXCEPT a
+			 * display function claimed by vgapci(4). The real GPU
+			 * driver (i915kms/amdgpu/radeonkms) attaches as vgapci's
+			 * CHILD (DRIVER_MODULE(.., vgapci)), so a vgapci-claimed
+			 * GPU is not yet KMS-driven. Look THROUGH vgapci to its
+			 * drmn child; if no *attached* drmn yet, request the GPU
+			 * kext. kextd kldloads it and newbus BUS_DRIVER_ADDED then
+			 * attaches drmn automatically — no manual reprobe (that
+			 * would race the built-in attach). (#64)
+			 */
+			if (device_get_driver(child) != NULL) {
+				devclass_t dc = device_get_devclass(child);
+				const char *dn = dc != NULL ?
+				    devclass_get_name(dc) : NULL;
+
+				if (dn == NULL || strcmp(dn, "vgapci") != 0 ||
+				    pci_get_class(child) != PCIC_DISPLAY)
+					continue;	/* real owner — skip */
+				if (iocat_drmn_bound(child))
+					continue;	/* DRM already bound */
+				/* vgapci-shadowed GPU, DRM unbound — fall through. */
+			}
 			unmatched++;
 			/* IOPCIPrimaryMatch form: device<<16 | vendor. */
 			mw = ((uint32_t)pci_get_device(child) << 16) |


### PR DESCRIPTION
## The bug (real hardware)
The graphics kext never autoloaded on a T460s. The in-kernel `present-scan` (`iocat_rematch_present`) skipped every device with a driver — and FreeBSD's `vgapci(4)` claims the VGA function at boot. But the real GPU driver (`i915kms`/`amdgpu`/`radeonkms`) attaches as **vgapci's child** (`DRIVER_MODULE(.., vgapci)`), so a vgapci-claimed GPU is **not yet KMS-driven**. vgapci is the GPU's mandatory parent bus, not its driver. The GPU *is* in the match table (Skylake `0x1916` is one of IntelGraphics' 364 ids), so only the **load trigger** was missing.

## The fix
Make the scan **vgapci-aware**: instead of blanket-skipping claimed devices, look **through** a vgapci-claimed `PCIC_DISPLAY` node to its `drmn` child, and request the GPU kext if no *attached* `drmn` exists yet.

**Crucial correctness detail** (from the #64 research, verified against `vga_pci.c`): `vga_pci_attach` **always pre-creates a `drmn` child in `DS_NOTPRESENT`**, so mere presence is not enough — only `device_is_attached(drmn)` means KMS is actually bound. A naive "has drmn child" check would always skip → never load. Hence `iocat_drmn_bound()` tests `device_is_attached`.

**No manual reprobe:** once kextd `kldload`s the kext, `DRIVER_MODULE → BUS_DRIVER_ADDED → device_probe_and_attach(drmn)` fires automatically; poking it ourselves would race the built-in attach and risk double-attach.

Other-driver-claimed devices stay skipped; the NIC/WiFi path (`driver == NULL`) is unchanged.

## Why this, not Apple's model
Apple binds GPUs by `IOProbeScore` arbitration on a single `IOPCIDevice` nub (real driver out-scores the generic claimer). NextBSD binds via **newbus**, where the DRM driver is vgapci's *child*, not a competitor for the node — so the native fix is "trigger the load, let newbus attach," not nub arbitration. (The IOProbeScore re-arbitration model is tracked as a future spike, nextbsd#271.)

## Verification
- CI: compiles + boots (in qemu the stdvga device has no catalogue personality, so the look-through is a no-op there — this exercises the build + boot, not the bind).
- Real hardware (T460s) is the functional end-to-end test: with the kext load fix (kernel-modules #16, OSBundleCompatibleVersion) also in place, the GPU should now autoload + bind. Watch the **efifb/vt → i915kms console handoff** at attach (the known KMS-handoff hazard).

Pairs with nextbsd-kernel-modules#16 (which fixes the *load*); this fixes the *autoload trigger*.