### PR TITLE
config: bake in HID input drivers — mouse + touch/touchpad/pen + I2C (#335)

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -67,3 +67,38 @@ options 	GEOM_UZIP
 options 	TARFS
 options 	UNIONFS
 options 	NULLFS
+
+# HID input drivers (#335; see the input/touch driver spike). GENERIC compiles
+# in only the HID transport (hid, hidbus, usbhid) and the keyboard leaves (hkbd,
+# ukbd) -- the mouse/touch/pen leaves ship as loadable .ko modules that devd
+# auto-loads on stock FreeBSD. NextBSD ships NO .ko tree, so those leaves are
+# simply absent (config -x confirmed no hms/ums/hmt on the running kernel): a
+# USB mouse enumerates (usbhid0 -> hidbus0) with nothing to bind it, no
+# /dev/input node, no pointer. They must be compiled in here.
+
+# Mouse -- the reported bug (#335). hms is the hidbus mouse leaf (peer of hkbd):
+# relative mice AND absolute pointers (VM "tablet": QEMU usb-tablet, VirtualBox,
+# bhyve). Supersedes legacy ums (relative-only; won't attach while usbhid owns
+# the device). Built on the hidmap usage->evdev mapper.
+device		hms
+
+# Touch / touchpad / pen. hmt = multitouch touchpads AND touchscreens; hpen =
+# pens + single-touch digitizers; hconf drives the digitizer config TLC (puts a
+# Precision Touchpad into MT mode -- hmt hard-MODULE_DEPENDs on it). hidmap is
+# the 1:1 usage->evdev mapper hms/hpen are built on.
+device		hidmap
+device		hmt
+device		hpen
+device		hconf
+
+# I2C-HID transport for laptop precision touchpads/touchscreens: acpi -> ig4
+# (Intel/AMD LPSS I2C controller) -> iicbus -> iichid -> hidbus -> hmt/hms/hconf.
+# iichid matches ACPI _HID PNP0C50/ACPI0C50/ELAN0000; ietp catches Elan pads
+# that bind there instead of hmt. IICHID_SAMPLING is MANDATORY on amd64: the
+# touchpad IRQ is a GPIO line the kernel can't hand out, so iichid falls back to
+# polling -- without this option an IRQ-less I2C HID device fails to attach.
+device		iicbus
+device		ig4
+device		iichid
+device		ietp
+options 	IICHID_SAMPLING


### PR DESCRIPTION
## What

Bake the full HID **input** leaf set into `config/NEXTBSD` so mice, touchpads, touchscreens, and pens work:

```
device  hms        # HID mouse: relative + absolute (VM tablet); the #335 bug
device  hidmap     # usage->evdev mapper hms/hpen build on
device  hmt        # multitouch touchpads AND touchscreens
device  hpen       # pens/stylus + single-touch digitizers
device  hconf      # Precision-Touchpad mode switch (hmt hard-depends)
device  iicbus
device  ig4        # Intel/AMD LPSS I2C controller
device  iichid     # HID-over-I2C (PNP0C50/ACPI0C50/ELAN0000)
device  ietp       # Elan I2C touchpads that bind here instead of hmt
options IICHID_SAMPLING   # MANDATORY on amd64 (no GPIO IRQ) — else I2C HID won't attach
```

## Why

USB mice (and all touch input) are dead because **GENERIC compiles in only the HID transport (`hid`/`hidbus`/`usbhid`) and the keyboard leaves (`hkbd`/`ukbd`)** — the mouse/touch/pen leaves ship as loadable `.ko` modules that `devd` auto-loads on stock FreeBSD. **NextBSD ships no `.ko` tree**, so those leaves are simply absent. `config -x /boot/kernel/kernel` on the T460s confirms: `hkbd`/`ukbd`/`usbhid`/`hidbus` present, **no `hms`/`ums`/`hmt`**. A USB mouse enumerates `usbhid0 → hidbus0` with nothing to bind it → no `/dev/input/eventN`, no pointer.

`hms` alone closes the reported mouse bug. The touch/I2C block is the recommended follow-on (per the input/touch driver spike) so we don't reopen this per device class — `hmt`/`hpen` for touch & pen, `iichid`+`ig4` for I2C precision touchpads, `ietp` for Elan, and **`IICHID_SAMPLING`** which is mandatory on amd64 (the touchpad IRQ is a GPIO line the kernel can't hand out; without it an IRQ-less I2C HID device fails to attach entirely).

`hms` supersedes legacy `ums` (relative-only; can't drive VM absolute tablets) and is the in-base successor to the `utouch` port. NextBSD's no-`.ko` model means none of these can autoload as a kext, so they're compiled in.

## Scope notes

- `hms` is the only part functionally testable on the T460s now (its trackpad/point is PS/2 via `psm`); the touch/I2C block is sound by code inspection + parity with GENERIC's module set, validated later on I2C-HID / touchscreen hardware.
- Out of scope (no base driver regardless): Microsoft Surface touch/pen (IPTS/ITHC/SAM, Linux-only) and native `virtio-input` guests (use an emulated USB tablet).

## Acceptance

CI kernel build is green with the new devices/option. On a fresh boot with a USB mouse: `hms0` attaches under `hidbus0`, a `/dev/input/eventN` appears, pointer moves.

Closes nextbsd-redux/nextbsd#335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)