### PR TITLE
patches: boot arm64 under Apple Virtualization.framework

### DIFF
--- a/patches/0010-virtio_console-register-a-low-level-console-for-the-console-port.patch
+++ b/patches/0010-virtio_console-register-a-low-level-console-for-the-console-port.patch
@@ -1,0 +1,336 @@
+From cf50f191ec3a0a19b5fcdd40408bdc444967901d Mon Sep 17 00:00:00 2001
+From: networkextension <gbvbwbkjjx@privaterelay.appleid.com>
+Date: Mon, 6 Jul 2026 22:37:22 +0800
+Subject: [PATCH] virtio_console: register a low-level console for the console
+ port
+
+vtcon(4) only created a userland tty; kernel printf/panic never reached the
+virtio console, so on hypervisors whose only usable console is the virtio-console
+(e.g. Apple Virtualization.framework: no UART, and a Blt-only virtio-gpu with no
+linear framebuffer for vt_efifb) the kernel booted blind.
+
+Register the console port as a low-level console (consdev) via cnadd(9) at
+attach, like Linux virtio_console/hvc0: the sole port 0 of a non-multiport
+device, or the port the host marks with VIRTIO_CONSOLE_CONSOLE_PORT on a
+multiport device. cn_putc reuses the polled vtcon_port_out(), serialized against
+tty output on the shared out virtqueue by a spin mutex (a sleepable mutex is
+illegal in cnputc context) and bypassed while polling (panic/kdb). cn_getc
+drains the in virtqueue within the grab bracket, leaving the tty RX path intact.
+
+Add device virtio_console to arm64 std.virt so GENERIC includes it.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ sys/arm64/conf/std.virt                 |   1 +
+ sys/dev/virtio/console/virtio_console.c | 254 +++++++++++++++++++++++-
+ 2 files changed, 253 insertions(+), 2 deletions(-)
+
+diff --git a/sys/arm64/conf/std.virt b/sys/arm64/conf/std.virt
+index 8e64ce44f89b52..9fc2b1a3ef06e4 100644
+--- a/sys/arm64/conf/std.virt
++++ b/sys/arm64/conf/std.virt
+@@ -27,3 +27,4 @@ device		vtnet			# VirtIO Ethernet device
+ options 	FDT
+ device		acpi
+ device		acpi_ged
++device		virtio_console	# VirtIO Console device
+diff --git a/sys/dev/virtio/console/virtio_console.c b/sys/dev/virtio/console/virtio_console.c
+index 66433565ce2509..14370ef2eb21af 100644
+--- a/sys/dev/virtio/console/virtio_console.c
++++ b/sys/dev/virtio/console/virtio_console.c
+@@ -233,6 +233,48 @@ static void	 vtcon_disable_interrupts(struct vtcon_softc *);
+ 
+ static int	 vtcon_pending_free;
+ 
++/*
++ * Low-level console support.  A virtio console port can serve as the system
++ * console: kernel printf/panic output and a polled getc for the debugger,
++ * analogous to Linux's hvc0.  The console is a singleton -- the first port
++ * marked as a console (the sole port of a non-multiport device, or a port the
++ * host promotes via VIRTIO_CONSOLE_CONSOLE_PORT) is registered with cnadd(9).
++ */
++static struct vtcon_port	*vtcon_cn_port;		/* console port or NULL */
++static struct consdev		*vtcon_cn_consdev;	/* for cnremove */
++static struct mtx		 vtcon_cn_tx_mtx;	/* serializes cn vs tty TX */
++/*
++ * A spin mutex: vtcon_cnputc() may run in any context (with spin locks held,
++ * in a critical section, or during panic), where a sleepable MTX_DEF lock is
++ * illegal.  This mirrors uart(4)'s hardware mutex.  vtcon_port_out() only spins
++ * (virtqueue_poll) under it, never sleeps, so holding a spin lock is safe.
++ */
++MTX_SYSINIT(vtcon_cn_tx, &vtcon_cn_tx_mtx, "vtconcntx", MTX_SPIN);
++static char			*vtcon_cn_rx_buf;	/* current invq buffer */
++static int			 vtcon_cn_rx_off;	/* next byte in buffer */
++static int			 vtcon_cn_rx_len;	/* valid bytes in buffer */
++
++static cn_probe_t	vtcon_cnprobe;
++static cn_init_t	vtcon_cninit;
++static cn_term_t	vtcon_cnterm;
++static cn_getc_t	vtcon_cngetc;
++static cn_putc_t	vtcon_cnputc;
++static cn_grab_t	vtcon_cngrab;
++static cn_ungrab_t	vtcon_cnungrab;
++
++static const struct consdev_ops vtcon_cnops = {
++	.cn_probe	= vtcon_cnprobe,
++	.cn_init	= vtcon_cninit,
++	.cn_term	= vtcon_cnterm,
++	.cn_getc	= vtcon_cngetc,
++	.cn_putc	= vtcon_cnputc,
++	.cn_grab	= vtcon_cngrab,
++	.cn_ungrab	= vtcon_cnungrab,
++};
++
++static void	 vtcon_setup_console(struct vtcon_port *);
++static void	 vtcon_cn_emit(struct vtcon_port *, char *, int);
++
+ static struct ttydevsw vtcon_tty_class = {
+ 	.tsw_flags	= 0,
+ 	.tsw_open	= vtcon_tty_open,
+@@ -357,6 +399,12 @@ vtcon_attach(device_t dev)
+ 		error = vtcon_port_create(sc, 0);
+ 		if (error)
+ 			goto fail;
++		/*
++		 * A non-multiport device never sends VIRTIO_CONSOLE_CONSOLE_PORT,
++		 * so its sole port is implicitly the console (as Linux treats
++		 * port 0 of a non-multiport virtio-console as hvc0).  Register it.
++		 */
++		vtcon_setup_console(sc->vtcon_ports[0].vcsp_port);
+ 		if (sc->vtcon_flags & VTCON_FLAG_SIZE)
+ 			vtcon_port_update_console_size(sc);
+ 	}
+@@ -785,6 +833,13 @@ vtcon_ctrl_port_console_event(struct vtcon_softc *sc, int id)
+ 	port->vtcport_flags |= VTCON_PORT_FLAG_CONSOLE;
+ 	vtcon_port_submit_event(port, VIRTIO_CONSOLE_PORT_OPEN, 1);
+ 	VTCON_PORT_UNLOCK(port);
++
++	/*
++	 * Register this port as the system console.  Done outside the port
++	 * lock because cnadd()/malloc(M_WAITOK) may sleep; the singleton guard
++	 * in vtcon_setup_console() makes repeated events harmless.
++	 */
++	vtcon_setup_console(port);
+ }
+ 
+ static void
+@@ -1224,6 +1279,19 @@ vtcon_port_teardown(struct vtcon_port *port)
+ 
+ 	port->vtcport_flags |= VTCON_PORT_FLAG_GONE;
+ 
++	/*
++	 * If this was the system console, deregister it.  The cn_* methods all
++	 * null-check vtcon_cn_port and test FLAG_GONE (set above), so any
++	 * concurrent console I/O during teardown degrades to a no-op.
++	 */
++	if (port == vtcon_cn_port) {
++		cnremove(vtcon_cn_consdev);
++		free(vtcon_cn_consdev, M_DEVBUF);
++		vtcon_cn_consdev = NULL;
++		vtcon_cn_port = NULL;
++		vtcon_cn_rx_buf = NULL;
++	}
++
+ 	if (tp != NULL) {
+ 		atomic_add_int(&vtcon_pending_free, 1);
+ 		tty_rel_gone(tp);
+@@ -1380,6 +1448,179 @@ vtcon_port_out(struct vtcon_port *port, void *buf, int bufsize)
+ 	}
+ }
+ 
++/*
++ * True when the kernel is single-threaded and interrupts cannot be relied on
++ * (panic, debugger, or a stopped scheduler).  In that state the tty output
++ * thread is frozen, so console TX must not block on a lock.
++ */
++static __inline bool
++vtcon_cn_polling(void)
++{
++
++	return (KERNEL_PANICKED() || kdb_active || SCHEDULER_STOPPED());
++}
++
++/*
++ * Emit a buffer on the console port's out virtqueue.  Both the low-level
++ * console (vtcon_cnputc) and the tty output path (vtcon_tty_outwakeup) reach
++ * the single out virtqueue through here; vtcon_port_out() polls to completion
++ * and asserts the queue is empty on entry, so the two must be serialized.  We
++ * use a dedicated mutex rather than the port lock: vtcon_cnputc() must never
++ * take the port lock (a printf while it is held, or a panic, would deadlock).
++ */
++static void
++vtcon_cn_emit(struct vtcon_port *port, char *buf, int len)
++{
++
++	if (vtcon_cn_polling()) {
++		/*
++		 * Single-threaded: the tty thread cannot be mid-transmit, but
++		 * an in-flight tty buffer may still be owned by the host.  Wait
++		 * for the queue to drain, then emit directly, taking no lock.
++		 */
++		while (!virtqueue_empty(port->vtcport_outvq))
++			virtqueue_poll(port->vtcport_outvq, NULL);
++		vtcon_port_out(port, buf, len);
++	} else {
++		mtx_lock_spin(&vtcon_cn_tx_mtx);
++		vtcon_port_out(port, buf, len);
++		mtx_unlock_spin(&vtcon_cn_tx_mtx);
++	}
++}
++
++static void
++vtcon_cnprobe(struct consdev *cp)
++{
++
++	/*
++	 * A virtio console is a PCI/MMIO device that is not available this
++	 * early; it is discovered and registered dynamically via cnadd(9) in
++	 * vtcon_setup_console().  Nothing to probe here.
++	 */
++	cp->cn_pri = CN_DEAD;
++}
++
++static void
++vtcon_cninit(struct consdev *cp)
++{
++}
++
++static void
++vtcon_cnterm(struct consdev *cp)
++{
++}
++
++static void
++vtcon_cnputc(struct consdev *cp, int c)
++{
++	struct vtcon_port *port;
++	char ch;
++
++	port = vtcon_cn_port;
++	if (port == NULL || (port->vtcport_flags & VTCON_PORT_FLAG_GONE))
++		return;
++
++	ch = c;
++	vtcon_cn_emit(port, &ch, 1);
++}
++
++/*
++ * Polled console input.  Only ever called between cn_grab and cn_ungrab, which
++ * disable the in virtqueue interrupt, so this does not race the interrupt-driven
++ * vtcon_port_in().  A dequeued buffer holds up to VTCON_BULK_BUFSZ bytes while
++ * we return one byte per call; exhausted buffers are requeued so the in queue
++ * accounting stays consistent once the interrupt path resumes.
++ */
++static int
++vtcon_cngetc(struct consdev *cp)
++{
++	struct vtcon_port *port;
++	uint32_t len;
++
++	port = vtcon_cn_port;
++	if (port == NULL || (port->vtcport_flags & VTCON_PORT_FLAG_GONE))
++		return (-1);
++
++	if (vtcon_cn_rx_buf == NULL || vtcon_cn_rx_off >= vtcon_cn_rx_len) {
++		if (vtcon_cn_rx_buf != NULL) {
++			vtcon_port_requeue_buf(port, vtcon_cn_rx_buf);
++			virtqueue_notify(port->vtcport_invq);
++			vtcon_cn_rx_buf = NULL;
++		}
++		vtcon_cn_rx_buf = virtqueue_dequeue(port->vtcport_invq, &len);
++		if (vtcon_cn_rx_buf == NULL)
++			return (-1);
++		vtcon_cn_rx_off = 0;
++		vtcon_cn_rx_len = len;
++		if (len == 0) {
++			vtcon_port_requeue_buf(port, vtcon_cn_rx_buf);
++			virtqueue_notify(port->vtcport_invq);
++			vtcon_cn_rx_buf = NULL;
++			return (-1);
++		}
++	}
++
++	return ((u_char)vtcon_cn_rx_buf[vtcon_cn_rx_off++]);
++}
++
++static void
++vtcon_cngrab(struct consdev *cp)
++{
++	struct vtcon_port *port;
++
++	port = vtcon_cn_port;
++	if (port != NULL && port->vtcport_invq != NULL)
++		virtqueue_disable_intr(port->vtcport_invq);
++}
++
++static void
++vtcon_cnungrab(struct consdev *cp)
++{
++	struct vtcon_port *port;
++
++	port = vtcon_cn_port;
++	if (port == NULL || port->vtcport_invq == NULL)
++		return;
++
++	/* Return any partially-consumed buffer to the in queue. */
++	if (vtcon_cn_rx_buf != NULL) {
++		vtcon_port_requeue_buf(port, vtcon_cn_rx_buf);
++		virtqueue_notify(port->vtcport_invq);
++		vtcon_cn_rx_buf = NULL;
++	}
++
++	if (virtqueue_enable_intr(port->vtcport_invq) != 0)
++		virtqueue_notify(port->vtcport_invq);
++}
++
++/*
++ * Register a port as the system console.  Called for the sole port of a
++ * non-multiport device (from vtcon_attach) or for a port the host promotes to
++ * a console (from vtcon_ctrl_port_console_event).  The console is a singleton:
++ * the first such port wins.
++ */
++static void
++vtcon_setup_console(struct vtcon_port *port)
++{
++	struct consdev *cp;
++
++	if (vtcon_cn_port != NULL)
++		return;
++
++	cp = malloc(sizeof(*cp), M_DEVBUF, M_WAITOK | M_ZERO);
++	cp->cn_ops = &vtcon_cnops;
++	cp->cn_arg = port;
++	cp->cn_pri = CN_NORMAL;
++	snprintf(cp->cn_name, sizeof(cp->cn_name), "%s%r.%r", VTCON_TTY_PREFIX,
++	    device_get_unit(port->vtcport_sc->vtcon_dev), port->vtcport_id);
++
++	port->vtcport_flags |= VTCON_PORT_FLAG_CONSOLE;
++	vtcon_cn_port = port;
++	vtcon_cn_consdev = cp;
++
++	cnadd(cp);
++}
++
+ static void
+ vtcon_port_submit_event(struct vtcon_port *port, uint16_t event,
+     uint16_t value)
+@@ -1431,8 +1672,17 @@ vtcon_tty_outwakeup(struct tty *tp)
+ 	if (port->vtcport_flags & VTCON_PORT_FLAG_GONE)
+ 		return;
+ 
+-	while ((len = ttydisc_getc(tp, buf, sizeof(buf))) != 0)
+-		vtcon_port_out(port, buf, len);
++	while ((len = ttydisc_getc(tp, buf, sizeof(buf))) != 0) {
++		/*
++		 * The console port shares its out virtqueue with kernel
++		 * printf; serialize through vtcon_cn_emit().  Other ports have
++		 * no console contender and emit directly.
++		 */
++		if (port == vtcon_cn_port)
++			vtcon_cn_emit(port, buf, len);
++		else
++			vtcon_port_out(port, buf, len);
++	}
+ }
+ 
+ static void

