### PR TITLE
mach: skip fork bootstrap inheritance for tasks with no ipc_space — fixes AppImage panic

### DIFF
--- a/src-overlay/sys/compat/mach/kern/task.c
+++ b/src-overlay/sys/compat/mach/kern/task.c
@@ -1251,6 +1251,35 @@ mach_task_fork_bsport(void *arg __unused, struct proc *p1, struct proc *p2,
 
 	if (parent_task == NULL)
 		return; /* parent has no Mach state — nothing to inherit */
+
+	/*
+	 * Out-of-tree fix (nextbsd-kernel#66): p_machdata being set does NOT mean
+	 * the task is a real Mach task. A Linux-ABI process acquires a task
+	 * lazily but never an itk_space — the same asymmetry #64 fixed in
+	 * ipc_entry_list_close, where current_space() is NULL for such a process.
+	 * Its itk_* fields are therefore not valid to read OR to lock, and this
+	 * hook died two different ways on them:
+	 *
+	 *   +0xf2  -> ipc_port_copy_send: read 0x490, page not present (stale
+	 *             itk_bootstrap port)
+	 *   +0x293 -> itk_lock -> __mtx_lock_sleep -> turnstile_wait ->
+	 *             propagate_priority: WRITE to kernel text, protection
+	 *             violation (itk_lock_data is not an initialised struct mtx,
+	 *             so the lock looks contended and the turnstile chain is
+	 *             garbage)
+	 *
+	 * Two distinct crash sites means guarding individual dereferences is the
+	 * wrong shape: the whole hook is operating on a structure that is not
+	 * valid for this process. Bail out instead.
+	 *
+	 * Native processes own a space, so bootstrap-port inheritance for
+	 * launchd-spawned daemons — the reason this hook exists (Task #39) — is
+	 * unaffected. A Linux process has no space and cannot use Mach IPC at
+	 * all, so there is genuinely nothing to inherit.
+	 */
+	if (parent_task->itk_space == NULL)
+		return;
+
 	if (parent_task->itk_bootstrap == IP_NULL)
 		return; /* parent has no bootstrap port — nothing to inherit */
 


### PR DESCRIPTION
Fixes #66. Three-line guard; the rest is the explanation.

## Symptom

Any AppImage panics the machine within ~2 seconds of starting. `claude-code` survives, which is why this took a while to pin down.

## Backtrace

Reproduced under qemu on `NextBSD-amd64-20260802-055026` (all of #61/#62/#64/#65) with a serial console — hardware has no dump device, so a panic there just vanishes into a reboot.

```
Fatal trap 12: page fault while in kernel mode
fault virtual address   = 0xffffffff81239ce3
fault code              = supervisor write data, protection violation
current process         = 143 (thorium.AppImage)

#5  0xffffffff80c05bc8 at propagate_priority+0x58
#6  0xffffffff80c067d2 at turnstile_wait+0x2d2
#7  0xffffffff80b778c5 at __mtx_lock_sleep+0x175
#8  0xffffffff80f8ab53 at mach_task_fork_bsport+0x293
#9  0xffffffff80b522d8 at do_fork+0x10c8
#10 0xffffffff80b50c3e at fork1+0x83e
#11 0xffffffff811b49e8 at linux_fork+0x58
```

That is the `itk_lock(parent_task)` / `itk_lock(child_task)` pair. `itk_lock_data` is not an initialised `struct mtx`, so the lock is treated as contended, `turnstile_wait` enqueues against a bogus owner, and `propagate_priority` writes through a garbage pointer into kernel text.

## Two crash sites, one cause

An earlier run hit a **different** point in the same function:

| | earlier | this one |
|---|---|---|
| offset | `mach_task_fork_bsport+0xf2` | `mach_task_fork_bsport+0x293` |
| via | `ipc_port_copy_send+0x7a` | `__mtx_lock_sleep` → `turnstile_wait` → `propagate_priority` |
| fault | read `0x490`, page not present | **write** to kernel text, protection violation |

Two distinct failure modes in one function is the tell: guarding individual dereferences would be the wrong shape, because **the hook is operating on a task structure that is not valid for this process at all**. Whichever line runs first fails, depending on what the uninitialised memory happens to contain. That also explains claude-vs-AppImage without needing two bugs — same invalid state, different luck.

## The fix, and why this predicate

`p_machdata` being set does not mean the task is a real Mach task. #63/#64 already established the asymmetry: **a native process owns an `itk_space`; a Linux-ABI process acquires a task lazily and never does.** That is precisely why `ipc_entry_list_close` needed its guard in #64, and why `current_space()` (`current_task()->itk_space`) returns NULL for such a process.

So:

```c
	if (parent_task->itk_space == NULL)
		return;
```

placed before anything touches `itk_bootstrap` or takes `itk_lock`, since neither is valid to read *or* lock on a bogus task.

**Native behaviour is unchanged.** Those tasks have a space, so bootstrap-port inheritance for launchd-spawned daemons — the entire reason Task #39 added this hook, so `bootstrap_check_in` works for MachServices — still happens exactly as before. A Linux process has no space and cannot use Mach IPC at all, so there is nothing to inherit and skipping is correct rather than a workaround.

This is the third instance of the same class (#63/#64 on exit, this on fork), so an audit of the remaining `process_*` eventhandlers for the same assumption is probably worthwhile as a follow-up.

## Verification

I will boot the CI-built image from this branch and re-run the same AppImage before proposing a merge. The reproducer takes 2 seconds, so this is a real check rather than an inference — and given four of my automated checks tonight produced false passes by asserting on the absence of an error string, the criterion here is positive: the AppImage must run *and* the box must still be up afterwards.
