### PR TITLE
graphics: bake drm-kmod base deps (iic, lindebugfs, linuxkpi_video) into the kernel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,26 @@ jobs:
           test -f /usr/src/sys/sys/ioregistry.h
           echo "==> ioregistry wired: $(grep -c 'dev/iokit/iokit_registry.c' /usr/src/sys/conf/files) entry; source + header present"
 
+      # Bake linuxkpi_video into the kernel (graphics autoload, #64). drm.ko
+      # (IOGraphics.kext) hard-MODULE_DEPENDs on linuxkpi_video -- drm-kmod's
+      # video helpers (drm_aperture/HDMI/cmdline) -- which FreeBSD ships module-
+      # only with no config option (no in-tree consumer). NextBSD ships no
+      # /boot/kernel .ko tree, so we compile its sources in here, gated on
+      # COMPAT_LINUXKPI. The source files are stock base sources (already in the
+      # clone); we only append the files fragment. KERNEL build only -- the
+      # modules build shares patches/series but does not lay the overlay or cat
+      # these fragments, so it keeps building linuxkpi_video as its own .ko (same
+      # rule as iocatalogue/ioregistry). iic + lindebugfs, drm's other two
+      # missing base deps, are baked via config/NEXTBSD (device iic + LINDEBUGFS).
+      - name: Wire in linuxkpi_video (drm dep; graphics autoload, #64)
+        run: |
+          set -eu
+          cat "$GITHUB_WORKSPACE/src-overlay/conf/files.linuxkpi_video" >> /usr/src/sys/conf/files
+          for s in linux_hdmi linux_aperture linux_cmdline linuxkpi_videokmod; do
+            test -f "/usr/src/sys/compat/linuxkpi/common/src/$s.c"
+          done
+          echo "==> linuxkpi_video wired: $(grep -c 'linuxkpi_videokmod.c' /usr/src/sys/conf/files) entry; sources present"
+
       - name: Build kernel (no modules)
         run: |
           cd /usr/src

--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -25,3 +25,18 @@ options 	INIT_PATH=/sbin/launchd
 # driver->kext conversion; ix/ixl/ice/igc stay built in (no qemu device to prove
 # their auto-load -- see nextbsd #245).
 nodevice 	em
+
+# Graphics (drm-kmod) base deps. IOGraphics.kext = drm.ko hard-MODULE_DEPENDs on
+# a set of base modules; GENERIC's `options COMPAT_LINUXKPI` already bakes most
+# (iicbus, iicbb, backlight, linuxkpi) but NOT these two:
+#   iic        -- `optional iic` only; the /dev/iic char layer drm uses for DDC.
+#   lindebugfs -- `optional lindebugfs`; drm's debugfs interface. Functionally
+#                 optional, but the MODULE_DEPEND is HARD so drm.ko won't load
+#                 without the module present.
+# NextBSD ships no /boot/kernel .ko tree (kernel-only; everything else is a
+# kext), so unbaked module deps can't be resolved at load time -- drm.ko fails
+# with "depends on iic - not available". Baking them here satisfies the linker.
+# drm's third missing dep, linuxkpi_video, has no config option and is wired in
+# via src-overlay/conf/files.linuxkpi_video (build.yml). (graphics autoload, #64)
+device		iic
+options 	LINDEBUGFS

--- a/src-overlay/conf/files.linuxkpi_video
+++ b/src-overlay/conf/files.linuxkpi_video
@@ -1,0 +1,20 @@
+# linuxkpi_video -- drm-kmod's video helper module (drm_aperture / HDMI infoframe
+# / kernel cmdline helpers). It has no in-tree consumer, so FreeBSD ships it
+# module-only (sys/modules/linuxkpi_video) with no kernel-config option. drm.ko
+# hard-MODULE_DEPENDs on it, and NextBSD ships no /boot/kernel .ko tree, so we
+# bake it into the kernel by compiling its sources here, gated on the
+# COMPAT_LINUXKPI option already set by NEXTBSD/GENERIC. Source list and the
+# linux_hdmi.c -Wno-cast-qual flag mirror sys/modules/linuxkpi_video/Makefile;
+# the ${LINUXKPI_C} compile rule matches the other compat_linuxkpi entries in
+# sys/conf/files. Appended to sys/conf/files by build.yml on the KERNEL build
+# only -- the modules build shares patches/series but keeps building
+# linuxkpi_video as its own .ko, so it must never see these listed (same rule as
+# files.iocatalogue / files.ioregistry).
+compat/linuxkpi/common/src/linux_hdmi.c		optional compat_linuxkpi \
+	compile-with "${LINUXKPI_C} -Wno-cast-qual"
+compat/linuxkpi/common/src/linux_aperture.c	optional compat_linuxkpi \
+	compile-with "${LINUXKPI_C}"
+compat/linuxkpi/common/src/linux_cmdline.c	optional compat_linuxkpi \
+	compile-with "${LINUXKPI_C}"
+compat/linuxkpi/common/src/linuxkpi_videokmod.c	optional compat_linuxkpi \
+	compile-with "${LINUXKPI_C}"


### PR DESCRIPTION
## Why
The #64 vgapci look-through autoload trigger **works** on the T460s — present-scan now requests `org.nextbsd.kext.intelgraphics` for the Skylake GPU (`0x19168086`). But the kext load then fails:

```
KLD IOGraphics: depends on iic - not available or version mismatch
linker_load_file: .../IOGraphics.kext/Contents/MacOS/IOGraphics - unsupported file type
```

`IOGraphics` (= `drm.ko`) is a **valid** ELF kmod (the "unsupported file type" line is just a cascade from the failed dependency). The real problem: `drm.ko` hard-`MODULE_DEPEND`s on a set of base modules, and **NextBSD ships no `/boot/kernel` `.ko` tree** (kernel-only; everything else is a kext — see `nextbsd build.sh:644`), so any dep that's neither baked nor a kext can't be resolved at load time.

## drm.ko's full dep set
`agp, iicbus, iic, iicbb, pci, mem, linuxkpi, linuxkpi_video, dmabuf, lindebugfs`

| dep | provided by |
|---|---|
| `agp`, `mem`, `pci` | GENERIC (built-in) ✓ |
| `iicbus`, `iicbb`, `backlight`, `linuxkpi` | `options COMPAT_LINUXKPI` ✓ |
| `dmabuf`, `ttm` | `DMABuf.kext` / `TTM.kext` (OSBundleLibraries) ✓ |
| **`iic`** | **`optional iic` only — not covered → `device iic`** |
| **`lindebugfs`** | **`optional lindebugfs` — hard dep → `options LINDEBUGFS`** |
| **`linuxkpi_video`** | **module-only, no config option → baked via files fragment** |

`iic` was just the *first* unmet dep; `lindebugfs`/`linuxkpi_video` would fail next.

## Changes (all in `nextbsd-kernel`)
- **`config/NEXTBSD`**: `device iic` + `options LINDEBUGFS`.
- **`src-overlay/conf/files.linuxkpi_video`**: the 4 `linuxkpi_video` sources gated `optional compat_linuxkpi`, with the `linux_hdmi.c -Wno-cast-qual` flag — mirrors `sys/modules/linuxkpi_video/Makefile`.
- **`build.yml`**: a wiring step appending that fragment to `sys/conf/files` (kernel build only, like `iocatalogue`/`ioregistry`), so the modules build still produces `linuxkpi_video.ko` as its own `.ko`.

`lindebugfs` is functionally optional (just drm's debugfs interface) but the `MODULE_DEPEND` is *hard*, so drm.ko won't load without the module present — and it's tiny.

## Test
- CI: kernel must build amd64+arm64 with the three bakes and pass the boot smoke-test.
- HW: on the T460s, `IntelGraphics`/`IOGraphics` should now load past the `iic` failure → `drmn` attach → `/dev/dri/card0`. The known efifb→i915 console-handoff hazard (handled by `linux_aperture.c`, now baked) is the next thing to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)