--- a/patches/0011-arm64-detect-GIC-version-from-GICD_PIDR2-when-the-MADT-leaves-it-unspecified.patch
+++ b/patches/0011-arm64-detect-GIC-version-from-GICD_PIDR2-when-the-MADT-leaves-it-unspecified.patch
@@ -1,0 +1,88 @@
+From aabce0c8335937269679e51ea8f4e67824fcbb7f Mon Sep 17 00:00:00 2001
+From: networkextension <gbvbwbkjjx@privaterelay.appleid.com>
+Date: Mon, 6 Jul 2026 09:36:48 +0800
+Subject: [PATCH] arm64: detect GIC version from GICD_PIDR2 when the MADT
+ leaves it unspecified
+
+Apple's Virtualization.framework presents an arm64 guest via ACPI (no FDT)
+whose MADT GIC Distributor subtable reports Version 0
+(ACPI_MADT_GIC_VERSION_NONE) rather than 3.  gic_v3_acpi_identify() only
+accepts Version 3/4 and otherwise bails, so the GICv3 driver never attaches,
+the generic timer has no interrupt parent, and the kernel panics with
+"No usable event timer found!".  Detect the version from the distributor's
+GICD_PIDR2 register when it is left unspecified, as Linux does.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ sys/arm64/arm64/gic_v3_acpi.c | 37 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/sys/arm64/arm64/gic_v3_acpi.c b/sys/arm64/arm64/gic_v3_acpi.c
+index 88fd0394c548fd..1f01f5217f646e 100644
+--- a/sys/arm64/arm64/gic_v3_acpi.c
++++ b/sys/arm64/arm64/gic_v3_acpi.c
+@@ -43,6 +43,9 @@
+ #include <contrib/dev/acpica/include/acpi.h>
+ #include <dev/acpica/acpivar.h>
+ 
++#include <vm/vm.h>
++#include <vm/pmap.h>
++
+ #include "gic_v3_reg.h"
+ #include "gic_v3_var.h"
+ 
+@@ -169,6 +172,7 @@ gic_v3_acpi_identify(driver_t *driver, device_t parent)
+ 	struct madt_table_data madt_data;
+ 	ACPI_TABLE_MADT *madt;
+ 	vm_paddr_t physaddr;
++	int gic_version;
+ 	uintptr_t private;
+ 	device_t dev;
+ 
+@@ -194,8 +198,35 @@ gic_v3_acpi_identify(driver_t *driver, device_t parent)
+ 		goto out;
+ 	}
+ 
+-	/* Check the GIC version is supported by thiss driver */
+-	switch(madt_data.dist->Version) {
++	/*
++	 * Check the GIC version is supported by this driver. Some hypervisors
++	 * (e.g. Apple's Virtualization.framework) leave the MADT GIC version
++	 * unspecified (ACPI_MADT_GIC_VERSION_NONE); detect it from the
++	 * distributor's GICD_PIDR2 register in that case, as Linux does.
++	 */
++	gic_version = madt_data.dist->Version;
++	if (gic_version == ACPI_MADT_GIC_VERSION_NONE) {
++		void *dist_va;
++
++		dist_va = pmap_mapdev(madt_data.dist->BaseAddress, GICD_SIZE);
++		if (dist_va != NULL) {
++			uint32_t pidr2;
++
++			pidr2 = *(volatile uint32_t *)
++			    ((uintptr_t)dist_va + GICD_PIDR2);
++			switch (GICR_PIDR2_ARCH(pidr2)) {
++			case GICR_PIDR2_ARCH_GICv3:
++				gic_version = ACPI_MADT_GIC_VERSION_V3;
++				break;
++			case GICR_PIDR2_ARCH_GICv4:
++				gic_version = ACPI_MADT_GIC_VERSION_V4;
++				break;
++			}
++			pmap_unmapdev(dist_va, GICD_SIZE);
++		}
++	}
++
++	switch (gic_version) {
+ 	case ACPI_MADT_GIC_VERSION_V3:
+ 	case ACPI_MADT_GIC_VERSION_V4:
+ 		break;
+@@ -229,7 +260,7 @@ gic_v3_acpi_identify(driver_t *driver, device_t parent)
+ 		    rdist_map, &madt_data);
+ 	}
+ 
+-	private = madt_data.dist->Version;
++	private = gic_version;
+ 	/* Flag that the VGIC is in use */
+ 	if (madt_data.have_vgic)
+ 		private |= GICV3_PRIV_VGIC;

