### PR TITLE
kernel: bake in FUSEFS and the 64-bit Linuxulator (linux64 + linprocfs/linsysfs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,31 @@ jobs:
           test -f /usr/src/sys/kern/vfs_pivot.c
           echo "==> vfs.pivot wired: $(grep -c 'kern/vfs_pivot.c' /usr/src/sys/conf/files) entry; source present"
 
+      # Static Linuxulator: the 64-bit Linux ABI + linprocfs/linsysfs (#60).
+      # Upstream ships these only as sys/modules/*, and there has never been a
+      # static path for the 64-bit ABI (COMPAT_LINUX is commented out in
+      # sys/conf/options.amd64; files.amd64 has no linux entries). NextBSD ships
+      # no /boot/kernel .ko tree (assemble-image.sh:168) and no kld tooling
+      # (kldload/kldstat/kldunload are superseded by kext*), so a module cannot
+      # be loaded here at all -- compiling in is the only route. Sources are
+      # stock base sources already in the clone; we append the declarations and
+      # the files fragment. KERNEL build only, same rule as linuxkpi_video.
+      - name: Wire in the static Linuxulator (linux64 + linprocfs/linsysfs, #60)
+        run: |
+          set -eu
+          cat "$GITHUB_WORKSPACE/src-overlay/conf/options.compat_linux" >> /usr/src/sys/conf/options
+          cat "$GITHUB_WORKSPACE/src-overlay/conf/files.compat_linux" >> /usr/src/sys/conf/files.amd64
+          # COMPAT_LINUX must not already be live, or config(8) sees a duplicate.
+          grep -qE '^#COMPAT_LINUX' /usr/src/sys/conf/options.amd64
+          for s in amd64/linux/linux_sysvec.c amd64/linux/linux_genassym.c \
+                   amd64/linux/linux_locore.asm amd64/linux/linux_vdso_gtod.c \
+                   amd64/linux/linux_vdso.lds.s compat/linux/linux_vdso_inc.S \
+                   compat/linux/linux_elf64.c compat/linprocfs/linprocfs.c \
+                   compat/linsysfs/linsysfs.c; do
+            test -f "/usr/src/sys/$s" || { echo "MISSING /usr/src/sys/$s" >&2; exit 1; }
+          done
+          echo "==> Linuxulator wired: $(grep -c 'optional compat_linux' /usr/src/sys/conf/files.amd64) entries; sources present"
+
       - name: Build kernel (no modules)
         run: |
           cd /usr/src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,8 +205,14 @@ jobs:
           set -eu
           cat "$GITHUB_WORKSPACE/src-overlay/conf/options.compat_linux" >> /usr/src/sys/conf/options
           cat "$GITHUB_WORKSPACE/src-overlay/conf/files.compat_linux" >> /usr/src/sys/conf/files.amd64
-          # COMPAT_LINUX must not already be live, or config(8) sees a duplicate.
-          grep -qE '^#COMPAT_LINUX' /usr/src/sys/conf/options.amd64
+          # We declare COMPAT_LINUX ourselves, so it must still be commented out
+          # upstream; LINPROCFS/LINSYSFS are already declared live in
+          # options.amd64 and must NOT be redeclared. Either assumption breaking
+          # on a FreeBSD bump is a "Duplicate option" failure in config(8), so
+          # assert both here where the message is legible.
+          grep -qE '^#COMPAT_LINUX[[:space:]]' /usr/src/sys/conf/options.amd64
+          grep -qE '^LINPROCFS[[:space:]]'     /usr/src/sys/conf/options.amd64
+          grep -qE '^LINSYSFS[[:space:]]'      /usr/src/sys/conf/options.amd64
           for s in amd64/linux/linux_sysvec.c amd64/linux/linux_genassym.c \
                    amd64/linux/linux_locore.asm amd64/linux/linux_vdso_gtod.c \
                    amd64/linux/linux_vdso.lds.s compat/linux/linux_vdso_inc.S \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,20 @@ jobs:
         run: |
           set -eu
           cat "$GITHUB_WORKSPACE/src-overlay/conf/options.compat_linux" >> /usr/src/sys/conf/options
-          cat "$GITHUB_WORKSPACE/src-overlay/conf/files.compat_linux" >> /usr/src/sys/conf/files.amd64
+          # The ABI itself is amd64-only for now (files.compat_linux references
+          # amd64/linux/* and x86/linux/*). arm64 has a complete Linux ABI in
+          # tree (sys/arm64/linux/) and mirroring this for it is a follow-up.
+          if [ "${{ matrix.target }}" = "amd64" ]; then
+            cat "$GITHUB_WORKSPACE/src-overlay/conf/files.compat_linux" >> /usr/src/sys/conf/files.amd64
+          else
+            # config/NEXTBSD is shared by both matrix legs, so every option it
+            # names must be DECLARED on both even where it selects nothing --
+            # otherwise config(8) fails with `unknown option "LINSYSFS"'.
+            # LINPROCFS/LINSYSFS live in options.amd64 upstream; COMPAT_LINUX we
+            # append to the MI sys/conf/options above, so it already covers both.
+            printf 'LINPROCFS\topt_dontuse.h\nLINSYSFS\topt_dontuse.h\n' \
+              >> /usr/src/sys/conf/options.arm64
+          fi
           # We declare COMPAT_LINUX ourselves, so it must still be commented out
           # upstream; LINPROCFS/LINSYSFS are already declared live in
           # options.amd64 and must NOT be redeclared. Either assumption breaking
@@ -220,7 +233,8 @@ jobs:
                    compat/linsysfs/linsysfs.c; do
             test -f "/usr/src/sys/$s" || { echo "MISSING /usr/src/sys/$s" >&2; exit 1; }
           done
-          echo "==> Linuxulator wired: $(grep -c 'optional compat_linux' /usr/src/sys/conf/files.amd64) entries; sources present"
+          n=$(grep -c 'optional compat_linux' /usr/src/sys/conf/files.amd64 || true)
+          echo "==> Linuxulator wired (${{ matrix.target }}): $n entries in files.amd64; sources present"
 
       - name: Build kernel (no modules)
         run: |

--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -80,8 +80,14 @@ options 	FUSEFS
 # src-overlay/conf/files.compat_linux and the declarations by
 # src-overlay/conf/options.compat_linux (wired in build.yml). NextBSD has no
 # /boot/kernel .ko tree and no kldload, so compiling in is the only route.
-# Revert path when the kext-conversion project lands: drop these three lines and
-# delete the two overlay fragments.
+# amd64 only in effect: files.compat_linux references amd64/linux/* and
+# x86/linux/*, and build.yml appends it on the amd64 leg only. This config is
+# shared by both matrix legs, so the workflow declares LINPROCFS/LINSYSFS for
+# arm64 as well -- there they are accepted but select nothing. arm64 has a
+# complete Linux ABI in tree (sys/arm64/linux/); mirroring this for it is a
+# follow-up, not a blocker for #60.
+# Revert path when the kext-conversion project lands: drop these four options
+# and delete the two overlay fragments.
 options 	COMPAT_LINUX
 options 	LINPROCFS
 options 	LINSYSFS

--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -92,6 +92,16 @@ options 	COMPAT_LINUX
 options 	LINPROCFS
 options 	LINSYSFS
 
+# POSIX message queues -- a hard link-time dependency of the Linuxulator, not a
+# nicety. compat/linux/linux_misc.c:2989-3076 calls kern_kmq_open/sys_kmq_unlink/
+# kern_kmq_timedsend/kern_kmq_timedreceive/kern_kmq_notify/kern_kmq_setattr
+# unconditionally, and kern/uipc_mqueue.c is `optional p1003_1b_mqueue' which
+# GENERIC does not set (it ships as mqueuefs.ko -- the same module-only trap as
+# the ABI itself, one layer down). Without this the static kernel fails to link
+# with six undefined symbols. Declared in the MI sys/conf/options, and
+# uipc_mqueue.c is MI too, so this is safe on both matrix legs.
+options 	P1003_1B_MQUEUE
+
 # 802.11 WPA authenticator (#51). GENERIC brings `device wlan` plus the crypto
 # set (wep/tkip/ccmp/gcmp/amrr) but deliberately NOT wlan_xauth: on stock FreeBSD
 # net80211 autoloads it as a .ko the first time a WPA network is touched. That

--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -68,6 +68,24 @@ options 	TARFS
 options 	UNIONFS
 options 	NULLFS
 
+# FUSE (nextbsd-kernel#60). Stock option -- fs/fuse/*.c is gated `optional fusefs'
+# in sys/conf/files -- so this needs no overlay, just the option. Compiling it in
+# rather than shipping fusefs.ko sidesteps #52 entirely: there is no .ko for
+# assemble-image.sh:168 to delete, and no kld tooling is needed to load it.
+options 	FUSEFS
+
+# 64-bit Linux ABI + linprocfs/linsysfs (nextbsd-kernel#60). Upstream ships these
+# only as modules and there has never been a static path for the 64-bit ABI, so
+# the `optional compat_linux' entries these select are supplied by
+# src-overlay/conf/files.compat_linux and the declarations by
+# src-overlay/conf/options.compat_linux (wired in build.yml). NextBSD has no
+# /boot/kernel .ko tree and no kldload, so compiling in is the only route.
+# Revert path when the kext-conversion project lands: drop these three lines and
+# delete the two overlay fragments.
+options 	COMPAT_LINUX
+options 	LINPROCFS
+options 	LINSYSFS
+
 # 802.11 WPA authenticator (#51). GENERIC brings `device wlan` plus the crypto
 # set (wep/tkip/ccmp/gcmp/amrr) but deliberately NOT wlan_xauth: on stock FreeBSD
 # net80211 autoloads it as a .ko the first time a WPA network is touched. That

--- a/src-overlay/conf/files.compat_linux
+++ b/src-overlay/conf/files.compat_linux
@@ -1,0 +1,121 @@
+# files.compat_linux -- static Linuxulator (linux64) for NextBSD.
+#
+# Appended to /usr/src/sys/conf/files.amd64 by the kernel workflow, same
+# mechanism as files.linuxkpi_video / files.vfs_pivot.
+#
+# WHY THIS EXISTS
+# Upstream ships the 64-bit Linux ABI *only* as sys/modules/linux64.  There has
+# never been a static path for it on amd64: COMPAT_LINUX is commented out in
+# sys/conf/options.amd64 (11.0 through 15.1), and files.amd64 carries no linux
+# entries at all.  The 32-bit ABI did have one until FreeBSD 14.0, removed by
+# e013e3693 ("linux(4): Get rid of Linuxulator kernel build options") because
+# "we can't build both emulators together into the kernel" -- a duplicate-symbol
+# collision between the two ABIs compiled from the same sources.  We build only
+# the 64-bit ABI, so that collision does not apply.
+#
+# NextBSD ships no /boot/kernel .ko tree (ci/assemble-image.sh:168) and has no
+# kld tooling (kldload/kldstat/kldunload are superseded by kext*), so a module
+# is not loadable here at all.  Compiling in is the only route.
+#
+# These entries transcribe sys/modules/linux64/Makefile and
+# sys/modules/linux_common/Makefile into config(8) form, following the shape
+# releng/13.0's files.amd64 used for the (now removed) static linux32 path.
+#
+# Registration works statically: linux_sysvec.c uses
+# DECLARE_MODULE_TIED(linux64elf, ..., SI_SUB_EXEC, SI_ORDER_ANY) and inserts the
+# ELF brand entries from its MOD_LOAD handler, which the module system fires at
+# that SYSINIT point for statically linked code exactly as it does on kldload.
+
+# --- generated artefacts ----------------------------------------------------
+# linux_genassym.o -> linux_assym.h -> linux_locore.o
+#                                   \
+#                      linux_vdso_gtod.o -> linux_vdso.so.o -> linux_vdso_inc.S
+#
+# linux_vdso_inc.S .incbin's "linux_vdso.so.o" by that exact name, so the vDSO
+# target must keep the .so.o suffix.
+
+linux_genassym.o		optional compat_linux			\
+	dependency	"$S/amd64/linux/linux_genassym.c offset.inc"	\
+	compile-with	"${CC} -c ${NOSAN_CFLAGS:N-flto*:N-fno-common} -fcommon $S/amd64/linux/linux_genassym.c" \
+	no-obj no-implicit-rule						\
+	clean		"linux_genassym.o"
+
+linux_assym.h			optional compat_linux			\
+	dependency	"$S/kern/genassym.sh linux_genassym.o"		\
+	compile-with	"sh $S/kern/genassym.sh linux_genassym.o > ${.TARGET}" \
+	no-obj no-implicit-rule before-depend				\
+	clean		"linux_assym.h"
+
+linux_locore.o			optional compat_linux			\
+	dependency	"linux_assym.h assym.inc $S/amd64/linux/linux_locore.asm" \
+	compile-with	"${CC} -c -x assembler-with-cpp -DLOCORE -fPIC -pipe -O2 -Werror -mcmodel=small -msoft-float -nostdinc -fasynchronous-unwind-tables -fno-omit-frame-pointer -foptimize-sibling-calls -fno-stack-protector -I. -I$S -I$S/../include $S/amd64/linux/linux_locore.asm -o ${.TARGET}" \
+	no-obj no-implicit-rule						\
+	clean		"linux_locore.o"
+
+linux_vdso_gtod.o		optional compat_linux			\
+	dependency	"$S/amd64/linux/linux_vdso_gtod.c $S/compat/linux/linux_vdso_gtod.inc $S/x86/linux/linux_vdso_gettc_x86.inc" \
+	compile-with	"${CC} -c -fPIC -pipe -O2 -Werror -mcmodel=small -msoft-float -nostdinc -fasynchronous-unwind-tables -fno-omit-frame-pointer -foptimize-sibling-calls -fno-stack-protector -I. -I$S -I$S/../include $S/amd64/linux/linux_vdso_gtod.c -o ${.TARGET}" \
+	no-obj no-implicit-rule						\
+	clean		"linux_vdso_gtod.o"
+
+linux_vdso.so.o			optional compat_linux			\
+	dependency	"linux_locore.o linux_vdso_gtod.o"		\
+	compile-with	"${LD} --shared --eh-frame-hdr -soname=linux-vdso.so.1 --no-undefined --hash-style=both -warn-common -nostdlib --strip-debug -s --build-id=sha1 -Bsymbolic -T$S/amd64/linux/linux_vdso.lds.s -o ${.TARGET} linux_locore.o linux_vdso_gtod.o" \
+	no-obj no-implicit-rule						\
+	clean		"linux_vdso.so.o"
+
+# --- linux_common (shared ABI support; MODULE_DEPEND of linux64elf) ---------
+compat/linux/linux_common.c	optional compat_linux
+compat/linux/linux_mib.c	optional compat_linux
+compat/linux/linux_mmap.c	optional compat_linux
+compat/linux/linux_util.c	optional compat_linux
+compat/linux/linux_emul.c	optional compat_linux
+compat/linux/linux_dummy.c	optional compat_linux
+compat/linux/linux_errno.c	optional compat_linux
+compat/linux/linux_netlink.c	optional compat_linux
+compat/linux/linux.c		optional compat_linux
+x86/linux/linux_x86.c		optional compat_linux
+x86/linux/linux_vdso_selector_x86.c	optional compat_linux
+
+# --- linux64: machine-dependent --------------------------------------------
+amd64/linux/linux_dummy_machdep.c	optional compat_linux
+amd64/linux/linux_machdep.c	optional compat_linux
+amd64/linux/linux_syscalls.c	optional compat_linux
+amd64/linux/linux_sysent.c	optional compat_linux
+amd64/linux/linux_sysvec.c	optional compat_linux
+amd64/linux/linux_support.S	optional compat_linux			\
+	dependency	"linux_assym.h assym.inc"
+x86/linux/linux_dummy_x86.c	optional compat_linux
+
+# --- linux64: machine-independent ------------------------------------------
+# linux_elf.c is #include'd by linux_elf64.c (__ELF_WORD_SIZE), not built alone.
+compat/linux/linux_elf64.c	optional compat_linux
+compat/linux/linux_event.c	optional compat_linux
+compat/linux/linux_file.c	optional compat_linux
+compat/linux/linux_fork.c	optional compat_linux
+compat/linux/linux_futex.c	optional compat_linux
+compat/linux/linux_getcwd.c	optional compat_linux
+compat/linux/linux_ioctl.c	optional compat_linux
+compat/linux/linux_ipc.c	optional compat_linux
+compat/linux/linux_misc.c	optional compat_linux
+compat/linux/linux_ptrace.c	optional compat_linux
+compat/linux/linux_rseq.c	optional compat_linux
+compat/linux/linux_signal.c	optional compat_linux
+compat/linux/linux_socket.c	optional compat_linux
+compat/linux/linux_stats.c	optional compat_linux
+compat/linux/linux_sysctl.c	optional compat_linux
+compat/linux/linux_time.c	optional compat_linux
+compat/linux/linux_timer.c	optional compat_linux
+compat/linux/linux_vdso.c	optional compat_linux
+compat/linux/linux_xattr.c	optional compat_linux
+compat/linux/linux_vdso_inc.S	optional compat_linux			\
+	dependency	"linux_vdso.so.o"
+
+# --- linprocfs / linsysfs ---------------------------------------------------
+# Not optional extras: the AppImage runtime resolves its own path via
+# /proc/self/exe (AppImage/type2-runtime src/runtime/runtime.c), so /proc has to
+# exist even with no Linux base installed.  Both are plain filesystems with no
+# generated files and no pseudofs dependency (see sys/modules/linprocfs/Makefile).
+compat/linprocfs/linprocfs.c	optional linprocfs
+compat/linsysfs/linsysfs.c	optional linsysfs
+compat/linsysfs/linsysfs_net.c	optional linsysfs

--- a/src-overlay/conf/options.compat_linux
+++ b/src-overlay/conf/options.compat_linux
@@ -1,0 +1,14 @@
+# options.compat_linux -- option declarations for the static Linuxulator.
+#
+# Appended to /usr/src/sys/conf/options by the kernel workflow.
+#
+# COMPAT_LINUX is declared but COMMENTED OUT in sys/conf/options.amd64, so it is
+# not live anywhere in the tree and re-declaring it here is not a duplicate.
+# LINPROCFS/LINSYSFS have never had option declarations at all.
+#
+# opt_dontuse.h is the correct bucket: nothing #ifdef's on these, they only
+# select the `optional' entries in files.compat_linux (same as NULLFS/TARFS/
+# UNIONFS/FUSEFS).
+COMPAT_LINUX	opt_dontuse.h
+LINPROCFS	opt_dontuse.h
+LINSYSFS	opt_dontuse.h

--- a/src-overlay/conf/options.compat_linux
+++ b/src-overlay/conf/options.compat_linux
@@ -1,14 +1,20 @@
-# options.compat_linux -- option declarations for the static Linuxulator.
+# options.compat_linux -- option declaration for the static Linuxulator.
 #
 # Appended to /usr/src/sys/conf/options by the kernel workflow.
 #
-# COMPAT_LINUX is declared but COMMENTED OUT in sys/conf/options.amd64, so it is
-# not live anywhere in the tree and re-declaring it here is not a duplicate.
-# LINPROCFS/LINSYSFS have never had option declarations at all.
+# ONLY COMPAT_LINUX belongs here. sys/conf/options.amd64 already declares:
 #
-# opt_dontuse.h is the correct bucket: nothing #ifdef's on these, they only
-# select the `optional' entries in files.compat_linux (same as NULLFS/TARFS/
-# UNIONFS/FUSEFS).
+#   18: #COMPAT_LINUX          opt_dontuse.h    <- commented out, so ours is not
+#   19: COMPAT_LINUX32         opt_dontuse.h       a duplicate
+#   20: LINPROCFS              opt_dontuse.h    <- already live; do NOT redeclare
+#   21: LINSYSFS               opt_dontuse.h    <- already live; do NOT redeclare
+#
+# LINPROCFS/LINSYSFS are declared but select nothing, because upstream removed
+# their file entries when the Linuxulator went module-only (e013e3693, "Cut
+# LINPROCFS and LINSYSFS for consistency"). files.compat_linux supplies the
+# entries; the declarations are already there. Redeclaring them here is what
+# broke the first CI run ("Duplicate option LINPROCFS").
+#
+# opt_dontuse.h is the correct bucket: nothing #ifdef's on COMPAT_LINUX, it only
+# selects the `optional' entries in files.compat_linux (as NULLFS/TARFS/FUSEFS do).
 COMPAT_LINUX	opt_dontuse.h
-LINPROCFS	opt_dontuse.h
-LINSYSFS	opt_dontuse.h


### PR DESCRIPTION
Closes #60 (the bake-in half).

NextBSD ships no `/boot/kernel` `.ko` tree (`assemble-image.sh:168`) and no kld tooling — `kldload`/`kldstat`/`kldunload` are superseded by `kext*` (`nextbsd-freebsd-compat/scripts/superseded:13-16`). Anything upstream ships only as a module is therefore unreachable here. FUSE and the Linux ABI are both in that category, and together they're what blocks running AppImages.

**Additive only — no upstream file is patched.** Two new `src-overlay/conf/` fragments appended by the workflow, exactly as `files.linuxkpi_video` and `files.vfs_pivot` already are.

## FUSEFS — no overlay needed

`fs/fuse/*.c` is gated `optional fusefs` in `sys/conf/files`, so the stock option compiles it in. One line in `config/NEXTBSD`. Compiling in rather than shipping `fusefs.ko` also sidesteps #52: no `.ko` for `assemble-image.sh` to delete.

## The 64-bit Linuxulator — needs the overlay

There has never been a static path for it: `#COMPAT_LINUX` is commented out in `sys/conf/options.amd64` in 11.0, 12.0, 13.0, 14.0 and 15.1, and `files.amd64` carries no linux entries. The **32-bit** ABI had one until 14.0, removed by `e013e3693` — *"Since we have 32 and 64 bit Linux emulators, we can't build both emulators together into the kernel."* We build only the 64-bit ABI, so that collision doesn't apply.

`files.compat_linux` transcribes `sys/modules/linux64/Makefile` and `sys/modules/linux_common/Makefile` into config(8) form, following the shape releng/13.0's `files.amd64` used for the static linux32 path — 38 source entries plus five generated artefacts:

```
linux_genassym.o -> linux_assym.h -> linux_locore.o
                                  \
                     linux_vdso_gtod.o -> linux_vdso.so.o -> linux_vdso_inc.S
```

`linux_vdso_inc.S` `.incbin`s `"linux_vdso.so.o"` by that exact name, so the vDSO target keeps the `.so.o` suffix.

`linprocfs`/`linsysfs` are included because the AppImage runtime resolves itself via `/proc/self/exe`, so `/proc` must exist even with no Linux base. Both are plain filesystems — no generated files, no pseudofs dependency.

## Why static registration works

The concern with compiling in a module-only subsystem is that it registers nothing. Not the case here — `amd64/linux/linux_sysvec.c`:

```c
DECLARE_MODULE_TIED(linux64elf, linux64_elf_mod, SI_SUB_EXEC, SI_ORDER_ANY);
MODULE_DEPEND(linux64elf, linux_common, 1, 1, 1);
```

with `elf64_insert_brand_entry()` in the `MOD_LOAD` case. `DECLARE_MODULE` fires `MOD_LOAD` at its SYSINIT point for statically linked code exactly as it does on `kldload`, and `linux_common` is compiled in alongside so the dependency resolves.

## Not verified locally — CI is the test loop

I could not build this before opening the PR. The source entries are a mechanical transcription and should be fine; **the five generated-artefact rules are the risk** — translating `bsd.kmod.mk` recipes into `dependency`/`compile-with` form, particularly the vDSO's custom `ld` invocation with its own linker script. Expect one or two rounds of build fixes. Opening as draft for that reason.

## Out of scope

- **Mounting** `linprocfs`/`linsysfs` — belongs in `nextbsd-overlays` (`/private/etc/fstab`), not here.
- **`/compat/linux`** — deliberately not populated. Consequence, recorded in #60: statically-linked Linux binaries will run; dynamically-linked payloads looking for `/lib64/ld-linux-x86-64.so.2` will not.
- **Whether Linuxulator translates Linux `mount(2)` with fstype `fuse`** onto FreeBSD's fusefs is untested. If it doesn't, `--appimage-extract-and-run` bypasses FUSE entirely.

## Revert path

When the kext-conversion project lands (#52), this comes out cleanly: drop four `options` lines from `config/NEXTBSD`, delete the two overlay fragments, drop the `build.yml` step. Nothing else in the tree changed.
