### PR TITLE
mach: don't deref a NULL ipc_space in ipc_entry_list_close — fixes panic on every Linux exit(2)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_entry.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_entry.c
@@ -782,6 +782,21 @@ ipc_entry_list_close(void *arg __unused, struct proc *p)
 	FILEDESC_SUNLOCK(fdp);
 #endif
 
+	/*
+	 * Out-of-tree fix (nextbsd-kernel#63): p_machdata being set does NOT
+	 * imply the task owns an IPC space. A process whose ABI never allocates
+	 * one -- a Linux binary under COMPAT_LINUX acquires a mach task lazily
+	 * but no itk_space -- reaches here with current_space() == NULL, and the
+	 * walk below then reads NULL + offsetof(struct ipc_space, is_entry_list)
+	 * == 0x28 and panics in exit1(). Every Linux process died on exit(2).
+	 *
+	 * The descriptor loops above stay: such a process can still have
+	 * inherited DTYPE_MACH_IPC descriptors that must be closed. It is only
+	 * the space-owned entry list that has nothing to free.
+	 */
+	if (space == NULL)
+		return;
+
 	/* free unreferenced ipc_entrys */
 	i = 0;
 	while(!LIST_EMPTY(&space->is_entry_list)) {


### PR DESCRIPTION
Fixes #63. Every Linux binary panicked the kernel **on exit(2)** — one line of real change.

## How it was found

The physical box gave nothing: instant reset, no panic text, no surviving msgbuf, and no netdump despite `igc` supporting debugnet. So I booted the CI-assembled image under qemu with a serial console and ran a 122-byte hand-built static Linux ELF (`_start: mov $60,%eax; xor %edi,%edi; syscall`). That produced the panic in full:

```
Fatal trap 12: page fault while in kernel mode
fault virtual address   = 0x28
fault code              = supervisor read data, page not present
instruction pointer     = 0x20:0xffffffff80f76a70
current process         = 48 (tiny_exit)
rbx: 0000000000000000
#3 0xffffffff810d9fcd at trap_pfault+0x37d
#4 0xffffffff810af9c8 at calltrap+0x8
#5 0xffffffff80b4a44c at exit1+0x33c
#6 0xffffffff811b45ae at linux_exit+0x2e
#7 0xffffffff810da606 at amd64_syscall+0x126
```

`nm` on the matching `kernel.full` resolves the faulting IP:

```
0xffffffff80f76a70 -> ipc_entry_list_close+0x170
```

So it is **our Mach layer**, reached through `exit1()`'s `process_exit` handler — not the Linuxulator.

## Why 0x28

`struct ipc_space` begins `is_ref_lock_data` (a `struct mtx`, 32 bytes), then `is_references` (4, padded to 8), then `is_entry_list`. That puts `is_entry_list` at **0x28** — exactly the fault address, and exactly what the trailing loop touches:

```c
	while(!LIST_EMPTY(&space->is_entry_list)) {
```

`space` was NULL.

## Why the existing guard missed it

`ipc_entry_list_close()` already carries an out-of-tree guard:

```c
	if (p->p_machdata == NULL || curthread->td_proc->p_machdata == NULL)
		return;
```

That is necessary but not sufficient. `p_machdata` being set does **not** imply the task owns an IPC space — `current_space()` is `current_task()->itk_space` (`sys/mach/thread.h:639`). A Linux-ABI process acquires a mach task lazily but never gets an `itk_space`, so it sails past the guard and hits the walk with `space == NULL`.

## The fix

Guard the space-owned walk rather than the whole function:

```c
	if (space == NULL)
		return;

	/* free unreferenced ipc_entrys */
```

Deliberately placed *after* the descriptor loops, not before them: a Linux process can still have inherited `DTYPE_MACH_IPC` descriptors that must be closed. Only the space-owned entry list has nothing to free. Behaviour for Mach processes is unchanged.

## This is not a Linuxulator bug

#61 didn't introduce it — it made a latent NULL deref *reachable*, by adding the first process ABI that doesn't allocate Mach IPC state. The field symptom was `pkg install linux_base-rl9` rebooting the machine mid-install: its `@postexec` runs `/compat/linux/usr/sbin/ldconfig`, and the panic fired when that process exited.

Worth noting the same guard gap would bite any future non-Mach ABI, not just Linux.

## Verification

CI build is the first gate. After that I'll re-run the qemu repro against the newly built image — same 122-byte binary, which should now exit cleanly with `RC=0` — and post the result here before merging.