--- a/patches/README.md
+++ b/patches/README.md
@@ -29,3 +29,18 @@ git -C /path/to/nextbsd-kernel commit -am "patch: my change" && git push
 A push that only touches `patches/**` or `config/**` builds the **kernel**
 but does **not** trigger a module rebuild — that only happens when the
 toolchain/upstream source actually changes (`repository_dispatch`).
+
+## Third-party patches
+
+Patches not authored here keep their original `From:` line so authorship and
+provenance survive. Record where they came from below, and re-check them when
+the base branch moves &mdash; they are carried, not owned.
+
+| patch | origin | upstream status |
+|---|---|---|
+| `0010-virtio_console-*` | `networkextension/freebsd-src` @ `cf50f191e`, branch `apple-vz-virtio-console` | not submitted |
+| `0011-arm64-detect-GIC-version-*` | `networkextension/freebsd-src` @ `aabce0c83`, branch `apple-vz-gic-version-none` | not submitted |
+
+Both are required to boot under Apple's Virtualization.framework. Verified to
+apply cleanly to `releng/15.0` and to reference only symbols present there
+(`GICD_PIDR2`, `GICR_PIDR2_ARCH_*`, `cnadd(9)`).

--- a/patches/series
+++ b/patches/series
@@ -7,3 +7,5 @@
 0007-unionfs-layer-tagged-fileid.patch
 0008-NextBSD-enable-unprivileged-mounts-vfs-usermount-1.patch
 0009-NextBSD-default-elf64-fallback_brand-to-ELFOSABI_LINU.patch
