### PR TITLE
unionfs: allow renaming onto a directory target (Track A, #282)

### DIFF
--- a/patches/0006-unionfs-rename-allow-directory-target.patch
+++ b/patches/0006-unionfs-rename-allow-directory-target.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000006 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 10 Jun 2026 17:20:00 -0500
+Subject: [PATCH] unionfs: allow renaming onto a directory target (#282)
+
+unionfs_rename() rejected any rename whose target is a directory that has
+an upper vnode, returning EINVAL unconditionally. On the NextBSD live ISO
+(read-only uzip lower + tmpfs upper) a directory that exists only in the
+read-only lower acquires an EMPTY upper shadow during lookup
+(unionfs_mkshadowdir()), so pkg(8)'s extract-to-temp-dir-then-rename
+pattern -- and POSIX rename onto an empty directory in general -- failed
+with EINVAL (e.g. `pkg install xlibre`: rename .pkgtemp.Type1.X -> Type1).
+
+The block was overly conservative: the success path already handles a VDIR
+rename target via cache_purge(), and the upper filesystem (tmpfs) enforces
+empty-target semantics itself (ENOTEMPTY for a non-empty target). Drop the
+pre-emptive EINVAL and proceed against the upper vnode.
+
+Carried out-of-tree for NextBSD.
+---
+ sys/fs/unionfs/union_vnops.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/sys/fs/unionfs/union_vnops.c b/sys/fs/unionfs/union_vnops.c
+--- a/sys/fs/unionfs/union_vnops.c
++++ b/sys/fs/unionfs/union_vnops.c
+@@ -1559,10 +1559,20 @@
+ 		if (unp->un_uppervp == NULLVP)
+ 			rtvp = NULLVP;
+ 		else {
+-			if (tvp->v_type == VDIR) {
+-				error = EINVAL;
+-				goto unionfs_rename_abort;
+-			}
++			/*
++			 * NextBSD (nextbsd #282): do not reject a directory
++			 * rename target with EINVAL.  A directory that exists
++			 * only in the read-only lower layer acquires an (empty)
++			 * upper shadow directory during lookup
++			 * (unionfs_mkshadowdir()), so the common
++			 * extract-to-temp-dir-then-rename pattern used by pkg(8)
++			 * -- and POSIX rename onto an empty directory in general
++			 * -- used to fail here on the live unionfs root.  Proceed
++			 * against the upper vnode instead: the upper filesystem
++			 * enforces empty-target semantics (ENOTEMPTY for a
++			 * non-empty target), and the success path below already
++			 * handles a VDIR rename target via cache_purge().
++			 */
+ 			rtvp = unp->un_uppervp;
+ 			vref(rtvp);
+ 		}
+-- 
+2.43.0

--- a/patches/series
+++ b/patches/series
@@ -3,3 +3,4 @@
 0003-kqueue-reserve-evfilt-machport.patch
 0004-NextBSD-search-firmware_path-for-raw-firmware-images.patch
 0005-NextBSD-default-coredumps-off.patch
+0006-unionfs-rename-allow-directory-target.patch


### PR DESCRIPTION
Fixes the live-ISO `pkg install` failure `rename(.pkgtemp.Type1.X -> Type1): EINVAL` (nextbsd-redux/nextbsd#282).

## Root cause (source-traced)
`unionfs_rename()` returns **EINVAL** at `union_vnops.c:1562-1564` for *any* rename whose target is a directory with an upper vnode. The target `Type1` exists only in the read-only lower (uzip), but the rename's lookup **auto-creates an empty upper shadow** for it (`unionfs_lookup` → `unionfs_mkshadowdir`), so by rename time it has an upper vnode → unconditional EINVAL. pkg builds a directory under a temp name and renames it into place, so this blocks font/X package installs on the live union.

## Fix
Drop the pre-emptive EINVAL and proceed against the upper vnode. This is safe and minimal:
- The **success path already handles a VDIR rename target** (`cache_purge` at :1577) — the original author anticipated it; the EINVAL was just overly conservative.
- The auto-created upper shadow is **empty**, and the **upper FS (tmpfs) enforces POSIX empty-target semantics itself** (ENOTEMPTY for a non-empty target).
- No new locking, no copy-up/whiteout dance → no LOR risk.

Patch `patches/0006`, applies cleanly against `releng/15.0` (verified).

## Validation
- This PR: kernel **compiles** + **boots** (CI).
- Full validation (font install succeeds on the live ISO) needs a patched-kernel ISO + the empirical reproduction once a live box is back online — the source analysis (#282) is conclusive that this is the failing path.

Analysis + alternatives: nextbsd-redux/nextbsd#282. The unionfs limitation is documented (Daichi); upstream's Dec-2025 `unionfs_copylink` symlink fix is the same spirit (handle the case instead of bailing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)