### PR TITLE
config: keep overlay-only options out of the shared kernel config (unbreaks nextbsd-kernel-modules)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,16 +207,22 @@ jobs:
           # The ABI itself is amd64-only for now (files.compat_linux references
           # amd64/linux/* and x86/linux/*). arm64 has a complete Linux ABI in
           # tree (sys/arm64/linux/) and mirroring this for it is a follow-up.
+          # The three options go into the COPIED config here, not into
+          # config/NEXTBSD in the repo -- same rule as COMPAT_MACH above.
+          # nextbsd-kernel-modules reuses config/NEXTBSD to build a KBI-matched
+          # kernel and lays in none of src-overlay/, so an option the overlay
+          # alone declares makes its config(8) die with `unknown option'. Naming
+          # them in the shared file is what broke that build on both legs from
+          # 2026-08-03. amd64 only: files.compat_linux references amd64/linux/*
+          # and x86/linux/*, so on arm64 the ABI selects nothing and the options
+          # would need declaring for no gain.
           if [ "${{ matrix.target }}" = "amd64" ]; then
             cat "$GITHUB_WORKSPACE/src-overlay/conf/files.compat_linux" >> /usr/src/sys/conf/files.amd64
-          else
-            # config/NEXTBSD is shared by both matrix legs, so every option it
-            # names must be DECLARED on both even where it selects nothing --
-            # otherwise config(8) fails with `unknown option "LINSYSFS"'.
-            # LINPROCFS/LINSYSFS live in options.amd64 upstream; COMPAT_LINUX we
-            # append to the MI sys/conf/options above, so it already covers both.
-            printf 'LINPROCFS\topt_dontuse.h\nLINSYSFS\topt_dontuse.h\n' \
-              >> /usr/src/sys/conf/options.arm64
+            for _o in COMPAT_LINUX LINPROCFS LINSYSFS; do
+              grep -qE "^options[[:space:]]+${_o}\b" \
+                /usr/src/sys/amd64/conf/NEXTBSD || \
+                printf 'options\t%s\n' "$_o" >> /usr/src/sys/amd64/conf/NEXTBSD
+            done
           fi
           # We declare COMPAT_LINUX ourselves, so it must still be commented out
           # upstream; LINPROCFS/LINSYSFS are already declared live in

--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -108,11 +108,18 @@ options 	FDESCFS
 # arm64 as well -- there they are accepted but select nothing. arm64 has a
 # complete Linux ABI in tree (sys/arm64/linux/); mirroring this for it is a
 # follow-up, not a blocker for #60.
-# Revert path when the kext-conversion project lands: drop these four options
+# Revert path when the kext-conversion project lands: drop the workflow wiring
 # and delete the two overlay fragments.
-options 	COMPAT_LINUX
-options 	LINPROCFS
-options 	LINSYSFS
+#
+# COMPAT_LINUX / LINPROCFS / LINSYSFS are NOT named here on purpose. They are
+# appended to the copied config by the workflow's "Wire in the static
+# Linuxulator" step, on the amd64 leg only -- the same pattern COMPAT_MACH uses,
+# and for the same reason: nextbsd-kernel-modules reuses THIS file to build a
+# KBI-matched kernel and lays in none of src-overlay/, so any option declared
+# only by the overlay makes its config(8) die with `unknown option'. That is
+# exactly what happened when these three landed here (modules red on both legs
+# from 2026-08-03; nextbsd-kernel itself stayed green because it does apply the
+# overlay). Keep this file to options that stock FreeBSD declares.
 
 # POSIX message queues -- a hard link-time dependency of the Linuxulator, not a
 # nicety. compat/linux/linux_misc.c:2989-3076 calls kern_kmq_open/sys_kmq_unlink/


### PR DESCRIPTION
## The failure

`nextbsd-kernel-modules` has been red on **both** legs since 2026-08-03, blocking `publish` and the kext PoC:

```
/usr/src/sys/amd64/conf/NEXTBSD: unknown option "COMPAT_LINUX"
bmake: stopped making "buildkernel"          (exit 2)
```

`nextbsd-kernel` itself stayed green throughout, and that asymmetry is the bug:

| | lays in `src-overlay/`? | so `COMPAT_LINUX` is… |
|---|---|---|
| `nextbsd-kernel` | yes — appends `options.compat_linux` | declared → `config(8)` happy |
| `nextbsd-kernel-modules` | **no**, by design | unknown → build dies |

## Why the modules build can't just apply the overlay

Because this workflow says it mustn't, in three places:

> *"the modules build shares the series but does not lay in the overlay, so it must never see this source listed in `sys/conf/files`"*

> *"The COMPAT_MACH wiring is done here, NOT in patches/series, on purpose: the modules build shares the series and must never see COMPAT_MACH (it would choke config with the source absent). **`config/NEXTBSD` in the repo stays clean for the same reason.**"*

The modules build wants a KBI-matched kernel, not NextBSD's Mach/IOKit/Linuxulator sources. `COMPAT_MACH` already honours this by being appended to the *copied* config in the workflow. The #60 Linuxulator work named `COMPAT_LINUX` / `LINPROCFS` / `LINSYSFS` directly in `config/NEXTBSD`, breaking the rule the moment it landed.

## The change

Move all three to where `COMPAT_MACH` already lives — appended to the copied config by the "Wire in the static Linuxulator" step, duplicate-guarded, **amd64 leg only**.

**No functional change to either shipped kernel.** amd64 gets the same three options, wired one step later. arm64 loses nothing: it never had `files.compat_linux`, so they were "accepted but select nothing" there — which also retires the `printf … >> options.arm64` that existed purely to keep the shared config parseable on that leg.

## Verification

This PR's CI proves the kernel still builds both arches. The modules repo can only go green once this merges (it clones `nextbsd-kernel` `main`), so I'll re-run it straight after and confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)