+0010-virtio_console-register-a-low-level-console-for-the-console-port.patch
+0011-arm64-detect-GIC-version-from-GICD_PIDR2-when-the-MADT-leaves-it-unspecified.patch


### PR DESCRIPTION
Two carried patches that get NextBSD/arm64 booting under Apple's Virtualization.framework. Both are **guest-side only**, and no config change is needed — arm64 `GENERIC` already includes `std.virt` at line 45, which is where `device virtio_console` lands.

| patch | fixes | size |
|---|---|---|
| `0010-virtio_console-*` | kernel `printf` cannot reach VZ's only console | +252/−2, +1 |
| `0011-arm64-detect-GIC-version-*` | `panic: No usable event timer found!` | +34/−3 |

## Why each is needed

**0010 — virtio_console consdev.** `vtcon(4)` ends at `tty_makedev()`, so it publishes `/dev/ttyV0.x` and never registers a `consdev`; the kernel console layer doesn't know it exists. On VZ that is fatal rather than inconvenient, because it is the *only* console a guest can have. Measured here on macOS 26.5.2:

- `gop list` at the loader → `gop: Graphics Output Protocol not present` — so `vt_efifb` can never attach
- VZ exposes no UART through public API, and its ACPI carries no SPCR and no DBG2 — so `uart(4)` has nothing to attach to either
- A Linux guest's device tree from the same host has **no serial node at all**

