### PR TITLE
Rebase patch stack onto releng/15.1 (0001, 0004) + bump build refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  FREEBSD_BRANCH: releng/15.0
+  FREEBSD_BRANCH: releng/15.1
 
 jobs:
   kernel:
@@ -82,7 +82,7 @@ jobs:
           # branches) to a clean NextBSD string and drop the FreeBSD bits that
           # don't fit out-of-tree: the #N build counter and the
           # <hash>[-dirty] VCS tag (the tree is always "dirty" -- it's
-          # releng/15.0 + the NextBSD patch stack). Result (uname -v):
+          # releng/15.1 + the NextBSD patch stack). Result (uname -v):
           #   NextBSD Kernel Version <RELEASE>; <date>; <user>@<host>:<objdir>
           # RELEASE (the build timestamp) leads, so nextbsd-version -k can still
           # find it. Replaced lines are tab-indented inside an if/else; both
@@ -261,7 +261,7 @@ jobs:
 
   # PR-only boot smoke test: drop THIS PR's kernel into the latest published
   # NextBSD ISO (nextbsd `continuous`) and boot it, so we catch a patch/config
-  # change that breaks boot before it merges. We pin production releng/15.0, so
+  # change that breaks boot before it merges. We pin production releng/15.1, so
   # KBI is stable and the ISO's shipped mach.ko + modules keep loading against a
   # freshly-built kernel — only the kernel binary is swapped.
   #
@@ -320,7 +320,7 @@ jobs:
       - name: Inject this kernel into the ISO's UFS root
         uses: vmactions/freebsd-vm@v1
         with:
-          release: '15.0'
+          release: '15.1'
           usesh: true
           sync: rsync
           copyback: true

--- a/patches/0001-NextBSD-widen-lkmnosys-dynamic-syscall-band-to-58-sl.patch
+++ b/patches/0001-NextBSD-widen-lkmnosys-dynamic-syscall-band-to-58-sl.patch
@@ -11,25 +11,23 @@ The generated companions (init_sysent.c, sys/sys/syscall.h, sysproto.h,
 syscalls.c, systrace_args.c, syscall.mk) are regenerated at build time via
 'make sysent' (see the build workflow's regenerate step).
 ---
- sys/kern/syscalls.master | 53 ++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 53 insertions(+)
+ sys/kern/syscalls.master | 55 +++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 55 insertions(+)
 
 diff --git a/sys/kern/syscalls.master b/sys/kern/syscalls.master
-index 967af1f..36a1007 100644
+index 6856a09..dfc250b 100644
 --- a/sys/kern/syscalls.master
 +++ b/sys/kern/syscalls.master
-@@ -3393,5 +3393,58 @@
- 		    int fd
+@@ -3422,4 +3422,59 @@
+ 		    int flags
  		);
  	}
 +; NextBSD: widened loadable-syscall band for mach.ko. The stock 10
 +; lkmnosys slots (210-219) are exhausted by the Mach trap set; these
 +; give mach.ko room to register each Mach trap as its own syscall and
 +; retire the single-slot multiplexor. Tail-appended (ABI-additive).
-+599	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
-+600	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
-+601	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
-+602	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++; Band starts at 603 to clear FreeBSD 15.1 base syscalls 599-602
++; (kexec_load/pdrfork/pdwait/renameat2).
 +603	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
 +604	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
 +605	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
@@ -74,8 +72,11 @@ index 967af1f..36a1007 100644
 +644	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
 +645	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
 +646	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++647	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++648	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++649	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
++650	AUE_NULL	NODEF|NOTSTATIC	lkmnosys lkmnosys nosys_args int
 +
- 
  ; vim: syntax=off
 -- 
 2.50.1 (Apple Git-155)

--- a/patches/0004-NextBSD-search-firmware_path-for-raw-firmware-images.patch
+++ b/patches/0004-NextBSD-search-firmware_path-for-raw-firmware-images.patch
@@ -56,7 +56,7 @@ index d616339..3af6032 100644
  	int oflags;
  	size_t resid;
  	int error;
--	bool warn = flags & FIRMWARE_GET_NOWARN;
+-	bool warn = (flags & FIRMWARE_GET_NOWARN) == 0;
  
 -	/*
 -	 * XXX TODO: Loop over some path instead of a single element path.


### PR DESCRIPTION
**Step 3 of the [15.1 / drm-6.12 execution plan](https://pkgdemon.github.io/nextbsd-15.1-drm612-execution-plan.html).** Follows the merged toolchain bump (`nextbsd-kernel-toolchain#8`).

Moving the base `releng/15.0 → releng/15.1` (`nextbsd-redux/nextbsd#336`) drifts **two** patches. (Note: the original scoping had predicted zero drift — that was wrong; this was caught by the actual `Apply patches` CI failure and confirmed by testing the series against a clean `releng/15.1` tree.)

### Rebases
| Patch | 15.1 drift | Fix |
|---|---|---|
| **0001** lkmnosys syscall band | 15.1 added base syscalls **599 `kexec_load`, 600 `pdrfork`, 601 `pdwait`, 602 `renameat2`**, colliding with the band's old `599–646` range | Shifted the 48-slot band to **`603–650`** (first free slot after 602). Safe: `mach_syscall_wire.c` auto-allocates from the band via `NO_SYSCALL`; nothing hardcodes the base. `make sysent` regenerates the companions at build. |
| **0004** firmware_path raw search | 15.1 fixed an inverted `warn` bool at `subr_firmware.c:284` — the **same** bug this patch already corrects in its refactor (semantic convergence) | Updated the removed-line context to 15.1's `(flags & FIRMWARE_GET_NOWARN) == 0`; the 91-line refactor hunk was already clean |

`0002/0003/0005/0006/0007` apply unchanged.

### Verification
The full rebased series applies **strict + cumulative, in order** against a clean `releng/15.1` checkout of every touched file — all 7 PASS. Final proof is this PR's own `Apply patches` + `buildkernel` + `make sysent` regeneration step on CI.

### Also (Step 3 build-ref bumps)
`build.yml`: `FREEBSD_BRANCH` decoy → `releng/15.1`, smoke-test VM `release: '15.0' → '15.1'`, two comment refs.

⚠️ A toolchain `workflow_dispatch` re-cascade is needed after merge so the kernel rebuilds against a cleanly-15.1-built toolchain image (the earlier cascade raced ahead of the toolchain bump).

Refs nextbsd-redux/nextbsd#336

🤖 Generated with [Claude Code](https://claude.com/claude-code)