### PR TITLE
kernel: compile in fdescfs — Bun resolves cwd via readlink(/dev/fd/N)

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -74,6 +74,28 @@ options 	NULLFS
 # assemble-image.sh:168 to delete, and no kld tooling is needed to load it.
 options 	FUSEFS
 
+# fdescfs -- /dev/fd/N for N > 2 (nextbsd-kernel#60). devfs alone only supplies
+# /dev/fd/{0,1,2}; arbitrary descriptors need fdescfs, which upstream ships as a
+# module and GENERIC does not compile in -- the same module-only trap as FUSEFS
+# and the Linuxulator, and unreachable here because NextBSD has no .ko tree.
+#
+# Needed because Bun (claude-code 2.x is a Bun binary) resolves its working
+# directory by open(cwd, O_PATH) followed by readlink("/dev/fd/N"). Traced:
+#
+#   linux_openat(AT_FDCWD,"/root",O_RDONLY|O_LARGEFILE|O_PATH) -> 14
+#   linux_readlink("/dev/fd/14")            -> -1 errno -2 ENOENT
+#   linux_write(9, ..., 0x49)               -> 73 bytes, the error text
+#   linux_exit_group(1)
+#
+# which surfaces as: Can't access working directory /root: Path does not exist.
+# MI (sys/conf/options:267, sys/conf/files:3600), so safe on both matrix legs --
+# unlike LINPROCFS/LINSYSFS, which are declared only in options.amd64.
+#
+# Mounting is separate and still required:
+#   mount -t fdescfs -o linrdlnk fdesc /compat/linux/dev/fd
+# The linrdlnk option gives Linux-style readlink semantics; rc.d/linux uses it.
+options 	FDESCFS
+
 # 64-bit Linux ABI + linprocfs/linsysfs (nextbsd-kernel#60). Upstream ships these
 # only as modules and there has never been a static path for the 64-bit ABI, so
 # the `optional compat_linux' entries these select are supplied by


### PR DESCRIPTION
Refs #60. One line: `options FDESCFS`.

## Symptom

With the Linuxulator working (#61) and `linprocfs` mounted, `claude-code` installs and `claude --version` prints `2.1.220` — but running it dies immediately:

```
Error: Can't access working directory /root: Path "/root" does not exist
```

`/root` obviously exists, and it fails identically from every directory (`/private/tmp`, `/usr/local`, a freshly made `/noshadow`).

## What the trace shows

Booted the published image under qemu with a serial console, installed claude-code, and pulled the full 37,692-line ktrace back to the host. **Every** access to the directory succeeds:

```
linux_getcwd(...)                                          -> 6 ("/root")
linux_statx(AT_FDCWD,"/root",AT_SYMLINK_NOFOLLOW,0xfff)    -> 0
linux_newfstatat(AT_FDCWD,"/root")                         -> 0
linux_openat(AT_FDCWD,"/root",O_RDONLY|O_LARGEFILE|O_PATH) -> 14
```

Only the final step fails, and then it gives up:

```
linux_readlink("/dev/fd/14")   -> -1 errno -2 No such file or directory
close(14)                      -> 0
linux_write(9, ..., 0x49)      -> 73 bytes
linux_exit_group(1)
```

`0x49` = 73, exactly the length of the error string, so that readlink is what it is reporting.

## Why

claude-code 2.x is a **Bun** binary — the thread names give it away (`mi-scavenger`, `Bun Pool 0`, `JITWorker`). Bun resolves its working directory by opening it `O_PATH` and reading the descriptor back through `/dev/fd/N`.

devfs supplies only `/dev/fd/{0,1,2}`. Anything higher needs **fdescfs**, which upstream ships as a module and GENERIC does not compile in. On NextBSD that makes it unreachable — no `.ko` tree, no kld tooling. The same module-only trap as FUSEFS and the Linuxulator.

## Why this one is easy

`FDESCFS` is declared in the **MI** `sys/conf/options:267` and its sources are gated MI in `sys/conf/files:3600`. So unlike `LINPROCFS`/`LINSYSFS` — declared only in `options.amd64`, which is what broke the arm64 leg in #61 and needed arch-aware wiring — this needs no special handling and is safe in the shared `NEXTBSD` config as-is.

## Still required after this: the mount

The option alone changes nothing at runtime. The filesystem has to be mounted:

```sh
mount -t fdescfs -o linrdlnk fdesc /compat/linux/dev/fd
```

`linrdlnk` gives Linux-style readlink semantics and is exactly what `rc.d/linux` uses. For reference the full set that `rc.d/linux` mounts is:

```
linprocfs  ->  /compat/linux/proc      -o nocover
linsysfs   ->  /compat/linux/sys       -o nocover
devfs      ->  /compat/linux/dev       -o nocover
fdescfs    ->  /compat/linux/dev/fd    -o nocover,linrdlnk
tmpfs      ->  /compat/linux/dev/shm   -o nocover,mode=1777
```

NextBSD has no `rc.d`, and `fstab` is inert here (nothing runs `mount -a`), so this needs a LaunchDaemon in `nextbsd-userland`. That is the last piece and it is deliberately not in this PR — the mount mechanism is still an open design decision on #60.

## Verification plan

Once CI is green I will boot the resulting image, mount the full set by hand, and confirm claude actually starts. I will post the result here before merging rather than assuming the trace-derived fix is sufficient.
