### PR TITLE
build: reformat kernel version banner (drop #0 + hash-dirty)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,13 +78,24 @@ jobs:
         run: |
           cd /usr/src
           nv=sys/conf/newvers.sh
+          # Also reformat the version banner (VERINFO/VERSTR, both metadata
+          # branches) to a clean NextBSD string and drop the FreeBSD bits that
+          # don't fit out-of-tree: the #N build counter and the
+          # <hash>[-dirty] VCS tag (the tree is always "dirty" -- it's
+          # releng/15.0 + the NextBSD patch stack). Result (uname -v):
+          #   NextBSD Kernel Version <RELEASE>; <date>; <user>@<host>:<objdir>
+          # RELEASE (the build timestamp) leads, so nextbsd-version -k can still
+          # find it. Replaced lines are tab-indented inside an if/else; both
+          # branches get the same value, which is fine.
           sed -i \
             -e 's~^TYPE=.*~TYPE="NextBSD"~' \
             -e 's~^RELEASE=.*~RELEASE=$(date -u +%Y%m%d-%H%M%S)~' \
             -e 's~t=$(date)$~t=$(date -u)~' \
+            -e 's~^[[:space:]]*VERINFO=".*~VERINFO="${TYPE} Kernel Version ${RELEASE}; ${t}; ${u}@${h}:${d}"~' \
+            -e 's~^[[:space:]]*VERSTR=".*~VERSTR="${VERINFO}\\\\n"~' \
             "$nv"
           echo "=== newvers.sh identity after rebrand ==="
-          grep -nE '^TYPE=|^REVISION=|^BRANCH=|^RELEASE=|t=\$\(date' "$nv" || true
+          grep -nE '^TYPE=|^RELEASE=|t=\$\(date|VERINFO=|VERSTR=' "$nv" || true
 
       # A syscalls.master patch changes the GENERATED syscall tables
       # (init_sysent.c, sys/sys/syscall.h, sysproto.h, syscalls.c, ...).


### PR DESCRIPTION
## What
Reformats the kernel version banner (`uname -v` / field 4 of `uname -a`) by extending the rebrand `sed` to rewrite `VERINFO`/`VERSTR`:

**Before:** `NextBSD 20260613-220051 #0 fef97a6889f9-dirty: Sat Jun 13 22:00:51 UTC 2026\n    root@host:/usr/obj/...`
**After:** `NextBSD Kernel Version 20260613-220051; Sat Jun 13 22:00:51 UTC 2026; root@host:/usr/obj/...`

## Why drop `#0` and `fef97a6889f9-dirty`
- `#N` is the build counter — always `#0` from a fresh CI obj tree.
- `<hash>-dirty` is the VCS tag, and the tree is **always** dirty: it's `releng/15.0` + the NextBSD patch stack (patches/ + overlay + sed), never committed. So the hash/dirty convey nothing useful here.

`RELEASE` (the build timestamp) leads the string, so `nextbsd-version -k` can still find it.

## Note
`uname -a` still shows `osrelease` (the timestamp) as field 3 — that field can't be suppressed — so the timestamp also appears there.

## Coupled change
`nextbsd-redux/nextbsd` updates `nextbsd-version`'s `-k` regex to extract the `YYYYMMDD-HHMMSS` pattern, robust to this wording (works with old and new banners). Order-independent.

## Verified locally
`sh -n` on the rewritten `newvers.sh`; generated `version[]` matches the "After" exactly.

Refs nextbsd-redux/nextbsd#300

🤖 Generated with [Claude Code](https://claude.com/claude-code)