### PR TITLE
kernel: default elf64 fallback_brand to ELFOSABI_LINUX so unbranded Linux binaries (AppImages) can exec

### DIFF
--- a/patches/0009-NextBSD-default-elf64-fallback_brand-to-ELFOSABI_LINU.patch
+++ b/patches/0009-NextBSD-default-elf64-fallback_brand-to-ELFOSABI_LINU.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sun, 2 Aug 2026 12:20:00 -0500
+Subject: [PATCH] NextBSD: default elf64 fallback_brand to ELFOSABI_LINUX
+
+Linux binaries are overwhelmingly built with EI_OSABI = ELFOSABI_NONE (0).
+FreeBSD identifies an ELF's ABI by, in order: EI_OSABI, a .note.ABI-tag, the
+interpreter path, then kern.elf64.fallback_brand. A STATICALLY linked Linux
+binary defeats the first three -- no OSABI, often no ABI note, and no PT_INTERP
+segment at all -- so it reaches the fallback. At -1 the loader gives up:
+
+	ELF binary type "0" not known.
+	Exec format error
+
+AppImages are exactly this case; the type2 runtime is static-pie musl (verified
+with readelf: OS/ABI "UNIX - System V", no INTERP, only .note.gnu.build-id).
+Because a user downloads them, brandelf(1) per file is not a workable
+alternative.
+
+x11/linux_base-rl9 works today only because the port brandelfs its loader
+(BRANDELF -t Linux .../ld-linux-x86-64.so.2), so DYNAMIC Linux binaries are
+identified by interpreter path. Static ones have no such hint.
+
+rc.d/linux sets this sysctl for the same reason. NextBSD has launchd as PID 1
+and no rc.d, and /etc/sysctl.conf is never read, so the kernel default is the
+only persistent mechanism -- the same reasoning as patch 0008 (vfs.usermount).
+
+32-bit is deliberately left at -1: nextbsd-kernel#61 compiled in only the 64-bit
+Linux ABI, so branding i386 ELFs as Linux would point them at an ABI that is not
+present. A clear "Exec format error" beats failing deeper in.
+
+The sysctl is CTLFLAG_RWTUN upstream, so kern.elf64.fallback_brand=-1 in
+/boot/loader.conf restores the stock posture persistently. Note this is a broader
+policy change than the mount work: it makes ANY unbranded ELF64 be treated as
+Linux, including one that is not Linux and would otherwise have failed cleanly.
+
+Refs #60, nextbsd-userland#54. Carried out-of-tree for NextBSD.
+---
+ sys/kern/imgact_elf.c | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+index 52223c3..6e61276 100644
+--- a/sys/kern/imgact_elf.c
++++ b/sys/kern/imgact_elf.c
+@@ -116,7 +116,37 @@ SYSCTL_NODE(_kern, OID_AUTO, ELF_ABI_ID, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+ 
+ #define	ELF_NODE_OID	__CONCAT(_kern_, ELF_ABI_ID)
+ 
++/*
++ * NextBSD: default the 64-bit brand of last resort to ELFOSABI_LINUX.
++ *
++ * Linux binaries are overwhelmingly built with EI_OSABI = ELFOSABI_NONE, and
++ * FreeBSD identifies an ELF's ABI by, in order: EI_OSABI, a .note.ABI-tag, the
++ * interpreter path, then this fallback. A statically linked Linux binary
++ * defeats the first three -- no OSABI, often no ABI note, and no PT_INTERP at
++ * all -- so it lands here. With -1 the loader gives up:
++ *
++ *     ELF binary type "0" not known.
++ *     Exec format error
++ *
++ * AppImages are exactly this case: the type2 runtime is static-pie musl. And
++ * because a user downloads them, brandelf(1) per file is not a workable
++ * alternative. rc.d/linux sets this sysctl for the same reason; NextBSD has no
++ * rc.d, so the kernel default is the only persistent mechanism (same reasoning
++ * as patch 0008 for vfs.usermount).
++ *
++ * 32-bit is deliberately left at -1: nextbsd-kernel#61 compiled in only the
++ * 64-bit Linux ABI, so branding i386 ELFs as Linux would point them at an ABI
++ * that is not present -- a clear "Exec format error" is better than failing
++ * deeper in.
++ *
++ * Still CTLFLAG_RWTUN upstream, so kern.elf64.fallback_brand=-1 in
++ * /boot/loader.conf restores the stock posture persistently.
++ */
++#if __ELF_WORD_SIZE == 64
++int __elfN(fallback_brand) = 3;		/* ELFOSABI_LINUX */
++#else
+ int __elfN(fallback_brand) = -1;
++#endif
+ SYSCTL_INT(ELF_NODE_OID, OID_AUTO,
+     fallback_brand, CTLFLAG_RWTUN, &__elfN(fallback_brand), 0,
+     ELF_ABI_NAME " brand of last resort");

--- a/patches/series
+++ b/patches/series
@@ -6,3 +6,4 @@
 0006-unionfs-rename-allow-directory-target.patch
 0007-unionfs-layer-tagged-fileid.patch
 0008-NextBSD-enable-unprivileged-mounts-vfs-usermount-1.patch
+0009-NextBSD-default-elf64-fallback_brand-to-ELFOSABI_LINU.patch


### PR DESCRIPTION
Refs #60, nextbsd-userland#54. `patches/0009`, added to `patches/series`, verified to apply cleanly against `releng/15.1`.

Separate from #67 on purpose: that one is a panic fix that should merge on its own merit, this one is a **policy change** and deserves its own discussion.

## Why it is needed

A stock AppImage cannot execute at all:

```
$ ./Thorium_Browser_150.0.7871.101_AVX.AppImage
ELF binary type "0" not known.
-sh: ./Thorium_...AppImage: Exec format error
```

FreeBSD resolves an ELF's ABI in this order — and an AppImage defeats the first three:

| step | AppImage |
|---|---|
| `EI_OSABI` | `UNIX - System V` (0) — no help |
| `.note.ABI-tag` | absent; only `.note.gnu.build-id` |
| interpreter path | **no `PT_INTERP` at all** — the type2 runtime is static-pie musl |
| `kern.elf64.fallback_brand` | `-1` → give up |

Verified with `readelf` on the actual file. So the fallback is the only remaining hook, and this patch changes its default from `-1` to `3` (`ELFOSABI_LINUX`).

## Why `linux_base` works today and this is still needed

`x11/linux_base-rl9` brands its loader at build time:

```make
	${BRANDELF} -t Linux ${WRKSRC}/usr/lib64/ld-linux-*.so.2
```

so every **dynamically** linked Linux binary is identified by its interpreter path. Static ones have no such hint. That is exactly why `/compat/linux/bin/sh` runs fine while a downloaded AppImage does not.

`brandelf -t Linux` per file is not a workable alternative for AppImages, since users download them and it modifies the file.

## Why the kernel default

`rc.d/linux` sets this sysctl. NextBSD has launchd as PID 1, no `rc.d`, and never reads `/etc/sysctl.conf` — so as with `0008` (`vfs.usermount`), the kernel default is the only mechanism that persists. It remains `CTLFLAG_RWTUN` upstream, so `kern.elf64.fallback_brand=-1` in `/boot/loader.conf` restores the stock posture.

## 32-bit deliberately left alone

`imgact_elf.c` is compiled twice via `__elfN()`, so a naive `= -1` → `= 3` would change **both** ABIs. Guarded on `__ELF_WORD_SIZE == 64`, because #61 compiled in only the 64-bit Linux ABI — branding i386 ELFs as Linux would point them at an ABI that is not present, and a clear `Exec format error` beats failing deeper in.

## The tradeoff, stated plainly

This is broader than the mount work. It makes **any** unbranded ELF64 on the system be treated as Linux, including something that is not Linux at all and would otherwise have failed cleanly at exec. I raised this on nextbsd-userland#54 and my preference there was to gate it on a Linux userland actually being installed, via the same trigger that mounts the filesystems — which keeps the default posture unchanged on images with no Linux runtime.

You asked for it baked into the kernel, so that is what this does. If you would rather have the gated version instead, the alternative is a `sysctl` call in the linuxfs job in nextbsd-userland#53 and this patch gets dropped — happy to switch.

## Verification

Not yet booted. Will confirm against the CI image from this branch that an unbranded static Linux binary execs without `brandelf`, before proposing a merge.
