### PR TITLE
ci: let fork PRs build (github.token fallback in assemble step)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,11 @@ jobs:
       - name: Assemble disk.img (this kernel + component continuous artifacts)
         if: github.event_name == 'pull_request' && matrix.target == 'amd64'
         env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          # Fork PRs never receive repo secrets, so DISPATCH_TOKEN is empty there;
+          # fall back to the built-in read-only token, which can pull the public
+          # component releases this step downloads. Same-repo/dispatch runs still
+          # use the PAT.
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN || github.token }}
           ARCH: ${{ matrix.target }}
           KERNEL_TGZ: /tmp/nextbsd-kernel-${{ matrix.target }}.tar.gz
           WORK: ${{ github.workspace }}/nbimg


### PR DESCRIPTION
## Problem

Fork-triggered `pull_request` runs (e.g. #56, from `jrjsmrtn/nextbsd-kernel`) fail the `kernel (amd64, amd64)` job. The kernel compiles fine on both arches — the failure is in the **Assemble disk.img** step, which shells out to `gh` to download the public component `continuous` releases:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
GH_TOKEN:            ← empty
##[error]Process completed with exit code 4.
```

GitHub **withholds all repository secrets from fork-triggered PR runs** by design, so `secrets.DISPATCH_TOKEN` resolves to an empty string and `gh` can't authenticate. (arm64 passes only because the assemble step is gated to `matrix.target == 'amd64'`.)

## Fix

Every artifact this step downloads lives in a **public** repo (`nextbsd-freebsd-compat`, `nextbsd-userland`, `nextbsd-kernel-modules`, `nextbsd-overlays`), so the built-in read-only `github.token` — which *is* provided to fork PRs — is sufficient. Fall back to it:

```yaml
GH_TOKEN: ${{ secrets.DISPATCH_TOKEN || github.token }}
```

Same-repo and `repository_dispatch` runs keep using the full PAT. The `repository_dispatch` step (which needs the PAT's cross-repo *write* scope) is unchanged.

## Note

After merge, existing fork PRs like #56 need an **Update branch** (merge `main` in) to pick up the new workflow — a plain job re-run reuses the old merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)