### PR TITLE
config: bake snd_uaudio so USB audio devices work

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -118,3 +118,23 @@ device		ig4
 device		iichid
 device		ietp
 options 	IICHID_SAMPLING
+
+# USB audio. Same unbaked-module-dep class as hms/hmt, wlan_xauth and drm's
+# iic/lindebugfs above -- the core is baked, the leaf that binds the actual
+# hardware is not:
+#   amd64 GENERIC:340 and arm64 std.dev:107 both bake `device sound` (the pcm
+#   core, /dev/dsp, feeder chain, midi) plus the PCI leaves (snd_hda, snd_ich,
+#   ...) on amd64. Neither bakes snd_uaudio -- on stock FreeBSD it ships as
+#   sys/modules/sound/driver/uaudio and devd kldloads it on USB attach.
+# NextBSD ships no /boot/kernel .ko tree (ci/assemble-image.sh:168 rm's them),
+# so that autoload can never resolve: a USB headset/DAC/mic enumerates on uhub
+# with no driver to claim it, no /dev/dsp node, no sound. Built-in HDA audio is
+# unaffected -- this is USB-only.
+#
+# DRIVER_MODULE_ORDERED(snd_uaudio, uhub, ...) so the attach path is
+# usb -> uhub -> uaudio -> ua_pcm (uaudio_pcm.c) -> pcm. All three of its hard
+# MODULE_DEPENDs (usb, sound, hid) are already compiled in on both arches, so
+# this is purely additive and cannot regress the PCI audio path. snd_uaudio is
+# a stock config token (sys/conf/files:3192, sys/conf/NOTES:2137), valid on
+# amd64 and arm64 alike -- one line covers the shared config for both.
+device		snd_uaudio


### PR DESCRIPTION
## Problem

USB sound devices do not work on NextBSD. They enumerate on `uhub` and then sit there with no driver bound — no `/dev/dsp` node, no audio.

The sound **core** is already present. `config/NEXTBSD` does `include GENERIC`, and both arches bake `device sound` (the pcm core, `/dev/dsp`, feeder chain, midi):

- amd64 — `sys/amd64/conf/GENERIC:341`, plus the PCI leaves `snd_hda` / `snd_ich` / `snd_cmi` / …
- arm64 — `sys/arm64/conf/std.dev:108` (pulled in by `include "std.dev"` from arm64 GENERIC)

What neither bakes is the **USB leaf**, `snd_uaudio`. On stock FreeBSD that ships as a loadable module (`sys/modules/sound/driver/uaudio`) and devd `kldload`s it when a USB audio device attaches.

NextBSD ships no `/boot/kernel` `.ko` tree — `ci/assemble-image.sh:168` does `rm -f "$ROOTFS"/boot/kernel/*.ko` — so that autoload path does not exist. The module is simply absent and the attach silently never happens.

This is the same class of bug as the fixes already sitting in this config, and documented there in the same terms:

| Fix | Symptom |
|---|---|
| `device hms` / `hmt` / `hpen` (#335) | USB mouse enumerates, no pointer |
| `device wlan_xauth` (#51) | every WPA association fails |
| `device iic` / `options LINDEBUGFS` (#64) | `drm.ko` won't load |

## Change

One line in `config/NEXTBSD` (plus a comment in the file's existing house style):

```
device		snd_uaudio
```

## Why this is safe

- `snd_uaudio` is a stock config token — `sys/conf/files:3192-3193` (`optional snd_uaudio usb`) and `sys/conf/NOTES:2137`. Valid on amd64 and arm64 alike, so the single shared config covers both matrix targets.
- All three of its hard `MODULE_DEPEND`s are already compiled in on both arches:
  - `MODULE_DEPEND(snd_uaudio, usb, ...)` → `device usb` ✔
  - `MODULE_DEPEND(snd_uaudio, sound, ...)` → `device sound` ✔
  - `MODULE_DEPEND(snd_uaudio, hid, ...)` → `device hid` ✔
- `DRIVER_MODULE_ORDERED(snd_uaudio, uhub, ...)`, so the attach chain is `usb → uhub → uaudio → ua_pcm` (`uaudio_pcm.c`) `→ pcm`. Nothing on the PCI audio path is touched.
- Purely additive: built-in HDA/AC'97 audio is unaffected, and there is no way for this to regress a machine that has no USB audio device.

Base: `releng/15.1` (per `build.yml`'s `FREEBSD_BRANCH`); all line numbers above are from that tag.

## Testing

Touches `config/**`, so this PR triggers the kernel-only build on both `amd64` and `arm64` — that validates it compiles and links statically on each. Runtime verification wants a real USB audio device (or `qemu -device usb-audio`): expect `uaudio0 on uhub…` + `pcm<N>: <USB audio>` in dmesg and a matching entry in `cat /dev/sndstat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)