### PR TITLE
kern: writable live-root overlay via a mountroot event handler (#70)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,21 @@ jobs:
           done
           echo "==> linuxkpi_video wired: $(grep -c 'linuxkpi_videokmod.c' /usr/src/sys/conf/files) entry; sources present"
 
+      # Writable live-root overlay (nextbsd #70 live-root series). The source
+      # kern/vfs_mountroot_overlay.c is laid into /usr/src/sys by the overlay cp
+      # above; here we append its files fragment so it is compiled into the
+      # kernel. It self-registers a `mountroot` event handler (no base patch) and
+      # is a no-op unless the live image sets the vfs.root.overlay kenv. KERNEL
+      # build only -- the modules build shares patches/series but not the overlay
+      # or these fragments, so it must never see this source (same rule as the
+      # iocatalogue/ioregistry/linuxkpi_video wiring above).
+      - name: Wire in writable live-root overlay (#70)
+        run: |
+          set -eu
+          cat "$GITHUB_WORKSPACE/src-overlay/conf/files.vfs_overlay" >> /usr/src/sys/conf/files
+          test -f /usr/src/sys/kern/vfs_mountroot_overlay.c
+          echo "==> vfs overlay wired: $(grep -c 'vfs_mountroot_overlay.c' /usr/src/sys/conf/files) entry; source present"
+
       - name: Build kernel (no modules)
         run: |
           cd /usr/src

--- a/src-overlay/conf/files.vfs_overlay
+++ b/src-overlay/conf/files.vfs_overlay
@@ -1,0 +1,9 @@
+# NextBSD writable live-root overlay (nextbsd #70 live-root series).
+# Self-registering `mountroot` event handler that stacks a tmpfs+unionfs writable
+# overlay over a read-only live root. `standard` (always compiled); it is a no-op
+# unless the live image sets the vfs.root.overlay kenv, so it is safe on the
+# installed (plain rw-UFS) system too. Source is laid into /usr/src/sys by the
+# overlay cp in build.yml. KERNEL build only -- the modules build shares
+# patches/series but does not lay the overlay or cat these fragments, so it must
+# never see this source listed in sys/conf/files (same rule as iocatalogue).
+kern/vfs_mountroot_overlay.c		standard

--- a/src-overlay/sys/kern/vfs_mountroot_overlay.c
+++ b/src-overlay/sys/kern/vfs_mountroot_overlay.c
@@ -33,6 +33,7 @@
 #include <sys/mutex.h>
 #include <sys/mount.h>
 #include <sys/proc.h>
+#include <sys/syscallsubr.h>		/* kern_unmount() */
 #include <sys/jail.h>
 #include <sys/filedesc.h>
 #include <sys/vnode.h>

--- a/src-overlay/sys/kern/vfs_mountroot_overlay.c
+++ b/src-overlay/sys/kern/vfs_mountroot_overlay.c
@@ -1,0 +1,178 @@
+/*-
+ * NextBSD: writable overlay for a read-only live root.
+ *
+ * When the live image's loader.conf sets the kenv `vfs.root.overlay`, stack a
+ * writable tmpfs over the read-only root via unionfs so `/` becomes read-write
+ * BEFORE init (PID 1 / launchd) is exec'd. The installed system does not set the
+ * kenv, so this is a no-op there and `/` stays a plain rw-UFS.
+ *
+ * Mechanism: register a `mountroot` event handler. EVENTHANDLER_INVOKE(mountroot)
+ * fires at the end of vfs_mountroot() (sys/kern/vfs_mountroot.c), which is called
+ * synchronously by start_init() (sys/kern/init_main.c:732) -- AFTER the real root
+ * is mounted (read-only, MNT_ROOTFS, devfs shuffled to /dev) and BEFORE
+ * start_init() execs PID 1. So the overlay exists before any userland runs.
+ *
+ * We use the high-level kernel_mount() API (as the root mount itself does), NOT
+ * the low-level vfs_mount_alloc()/VFS_MOUNT() devfs path: tmpfs and unionfs both
+ * dereference mnt_vnodecovered during mount, which the devfs path leaves NULL.
+ * Mounting unionfs over "/" makes the covered vnode (the real root) the union's
+ * LOWER automatically (sys/fs/unionfs/union_vfsops.c), with the tmpfs as the
+ * upper -- exactly the rw-over-ro semantics we want, no `below` option. unionfs
+ * refuses to BE MNT_ROOTFS, so we mount it with flags 0; the real root keeps
+ * MNT_ROOTFS and the union sits on top.
+ *
+ * Carried entirely in nextbsd-kernel (src-overlay + a kernel-build-only files
+ * fragment); no edit to the freebsd-src fork.  (nextbsd #70 live-root series)
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/eventhandler.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/mount.h>
+#include <sys/proc.h>
+#include <sys/jail.h>
+#include <sys/filedesc.h>
+#include <sys/vnode.h>
+
+/*
+ * Scratch mountpoint for the tmpfs upper. MUST already exist (empty) in the
+ * read-only root image: the kernel cannot mkdir on a RO fs, and tmpfs derives
+ * its default owner/mode from VOP_GETATTR(mnt_vnodecovered) at mount time. The
+ * NextBSD image build is responsible for creating it.
+ */
+#define	OVL_MNT	"/.overlay"
+
+static struct mount *
+overlay_find_mp(const char *onname, const char *fstype)
+{
+	struct mount *mp;
+
+	/* kernel_mount() does not hand back the mp; find it by name+type. */
+	mtx_lock(&mountlist_mtx);
+	TAILQ_FOREACH_REVERSE(mp, &mountlist, mntlist, mnt_list) {
+		if (strcmp(mp->mnt_stat.f_mntonname, onname) == 0 &&
+		    strcmp(mp->mnt_stat.f_fstypename, fstype) == 0)
+			break;
+	}
+	mtx_unlock(&mountlist_mtx);
+	return (mp);
+}
+
+static void
+overlay_set_ignore(struct mount *mp)
+{
+
+	if (mp == NULL)
+		return;
+	/* MNT_IGNORE => hidden from df(1); leaves one clean "/" line. */
+	MNT_ILOCK(mp);
+	mp->mnt_flag |= MNT_IGNORE;
+	MNT_IUNLOCK(mp);
+}
+
+static void
+vfs_overlay_mountroot(void *arg __unused)
+{
+	struct mntarg *ma;
+	struct mount *lower_mp, *tmpfs_mp, *union_mp;
+	struct vnode *uvp, *oldrootvp;
+	struct thread *td = curthread;
+	char *val;
+	int error;
+
+	val = kern_getenv("vfs.root.overlay");
+	if (val == NULL)
+		return;			/* not a live image: plain root, no-op */
+	freeenv(val);
+
+	/* The real read-only root currently at / (holds MNT_ROOTFS). */
+	lower_mp = rootvnode->v_mount;
+
+	/* 1. Writable tmpfs upper at OVL_MNT (must pre-exist in the RO image). */
+	ma = mount_arg(NULL, "fstype", "tmpfs", -1);
+	ma = mount_arg(ma, "fspath", OVL_MNT, -1);
+	ma = mount_arg(ma, "from", "tmpfs", -1);
+	ma = mount_arg(ma, "mode", "0755", -1);
+	/* size omitted => unlimited (capped by available RAM/swap). */
+	error = kernel_mount(ma, 0);
+	if (error != 0) {
+		printf("vfs.root.overlay: tmpfs mount on %s failed (%d); "
+		    "leaving root read-only\n", OVL_MNT, error);
+		return;
+	}
+	tmpfs_mp = overlay_find_mp(OVL_MNT, "tmpfs");
+
+	/* 2. unionfs over /: covered(/) = RO root = lower; target = tmpfs = upper. */
+	ma = mount_arg(NULL, "fstype", "unionfs", -1);
+	ma = mount_arg(ma, "fspath", "/", -1);
+	ma = mount_arg(ma, "target", OVL_MNT, -1);
+	error = kernel_mount(ma, 0);		/* flags 0: never MNT_ROOTFS */
+	if (error != 0) {
+		printf("vfs.root.overlay: unionfs mount over / failed (%d); "
+		    "leaving root read-only\n", error);
+		(void)kern_unmount(td, OVL_MNT, 0);
+		return;
+	}
+	union_mp = overlay_find_mp("/", "unionfs");
+	if (union_mp == NULL) {
+		printf("vfs.root.overlay: union mount not found after mount; "
+		    "leaving root as-is\n");
+		return;
+	}
+
+	/* 3. Re-point the global rootvnode at the union root. set_rootvnode()
+	 *    would pick TAILQ_FIRST (the lower), so do it explicitly. */
+	error = VFS_ROOT(union_mp, LK_EXCLUSIVE, &uvp);
+	if (error != 0) {
+		printf("vfs.root.overlay: VFS_ROOT(union) failed (%d)\n", error);
+		(void)kern_unmount(td, "/", 0);	/* union is not MNT_ROOTFS */
+		(void)kern_unmount(td, OVL_MNT, 0);
+		return;
+	}
+	VOP_UNLOCK(uvp);
+
+	oldrootvp = rootvnode;
+	rootvnode = uvp;		/* the VFS_ROOT ref becomes the global ref */
+	pwd_set_rootvnode();		/* refresh curproc's root from rootvnode */
+	cache_purge(uvp);
+
+	/*
+	 * vfs_mountroot() already set prison0.pr_root to the OLD root (it runs
+	 * before this event handler). Re-sync it to the union, or every process
+	 * (all are in prison0) would resolve / through the RO lower.
+	 */
+	mtx_lock(&prison0.pr_mtx);
+	if (prison0.pr_root != NULL)
+		vrele(prison0.pr_root);
+	prison0.pr_root = uvp;
+	vref(uvp);
+	mtx_unlock(&prison0.pr_mtx);
+
+	if (oldrootvp != NULL)
+		vrele(oldrootvp);
+
+	/* 4. Hide the RO lower + tmpfs from df; lower keeps MNT_ROOTFS. */
+	overlay_set_ignore(lower_mp);
+	overlay_set_ignore(tmpfs_mp);
+
+	printf("vfs.root.overlay: / is now read-write "
+	    "(unionfs: tmpfs upper over %s lower)\n",
+	    lower_mp->mnt_stat.f_fstypename);
+}
+
+/*
+ * Register the handler before vfs_mountroot() runs. SI_SUB_VFS is well before
+ * start_init()/SI_SUB_KTHREAD_INIT, and the eventhandler subsystem is up by
+ * then. EVENTHANDLER_PRI_FIRST so we run ahead of any other mountroot consumer.
+ */
+static void
+vfs_overlay_register(void *arg __unused)
+{
+
+	EVENTHANDLER_REGISTER(mountroot, vfs_overlay_mountroot, NULL,
+	    EVENTHANDLER_PRI_FIRST);
+}
+SYSINIT(vfs_root_overlay, SI_SUB_VFS, SI_ORDER_ANY, vfs_overlay_register, NULL);


### PR DESCRIPTION
**PR2 of the live-root series** (PR1 #38 baked the filesystems). When the live image's `loader.conf` sets the kenv `vfs.root.overlay`, the kernel stacks a writable `tmpfs` over the read-only root via `unionfs` so `/` is read-write **before init (launchd) is exec'd**. The installed system doesn't set the kenv → no-op → plain rw-UFS, unchanged.

## How (zero patch to freebsd-src)
A self-registering **`mountroot` event handler**. `EVENTHANDLER_INVOKE(mountroot)` fires at the end of `vfs_mountroot()`, which `start_init()` calls *synchronously* (init_main.c:732) **after** the real root is mounted and **before** it execs PID 1 — so the overlay exists before any userland runs. The handler is a new source in `src-overlay/sys/kern/vfs_mountroot_overlay.c`, wired into the **kernel build only** via a files fragment (same pattern as `iocatalogue`/`ioregistry`/`linuxkpi_video`). 

> Why an event handler and not a 2-line call patched into `vfs_mountroot.c`? The modules build shares `patches/series` but **not** our overlay — a patched-in call would be an undefined symbol there. The event handler avoids touching base entirely.

## Mechanics
- `kernel_mount()` (the high-level API the root mount itself uses) — **not** the low-level devfs path (tmpfs/unionfs deref `mnt_vnodecovered`, which devfs leaves `NULL`).
- `unionfs` over `/` makes the covered vnode (the real root) the **lower** automatically, tmpfs the upper; flags `0` (unionfs refuses `MNT_ROOTFS`, so the real root keeps it and the union sits on top).
- re-point `rootvnode` **and** `prison0.pr_root` at the union.
- `MNT_IGNORE` the RO lower + tmpfs → `df` shows one clean `/`.
- any failure unwinds and leaves the plain root → init always boots.

## What this PR validates vs. doesn't
- ✅ **Validates here:** kernel builds amd64+arm64; the existing boot smoke-test (no overlay kenv → handler returns immediately) confirms **normal boot is unaffected**. Safe to land — it's a gated no-op until a live image exists.
- ⏳ **Proven next:** the overlay path itself is exercised end-to-end by the live-ISO `qemu` test in PR3 (the `build.sh` ISO path), which also creates the empty `/.overlay` mountpoint the tmpfs attaches to.

## Honest unknowns (flagged in the design; the boot test settles them)
1. 🔴 mounting unionfs over `/` covers a `VV_ROOT` vnode — allowed in the code path, but the one thing only a boot can fully prove.
2. 🟡 `rootvnode`/`prison0` refcount discipline (validate under `INVARIANTS`).
3. 🟡 `/dev` visibility through the union.

These don't affect *this* PR's safety (gated no-op), only the PR3 live boot.

## Series
1. ~~#38 — bake the filesystems~~ ✅ merged
2. **this PR** — the overlay hook
3. `build.sh` live-ISO path (uzip + tarfs bake-off) + `/.overlay` dir + launchd `if (MNT_RDONLY) mount -uw /` + qemu boot-test
4. *(deferred: cpdup installer)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)