### PR TITLE
mach: register mach_port_request_notification trap (dead-name notifications) — #347/#353

### DIFF
--- a/src-overlay/sys/compat/mach/mach_syscall_wire.c
+++ b/src-overlay/sys/compat/mach/mach_syscall_wire.c
@@ -52,6 +52,7 @@ struct mach_msg_trap_args;
 struct _kernelrpc_mach_port_allocate_trap_args;
 struct _kernelrpc_mach_port_deallocate_trap_args;
 struct _kernelrpc_mach_port_insert_right_trap_args;
+struct _kernelrpc_mach_port_request_notification_trap_args;
 struct task_get_special_port_trap_args;
 struct task_set_special_port_trap_args;
 struct host_set_special_port_trap_args;
@@ -84,6 +85,8 @@ int sys__kernelrpc_mach_port_deallocate_trap(struct thread *,
     struct _kernelrpc_mach_port_deallocate_trap_args *);
 int sys__kernelrpc_mach_port_insert_right_trap(struct thread *,
     struct _kernelrpc_mach_port_insert_right_trap_args *);
+int sys__kernelrpc_mach_port_request_notification_trap(struct thread *,
+    struct _kernelrpc_mach_port_request_notification_trap_args *);
 int sys_task_get_special_port_trap(struct thread *,
     struct task_get_special_port_trap_args *);
 int sys_task_set_special_port_trap(struct thread *,
@@ -238,6 +241,19 @@ sys__kernelrpc_mach_port_insert_right_trap_guarded(struct thread *td,
 	return (sys__kernelrpc_mach_port_insert_right_trap(td, uap));
 }
 
+static int
+sys__kernelrpc_mach_port_request_notification_trap_guarded(struct thread *td,
+    struct _kernelrpc_mach_port_request_notification_trap_args *uap)
+{
+	if (td->td_proc->p_machdata == NULL)
+		mach_task_init_lazy(td->td_proc);
+	if (td->td_proc->p_machdata == NULL) {
+		td->td_retval[0] = 6;	/* KERN_RESOURCE_SHORTAGE */
+		return (0);
+	}
+	return (sys__kernelrpc_mach_port_request_notification_trap(td, uap));
+}
+
 /*
  * Task special-port traps. Both reach current_task() and the task's
  * itk_<slot> fields, so they need Mach task state. KERN_INVALID_ARGUMENT
@@ -388,6 +404,14 @@ static struct sysent _kernelrpc_mach_port_insert_right_sysent = {
 	.sy_flags	= 0,
 };
 
+/* 6 args: name, msgid, sync, notify, notifyPoly, previous (no target). */
+static struct sysent _kernelrpc_mach_port_request_notification_sysent = {
+	.sy_narg	= 6,
+	.sy_call	= (sy_call_t *)sys__kernelrpc_mach_port_request_notification_trap_guarded,
+	.sy_auevent	= AUE_NULL,
+	.sy_flags	= 0,
+};
+
 /*
  * Task special-port sysents. 3 args each:
  *   get: (target, which, port*)
@@ -466,6 +490,9 @@ static struct sysent _kernelrpc_mach_port_deallocate_old_sysent;
 static int _kernelrpc_mach_port_insert_right_offset = NO_SYSCALL;
 static struct sysent _kernelrpc_mach_port_insert_right_old_sysent;
 
+static int _kernelrpc_mach_port_request_notification_offset = NO_SYSCALL;
+static struct sysent _kernelrpc_mach_port_request_notification_old_sysent;
+
 static int task_get_special_port_offset = NO_SYSCALL;
 static struct sysent task_get_special_port_old_sysent;
 
@@ -527,6 +554,11 @@ SYSCTL_INT(_mach_syscall, OID_AUTO, mach_port_insert_right, CTLFLAG_RD,
     &_kernelrpc_mach_port_insert_right_offset, 0,
     "Dynamically-allocated FreeBSD syscall number for mach_port_insert_right "
     "(4-arg syscall; -1 if registration failed)");
+
+SYSCTL_INT(_mach_syscall, OID_AUTO, mach_port_request_notification, CTLFLAG_RD,
+    &_kernelrpc_mach_port_request_notification_offset, 0,
+    "Dynamically-allocated FreeBSD syscall number for "
+    "mach_port_request_notification (6-arg syscall; -1 if registration failed)");
 
 /*
  * Task special-port traps. Phase G prerequisite: needed so the
@@ -649,6 +681,10 @@ mach_syscall_wire_register(void *arg __unused)
 	wire_one("mach_port_insert_right", &_kernelrpc_mach_port_insert_right_offset,
 	    &_kernelrpc_mach_port_insert_right_sysent,
 	    &_kernelrpc_mach_port_insert_right_old_sysent);
+	wire_one("mach_port_request_notification",
+	    &_kernelrpc_mach_port_request_notification_offset,
+	    &_kernelrpc_mach_port_request_notification_sysent,
+	    &_kernelrpc_mach_port_request_notification_old_sysent);
 	wire_one("task_get_special_port", &task_get_special_port_offset,
 	    &task_get_special_port_sysent, &task_get_special_port_old_sysent);
 	wire_one("task_set_special_port", &task_set_special_port_offset,
@@ -683,6 +719,9 @@ mach_syscall_wire_deregister(void *arg __unused)
 	unwire_one("mach_port_insert_right",
 	    &_kernelrpc_mach_port_insert_right_offset,
 	    &_kernelrpc_mach_port_insert_right_old_sysent);
+	unwire_one("mach_port_request_notification",
+	    &_kernelrpc_mach_port_request_notification_offset,
+	    &_kernelrpc_mach_port_request_notification_old_sysent);
 	unwire_one("mach_port_deallocate",
 	    &_kernelrpc_mach_port_deallocate_offset,
 	    &_kernelrpc_mach_port_deallocate_old_sysent);

--- a/src-overlay/sys/compat/mach/mach_traps.c
+++ b/src-overlay/sys/compat/mach/mach_traps.c
@@ -400,7 +400,7 @@ sys__kernelrpc_mach_port_request_notification_trap(struct thread *td,
 {
 	ipc_space_t space = current_task()->itk_space;
 	ipc_port_t notify_port = IP_NULL, previous = IP_NULL;
-	mach_port_name_t prev_name = MACH_PORT_NULL;
+	mach_port_name_t prev_name = MACH_PORT_NAME_NULL;
 	kern_return_t kr;
 
 	/* Resolve the notify port name -> ipc_port_t with the caller's disposition

--- a/src-overlay/sys/compat/mach/mach_traps.c
+++ b/src-overlay/sys/compat/mach/mach_traps.c
@@ -378,6 +378,61 @@ done:
 	return (0);
 }
 
+/*
+ * nextbsd#347/#353: arm a Mach notification (dead-name / no-senders /
+ * port-destroyed) so libdispatch's Mach backend learns when a watched peer
+ * dies. Thin wrapper over the existing mach_port_request_notification() in
+ * ipc/mach_port.c. libmach passes 6 args (no target — see the 6-arg ABI note in
+ * libmach and mach_syscall_wire.c); we operate on current_task()'s space like
+ * every trap here.
+ *
+ * PANIC-CRITICAL (launchd calls this at PID-1 init inside os_assumes_zero):
+ *  - `previous` is written by the callee ONLY on KERN_SUCCESS; init it IP_NULL
+ *    and only translate/copyout on success.
+ *  - the callee returns `previous` as an ipc_port_t with a ref (pd/nsrequest);
+ *    ipc_object_copyout(SEND_ONCE) consumes exactly that ref. Guard on
+ *    IP_VALID — the common DEAD_NAME path returns IP_NULL, for which we copyout
+ *    MACH_PORT_NULL and do NOT call copyout on the port.
+ */
+int
+sys__kernelrpc_mach_port_request_notification_trap(struct thread *td,
+    struct _kernelrpc_mach_port_request_notification_trap_args *uap)
+{
+	ipc_space_t space = current_task()->itk_space;
+	ipc_port_t notify_port = IP_NULL, previous = IP_NULL;
+	mach_port_name_t prev_name = MACH_PORT_NULL;
+	kern_return_t kr;
+
+	/* Resolve the notify port name -> ipc_port_t with the caller's disposition
+	 * (typically MACH_MSG_TYPE_MAKE_SEND_ONCE). A null notify name is allowed. */
+	if (uap->notify != 0) {
+		kr = ipc_object_copyin(space, uap->notify, uap->notifyPoly,
+		    (ipc_object_t *)&notify_port);
+		if (kr != KERN_SUCCESS) {
+			td->td_retval[0] = kr;
+			return (0);
+		}
+	}
+
+	kr = mach_port_request_notification(space, uap->name, uap->msgid,
+	    uap->sync, notify_port, &previous);
+
+	if (kr == KERN_SUCCESS && IP_VALID(previous)) {
+		kern_return_t ckr = ipc_object_copyout(space,
+		    (ipc_object_t)previous, MACH_MSG_TYPE_PORT_SEND_ONCE, &prev_name);
+		if (ckr != KERN_SUCCESS) {
+			ipc_port_release_send(previous);
+			prev_name = (ckr == KERN_INVALID_CAPABILITY) ?
+			    MACH_PORT_NAME_DEAD : MACH_PORT_NAME_NULL;
+		}
+	}
+
+	if (uap->previous != NULL)
+		(void)copyout(&prev_name, uap->previous, sizeof(prev_name));
+	td->td_retval[0] = kr;
+	return (0);
+}
+
 int
 sys__kernelrpc_mach_port_mod_refs_trap(struct thread *td, struct _kernelrpc_mach_port_mod_refs_trap_args *uap)
 {

--- a/src-overlay/sys/sys/mach/_mach_sysproto.h
+++ b/src-overlay/sys/sys/mach/_mach_sysproto.h
@@ -126,6 +126,20 @@ struct _kernelrpc_mach_port_insert_right_trap_args {
 	char poly_l_[PADL_(mach_port_name_t)]; mach_port_name_t poly; char poly_r_[PADR_(mach_port_name_t)];
 	char polyPoly_l_[PADL_(mach_msg_type_name_t)]; mach_msg_type_name_t polyPoly; char polyPoly_r_[PADR_(mach_msg_type_name_t)];
 };
+/*
+ * nextbsd#347/#353: 6 args, NO `target` — libmach drops the redundant task and
+ * the trap uses current_task()'s space (like every trap here). Six is the
+ * reliable amd64 libc-syscall arg limit; a 7th (with target) would drop the
+ * `previous` out-pointer. Order matches libmach's syscall() call.
+ */
+struct _kernelrpc_mach_port_request_notification_trap_args {
+	char name_l_[PADL_(mach_port_name_t)]; mach_port_name_t name; char name_r_[PADR_(mach_port_name_t)];
+	char msgid_l_[PADL_(mach_msg_id_t)]; mach_msg_id_t msgid; char msgid_r_[PADR_(mach_msg_id_t)];
+	char sync_l_[PADL_(mach_port_mscount_t)]; mach_port_mscount_t sync; char sync_r_[PADR_(mach_port_mscount_t)];
+	char notify_l_[PADL_(mach_port_name_t)]; mach_port_name_t notify; char notify_r_[PADR_(mach_port_name_t)];
+	char notifyPoly_l_[PADL_(mach_msg_type_name_t)]; mach_msg_type_name_t notifyPoly; char notifyPoly_r_[PADR_(mach_msg_type_name_t)];
+	char previous_l_[PADL_(mach_port_name_t *)]; mach_port_name_t * previous; char previous_r_[PADR_(mach_port_name_t *)];
+};
 struct _kernelrpc_mach_port_insert_member_trap_args {
 	char target_l_[PADL_(mach_port_name_t)]; mach_port_name_t target; char target_r_[PADR_(mach_port_name_t)];
 	char name_l_[PADL_(mach_port_name_t)]; mach_port_name_t name; char name_r_[PADR_(mach_port_name_t)];


### PR DESCRIPTION
Closes the kernel half of #347/#353 — the root cause under #369's hang class.

## What

Wires a `mach_port_request_notification` syscall trap so libmach's wrapper auto-upgrades from its boot-safe no-op. Dead-name / no-senders / port-destroyed notifications then fire, so libdispatch's `EVFILT_MACHPORT` backend learns when a watched peer dies. That:
- closes the port-set/fd leak (#342 — `hostnamed` climbing to 3800+ fds), and
- **lets a Mach RPC to a dead/slow server fail fast (`MACH_RCV_PORT_DIED`) instead of parking forever in `ipc_mqueue_receive`** — the amplifier that turned every transient userland fault into a permanent boot hang in #369.

Thin wrapper over the existing `mach_port_request_notification()` in `ipc/mach_port.c` (classic CMU routine) — no new IPC logic. Three additions, all matching the `_kernelrpc_mach_port_insert_right_trap` pattern: the 6-field arg struct, the handler, and the wiring (guarded wrapper, `.sy_narg=6` sysent, offset/sysctl `mach.syscall.mach_port_request_notification`, wire/unwire).

## The two things that would have panicked PID 1 (and how they're handled)

1. **6 args, not 7.** libc `syscall()` only reliably passes 6 on amd64 (the kernel's own `mach_syscall_wire.c` comment documents this — `mach_msg_trap` dropped its 7th). The 7th here would be `previous`, the out-pointer. So `task` is dropped (kernel uses `current_task()`); the matching userland change is **already merged and in `continuous`** (userland #35).
2. **`previous` copyout.** `previous` is written by the callee only on `KERN_SUCCESS`; init `IP_NULL`, translate to a name only on success via `IP_VALID`-guarded `ipc_object_copyout(SEND_ONCE)`, and copyout `MACH_PORT_NULL` for the common DEAD_NAME/`IP_NULL` case. This is the sequence launchd's PID-1 `os_assumes_zero` call must survive.

## Validation

Compiles into the base kernel (`options COMPAT_MACH`) and boots via the new native-assembly CI (#49) against the freshly-republished userland `continuous` (which now has the 6-arg libmach). The **login gate is the panic detector**: if this trap corrupted a launchd PID-1 call, the boot wouldn't reach login and CI would fail. Watching whether `SYSLOG-RUN` also stabilizes (fail-fast checkin → no syslogd init stall → no duplicate-spawn `/var/run/log` race).

Refs: nextbsd-redux/nextbsd#347, #353, #342, #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)