Without this, the kernel boots blind and every failure looks identical.

**0011 — GIC version from `GICD_PIDR2`.** VZ's MADT reports GIC Distributor `Version 0` (`ACPI_MADT_GIC_VERSION_NONE`). `gic_v3_acpi_identify()` accepts only 3 or 4 and otherwise bails, so GICv3 never attaches, the generic timer has no interrupt parent, and the kernel panics. The patch probes the distributor instead, as Linux does.

## Evidence

Gathered locally 2026-08-18 (Apple Silicon, macOS 26.5.2):

- **Stock FreeBSD 16.0-CURRENT arm64 fails identically to NextBSD** — loader menu renders, `Loading kernel…`, then two vCPUs pegged at 199 % with no DHCP for 151 s+. This is upstream, not ours; rebasing cannot fix it.
- **A Linux guest booted under the same harness** and dumped VZ's DTB: `arm,gic-v3`, `psci` method `hvc`, virtual timer at INTID 27 (PPI 11), RAM at `0x70000000`, PL031 at `0x20050000`, PL061 at `0x20060000` — and no serial node. Independently consistent with `acpi.rsdp = 0xefbf0018` read from FreeBSD's own loader.
- Both patches **apply cleanly to `releng/15.0`** and reference only symbols present there: `GICD_PIDR2`, `GICR_PIDR2_ARCH_*`, `cnadd(9)`/`cnremove(9)`.

