### PR TITLE
config: bake in wlan_xauth — every WPA/WPA2/WPA3 association fails EINVAL without it (#51)

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -68,6 +68,22 @@ options 	TARFS
 options 	UNIONFS
 options 	NULLFS
 
+# 802.11 WPA authenticator (#51). GENERIC brings `device wlan` plus the crypto
+# set (wep/tkip/ccmp/gcmp/amrr) but deliberately NOT wlan_xauth: on stock FreeBSD
+# net80211 autoloads it as a .ko the first time a WPA network is touched. That
+# recovery path does not exist here (assemble-image.sh:168 rm's /boot/kernel/*.ko),
+# so the module is simply absent and the autoload silently fails:
+#   wpa_supplicant sets authmode IEEE80211_AUTH_WPA
+#     -> ieee80211_ioctl.c  ieee80211_authenticator_get()
+#     -> ieee80211_proto.c:446  auth_modnames[IEEE80211_AUTH_WPA] = "wlan_xauth"
+#     -> ieee80211_load_module("wlan_xauth") -> kldload -> no such module
+#     -> returns NULL -> ioctl(SIOCS80211) returns EINVAL, always.
+# Result: EVERY WPA/WPA2/WPA3 association fails; open networks work. Same class of
+# bug as the drm iic/lindebugfs and HID hms/hmt deps above -- an unbaked module
+# dep that can't be resolved at load time because there is no .ko tree.
+# Purely additive; cannot regress the wired path. (nextbsd-kernel#51)
+device		wlan_xauth
+
 # HID input drivers (#335; see the input/touch driver spike). GENERIC compiles
 # in only the HID transport (hid, hidbus, usbhid) and the keyboard leaves (hkbd,
 # ukbd) -- the mouse/touch/pen leaves ship as loadable .ko modules that devd


### PR DESCRIPTION
## The bug

`wlan_xauth` is absent from the kernel, and NextBSD ships no `.ko` tree to autoload it from. **Every WPA/WPA2/WPA3 association fails `EINVAL` at the first ioctl.** Open networks work — which is why this went unnoticed.

Two facts combine, and *neither is wrong on its own*:

1. **`wlan_xauth` isn't in the kernel.** `config/NEXTBSD` is `include GENERIC` plus additions. GENERIC gives us `device wlan` + `wlan_ccmp`/`tkip`/`wep`/`gcmp`/`amrr` — but upstream deliberately leaves `wlan_xauth` out, because net80211 autoloads it as a `.ko` on demand. On stock FreeBSD this is invisible and self-healing.
2. **There's no `.ko` tree to autoload from.** `ci/assemble-image.sh:168` does `rm -f "$ROOTFS"/boot/kernel/*.ko`. Intentional and correct for the kext model — but it removes the recovery mechanism upstream depends on.

The failure path:

```
wpa_supplicant sets authmode IEEE80211_AUTH_WPA
  -> ieee80211_ioctl.c   ieee80211_authenticator_get()
  -> ieee80211_proto.c   auth_modnames[IEEE80211_AUTH_WPA] = "wlan_xauth"
  -> ieee80211_load_module("wlan_xauth") -> kldload -> no such module on disk
  -> returns NULL -> ioctl(SIOCS80211, IEEE80211_IOC_AUTHMODE) = EINVAL, always
```

`wpa_supplicant` simply never leaves `SCANNING`, with no useful error surfaced.

## The fix

One additive config line: `device wlan_xauth`.

This is the **same class of bug** as the `drm` `iic`/`lindebugfs` deps and the HID `hms`/`hmt`/`hpen` leaves already baked into this file — an unbaked module dependency that can't be resolved at load time because there is no `.ko` tree to resolve it from. `wlan_xauth` is just the first instance anyone tripped over on the wireless path.

> The general lesson, beyond WLAN: on NextBSD, *every* lazy `kldload` path in the kernel is dead. net80211 alone has four such call sites. That systemic audit is #52.

## Risk: none

Purely additive. Statically links a small in-tree net80211 module that upstream ships and every other FreeBSD system loads on demand. It cannot regress the wired path, changes no userland, and touches no other subsystem. If a machine has no 802.11 hardware, the code is never entered.

`wlan_acl` and `wlan_rssadapt` are the same latent class, but neither is needed for a station — they only matter for hostap mode and alternate rate control — so they're left out rather than widening a zero-risk PR.

## Verification (standalone — needs nothing else from the WLAN plan)

```sh
# Before: expect "Invalid argument"
ifconfig wlan0 create wlandev iwlwifi0
wpa_supplicant -i wlan0 -c /tmp/wpa.conf -d      # never leaves SCANNING

# After: expect association to complete
wpa_cli -i wlan0 status                          # wpa_state=COMPLETED

# Sanity-check the authenticator registered:
sysctl net.wlan.devices                          # radio visible
ifconfig wlan0 list caps                         # WPA/RSN advertised
```

## Context

This is Phase 0 of the [NextBSD WLAN plan](https://pkgdemon.github.io/nextbsd-wlan-plan.html) — but it has **no dependency on anything else in that plan** and shouldn't wait for one. It's a regression against stock FreeBSD, the fix is one line, and it's independently testable. Everything else in the WLAN plan is about making WLAN *good*; this is the difference between WPA being *impossible* and WPA *working*.

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)