### PR TITLE
mach ipc: close the port-set lost-wakeup window in ipc_mqueue_deliver (#369)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_mqueue.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_mqueue.c
@@ -470,6 +470,39 @@ ipc_mqueue_deliver(
 	assert(port->ip_msgcount >= 0);
 	ipc_kmsg_enqueue_macro(&mqueue->imq_messages, kmsg);
 	port->ip_msgcount++;
+
+	/*
+	 * Lost-wakeup window (nextbsd#369): a port-set receiver scans member
+	 * ports reading ip_msgcount WITHOUT the port lock
+	 * (ipc_mqueue_pset_receive only ip_locks a port it saw non-empty), so
+	 * it can miss this message if its scan ran between our pool check
+	 * above and the enqueue, then block in the pset's thread pool.
+	 * ipc_pset_signal() only activates EVFILT_MACHPORT knotes — since
+	 * #256 it never wakes pool receivers — so nothing would ever deliver
+	 * to that thread: it parks in mach_msg_receive with the message
+	 * rotting on the queue. Re-check the pool now that the message is
+	 * enqueued, still holding the port lock. The pset lock orders the two
+	 * sides: a receiver registers before msleep drops the pset lock, so
+	 * either we see it here, or its scan — serialized after the
+	 * ips_unlock below — sees ip_msgcount != 0. Hand off the queue HEAD
+	 * (not necessarily our kmsg) to preserve FIFO and drain any message a
+	 * prior lost wakeup stranded.
+	 */
+	if (pset != NULL) {
+		ips_lock(pset);
+		receiver = thread_pool_get_act((ipc_object_t)pset, 0);
+		ips_unlock(pset);
+		if (receiver != NULL) {
+			kmsg = ipc_kmsg_queue_first(&mqueue->imq_messages);
+			assert(kmsg != IKM_NULL);
+			ipc_kmsg_rmqueue_first_macro(&mqueue->imq_messages, kmsg);
+			port->ip_msgcount--;
+			LAUNCHD_TRACE("deliver late receiver=%p kmsg=%p msgcount=%d",
+			    receiver, kmsg, port->ip_msgcount);
+			ipc_mqueue_run(receiver, mqueue, kmsg, port);
+			return (MACH_MSG_SUCCESS);
+		}
+	}
 	ip_unlock(port);
 
 	LAUNCHD_TRACE("deliver enqueued kmsg, no receiver, ip_msgcount=%d", port->ip_msgcount);


### PR DESCRIPTION
## What

Closes the port-set lost-wakeup window in `ipc_mqueue_deliver` that parks blocking `mach_msg` receivers forever — the root cause proposed for nextbsd-redux/nextbsd#369 (analysis in [this comment](https://github.com/nextbsd-redux/nextbsd/issues/369#issuecomment-5016468263)).

## The race

1. Sender (port lock held): `ips_lock(pset)` → `thread_pool_get_act` finds no receiver → `ips_unlock(pset)`. Message **not yet enqueued**.
2. Receiver: locks the pset, scans member ports — `ipc_mqueue_pset_receive` reads `ip_msgcount` **without the port lock** (it only `ip_lock`s a port it saw non-empty) — sees 0 everywhere, registers in the pset thread pool, `thread_block()`.
3. Sender: enqueues, `ip_unlock(port)`, `ipc_pset_signal(pset)` — which since #256 (#168 Stage 5) only activates `EVFILT_MACHPORT` knotes and never wakes pool receivers. The receiver sleeps forever with the message on the queue.

On one CPU the bad interleaving is even likely: releasing the pset lock after the empty pool-check can preempt straight into the contending receiver. Only an unrelated signal (PCATCH) or a later delivery that catches the receiver in the pool rescues it — hence "intermittent," and worst under single-thread TCG scheduling. Matches #369's `procstat` signature (`syslogd` parked in `ipc_mqueue_receive ← mach_msg_receive`), which we also observed live on the arm64 CI image while root-causing nextbsd-redux/nextbsd#355 (that hang itself turned out to be unrelated — getty/`CLOCAL`, see nextbsd-redux/nextbsd-userland#50).

## The fix

After enqueueing, while still holding the port lock, re-check the pset thread pool. If a receiver blocked inside the window, dequeue the queue **head** and hand it off through the existing `ipc_mqueue_run` path (sets `ith_kmsg`/`ith_object`/`ith_seqno`, `thread_go`) — pool receivers never rescan after wakeup (they assert `ith_kmsg != NULL`), so a bare `ipc_pset_changed`-style wakeup is not an option. Handing off the head preserves FIFO and drains any message a prior lost wakeup stranded.

Correctness notes:
- **Lock order** port → pset matches the function's existing entry path; the receiver's scan already avoids the inversion (drops the pset lock before a blocking `ip_lock`).
- **Ordering argument**: a receiver registers in the pool before `msleep` atomically releases the pset lock. So either the sender's re-check (which acquires the pset lock) sees it, or the receiver's scan is serialized after the sender's `ips_unlock` and sees `ip_msgcount != 0` via the same lock's release/acquire pairing.
- **Plain ports untouched**: there the port lock is held continuously across check→enqueue and check→sleep on both sides — no window exists.

## Validation

- Compile: this PR's kernel build (both arches) exercises the changed file; the amd64 PR boot smoke test covers the boot-path Mach traffic.
- The race is timing-dependent; the practical soak is #369's own venue — the amd64 `ci-image-boot` flakiness (`NOTIFYD-PROC-FAIL`/`SYSLOG-RUN-FAIL`) should stop recurring once a kernel with this fix flows into the userland CI images. Suggest keeping #369 open until a few green amd64 full-suite runs land, then re-tightening the gates userland PR #30 softened.

PS: hope this helps, but full disclosure: I used Fable 5 for this investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