## Provenance — please read before merging

These are **carried, not authored here**: `networkextension/freebsd-src`, branches `apple-vz-virtio-console` (`cf50f191e`) and `apple-vz-gic-version-none` (`aabce0c83`). Kept verbatim so the original `From:` survives, and recorded in a new "Third-party patches" table in `patches/README.md`.

Caveats worth weighing:

- Neither is submitted upstream, both are single-author on branches in a personal fork, and both carry `Co-Authored-By: Claude Opus 4.8` in their commit messages. They are not battle-tested.
- **We have not independently verified the MADT claim.** Our DTB proves the *hardware* is GICv3; the assertion is about what VZ's *MADT* reports, which needs an EFI-path ACPI dump we have not done. The claim is consistent with the 199 % spin we measured, but the evidence is theirs.
- Worth offering both upstream rather than carrying them indefinitely.

## Not covered here

Apple's virtual **xHCI aborts the whole VMM** when a guest writes a register it does not model (`Security Assertion Hit` → `__os_crash` → `brk #0x1` on the vCPU thread), and FreeBSD's `xhci(4)` does exactly that. Any VZ front-end that attaches a keyboard — including `swift-vm-cli`, which sets `keyboards`/`pointingDevices`/USB mass storage — still kills the VM. Headless configs are unaffected. Fixing that needs either a VZ-detection quirk or finding the offending write; neither exists in any tree yet.

Full write-up: https://pkgdemon.github.io/nextbsd-apple-virtualization-plan.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)