### PR TITLE
config: bake live-root filesystems (GEOM_UZIP, TARFS, UNIONFS, NULLFS)

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -40,3 +40,30 @@ nodevice 	em
 # via src-overlay/conf/files.linuxkpi_video (build.yml). (graphics autoload, #64)
 device		iic
 options 	LINDEBUGFS
+
+# Live-media root (nextbsd #70 + the live-root overlay design). The live ISO
+# boots a compressed, read-only root and a writable tmpfs+unionfs overlay is
+# stacked over it (by a vfs_mountroot hook, gated on a vfs.root.overlay kenv the
+# live image declares); the installed system stays plain rw-UFS and never
+# unions, decided at boot by the root provider being writable + the absence of
+# that kenv. GENERIC already bakes everything else this needs (FFS, CD9660,
+# MD_ROOT, TMPFS, GEOM_LABEL, ZSTDIO, md); these are the gap, and since NextBSD
+# ships no .ko tree they must be compiled in:
+#   GEOM_UZIP -- compressed read-only block image; block-level random-access
+#                decompression (snappier scattered reads on a desktop root).
+#                Leading candidate. zlib/LZMA/zstd codecs come with it.
+#   TARFS     -- read-only tar filesystem; whole-stream zstd gives a better
+#                ratio. Baked alongside uzip so the ISO build can produce both
+#                and we pick the winner on real image-size vs boot/launch
+#                latency. (ZSTDIO, already in GENERIC, covers zstd for both.)
+#   UNIONFS   -- merges the read-only lower with a writable tmpfs upper so the
+#                live / appears read-write.
+#   NULLFS    -- not needed for the core overlay (unionfs does the copy-up), but
+#                kept as cheap insurance for the deferred install/persistence
+#                plumbing: bind the pristine uzip lower for a cpdup clone, or
+#                bind a writable partition into the union for a "live USB with
+#                save". nullfs is a pass-through mirror (no copy-up of its own).
+options 	GEOM_UZIP
+options 	TARFS
+options 	UNIONFS
+options 	NULLFS


### PR DESCRIPTION
First step of the **live-ISO** series (nextbsd #70 + the live-root overlay design): a compressed read-only root with a writable `tmpfs`+`unionfs` overlay, while the installed system stays plain rw-UFS and never unions.

## What
GENERIC already bakes the carriers we reuse — `FFS`, `CD9660`, `MD_ROOT`, `TMPFS`, `GEOM_LABEL`, `ZSTDIO`, `md` — so the only gap is three filesystems (NextBSD ships no `/boot/kernel` `.ko` tree, so these must be compiled in):

| token | role |
|---|---|
| `GEOM_UZIP` | compressed RO block image; random-access decompress, on-demand from media (low RAM). **Leading candidate.** |
| `TARFS` | RO tar fs; whole-stream zstd = better ratio, but root is a RAM-resident preloaded md. Baked for the **bake-off**. |
| `UNIONFS` | merges the RO lower with a writable `tmpfs` upper → writable `/` |

Both bases boot **BIOS + UEFI + ISO** (the root fs is orthogonal to the firmware/loader path). They're baked together so the ISO build can produce each and we pick the winner on **image size / read latency / RAM**. Same baking mechanism as the graphics deps in #37.

## Why config-only
No functional effect until the `build.sh` ISO path and the `vfs_mountroot` overlay hook land — this just makes the filesystems available at root-mount time. Keeps the risky pieces out of this safe, CI-validatable foundation.

## Series
1. **this PR** — bake the filesystems
2. `vfs_mountroot` overlay hook (kernel, Option B) — gated on a `vfs.root.overlay` kenv, no-op on normal boot
3. `build.sh` live-ISO path (uzip **and** tarfs for the bake-off) + launchd `if (MNT_RDONLY) mount -uw /` + qemu boot-test
4. *(deferred: cpdup installer)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)