### PR TITLE
ci: use built-in github.token for public read step (drop PAT), fixes fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,14 @@ jobs:
       - name: Assemble disk.img (this kernel + component continuous artifacts)
         if: github.event_name == 'pull_request' && matrix.target == 'amd64'
         env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          # This step only READS public `continuous` release assets from the
+          # sibling component repos, so it needs no PAT — the built-in,
+          # auto-injected GITHUB_TOKEN authenticates gh for public cross-repo
+          # reads. Using it (not secrets.DISPATCH_TOKEN) is what lets PRs from
+          # forks build: fork PRs never receive repo secrets, but they do get a
+          # read-only github.token. The PAT stays only on the cross-repo
+          # repository_dispatch step below, which forks can never trigger.
+          GH_TOKEN: ${{ github.token }}
           ARCH: ${{ matrix.target }}
           KERNEL_TGZ: /tmp/nextbsd-kernel-${{ matrix.target }}.tar.gz
           WORK: ${{ github.workspace }}/nbimg


### PR DESCRIPTION
## What

The **Assemble disk.img** step only *reads* public `continuous` release assets from the sibling component repos. Reading public cross-repo artifacts needs **no PAT** — the auto-injected `GITHUB_TOKEN` authenticates `gh` for public reads. This swaps `secrets.DISPATCH_TOKEN` → `github.token` on that step.

## Why

Fork PRs never receive repo secrets, so `DISPATCH_TOKEN` was empty on them and the step exited 4 (`gh: set the GH_TOKEN environment variable`). Fork PRs *do* get a read-only `github.token`, which can read public releases — so this is what actually unblocks outside contributors.

Verified unauthenticated (no token at all) that every asset this step pulls returns HTTP 200:
- `releases/download/continuous/nextbsd-base-amd64.tar.gz` (compat)
- `releases/download/continuous/nextbsd-userland-amd64.tar.gz` (userland)
- `codeload …/nextbsd-overlays/tar.gz/refs/heads/main`

## What stays

The PAT (`DISPATCH_TOKEN`) remains on the **Trigger module build** step — that is a cross-repo `repository_dispatch`, which the built-in token *cannot* do and which fork PRs can never trigger (`if: github.event_name == 'repository_dispatch'`). So there is no PAT exposure to fork code, before or after this change.

Supersedes the `DISPATCH_TOKEN || github.token` fallback in #57 (this drops the PAT from the read path entirely rather than falling back).

## Template for the other repos

Same rule applies org-wide: **public-read / own-repo-upload steps → `github.token`; cross-repo dispatch steps → keep `DISPATCH_TOKEN`.** `nextbsd-kernel-modules` has read steps that need the same swap; the dispatch-only repos (toolchain, compat, freebsd-src) keep the PAT as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)