### PR TITLE
patches: stop virtio_gpu(4) spinning forever at attach

### DIFF
--- a/patches/0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch
+++ b/patches/0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch
@@ -1,9 +1,9 @@
-From 50dea6d0640169718c9a9eefec2021304d677800 Mon Sep 17 00:00:00 2001
+From 61ff913fb918ed7f0733d1f13fbaa633b6d7c3ee Mon Sep 17 00:00:00 2001
 From: pkgdemon <jpm820@gmail.com>
-Date: Tue, 18 Aug 2026 18:55:32 -0500
+Date: Tue, 18 Aug 2026 18:59:06 -0500
 Subject: [PATCH] virtio_gpu: bound the attach-time control-queue wait
 
-vtgpu_req_resp() ends in virtqueue_poll(9), an unbounded busy-wait. Every
+vtgpu_req_resp2() ends in virtqueue_poll(9), an unbounded busy-wait. Every
 caller runs from vtgpu_attach(), so a device that never completes a control
 request wedges a CPU during boot -- no console, no timeout, no recovery.
 Apple's Virtualization.framework does exactly that: the first
@@ -11,10 +11,10 @@ VIRTIO_GPU_CMD_GET_DISPLAY_INFO never completes and the guest spins two vCPUs
 at 100% indefinitely, which is currently enough to stop FreeBSD/arm64 booting
 there at all (reproduced on stock 16.0-CURRENT as well as a downstream kernel).
 
-Poll with a 5 second bound instead, and reset the device on timeout: req and
-resp are stack-allocated by the callers, so a late completion would write into
-a stack frame that no longer exists. Attach then fails cleanly and the machine
-carries on booting without a virtio-gpu console.
+Poll with a 5 second bound instead, and reset the device on timeout: the
+request and response buffers are stack-allocated by the callers, so a late
+completion would write into a stack frame that no longer exists. Attach then
+fails cleanly and the machine carries on booting without a virtio-gpu console.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 ---
@@ -22,7 +22,7 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
  1 file changed, 33 insertions(+), 3 deletions(-)
 
 diff --git a/sys/dev/virtio/gpu/virtio_gpu.c b/sys/dev/virtio/gpu/virtio_gpu.c
-index 6f786a4..ddc1c0a 100644
+index b95bae9..d57ec9e 100644
 --- a/sys/dev/virtio/gpu/virtio_gpu.c
 +++ b/sys/dev/virtio/gpu/virtio_gpu.c
 @@ -444,13 +444,21 @@ vtgpu_alloc_virtqueue(struct vtgpu_softc *sc)
@@ -30,7 +30,7 @@ index 6f786a4..ddc1c0a 100644
  }
  
 +/*
-+ * How long vtgpu_req_resp() waits for the device before giving up. Polled,
++ * How long vtgpu_req_resp2() waits for the device before giving up. Polled,
 + * pre-interrupt, at attach time only, so a generous bound costs nothing on a
 + * working device and bounds the damage on a broken one.
 + */
@@ -38,17 +38,17 @@ index 6f786a4..ddc1c0a 100644
 +#define	VTGPU_POLL_INTERVAL_US	10
 +
  static int
- vtgpu_req_resp(struct vtgpu_softc *sc, void *req, size_t reqlen,
-     void *resp, size_t resplen)
+ vtgpu_req_resp2(struct vtgpu_softc *sc, void *req1, size_t req1len,
+     void *req2, size_t req2len, void *resp, size_t resplen)
  {
  	struct sglist sg;
- 	struct sglist_seg segs[2];
--	int error;
-+	int error, i;
+ 	struct sglist_seg segs[3];
+-	int error, rcount;
++	int error, i, rcount;
  
- 	sglist_init(&sg, 2, segs);
+ 	sglist_init(&sg, 3, segs);
  
-@@ -474,9 +482,31 @@ vtgpu_req_resp(struct vtgpu_softc *sc, void *req, size_t reqlen,
+@@ -486,9 +494,31 @@ vtgpu_req_resp2(struct vtgpu_softc *sc, void *req1, size_t req1len,
  	}
  
  	virtqueue_notify(sc->vtgpu_ctrl_vq);
@@ -63,9 +63,9 @@ index 6f786a4..ddc1c0a 100644
 +	 * and no way out. Observed on Apple's Virtualization.framework, where
 +	 * the first VIRTIO_GPU_CMD_GET_DISPLAY_INFO never completes.
 +	 *
-+	 * Reset the device on timeout: req and resp are stack-allocated by the
-+	 * callers, so a late completion would otherwise write into a stack
-+	 * frame that no longer exists.
++	 * Reset the device on timeout: the request and response buffers are
++	 * stack-allocated by the callers, so a late completion would otherwise
++	 * write into a stack frame that no longer exists.
 +	 */
 +	for (i = 0; i < VTGPU_POLL_TIMEOUT_US; i += VTGPU_POLL_INTERVAL_US) {
 +		if (virtqueue_dequeue(sc->vtgpu_ctrl_vq, NULL) != NULL)

--- a/patches/0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch
+++ b/patches/0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch
@@ -1,0 +1,87 @@
+From 50dea6d0640169718c9a9eefec2021304d677800 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Tue, 18 Aug 2026 18:55:32 -0500
+Subject: [PATCH] virtio_gpu: bound the attach-time control-queue wait
+
+vtgpu_req_resp() ends in virtqueue_poll(9), an unbounded busy-wait. Every
+caller runs from vtgpu_attach(), so a device that never completes a control
+request wedges a CPU during boot -- no console, no timeout, no recovery.
+Apple's Virtualization.framework does exactly that: the first
+VIRTIO_GPU_CMD_GET_DISPLAY_INFO never completes and the guest spins two vCPUs
+at 100% indefinitely, which is currently enough to stop FreeBSD/arm64 booting
+there at all (reproduced on stock 16.0-CURRENT as well as a downstream kernel).
+
+Poll with a 5 second bound instead, and reset the device on timeout: req and
+resp are stack-allocated by the callers, so a late completion would write into
+a stack frame that no longer exists. Attach then fails cleanly and the machine
+carries on booting without a virtio-gpu console.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+---
+ sys/dev/virtio/gpu/virtio_gpu.c | 36 ++++++++++++++++++++++++++++++---
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/sys/dev/virtio/gpu/virtio_gpu.c b/sys/dev/virtio/gpu/virtio_gpu.c
+index 6f786a4..ddc1c0a 100644
+--- a/sys/dev/virtio/gpu/virtio_gpu.c
++++ b/sys/dev/virtio/gpu/virtio_gpu.c
+@@ -444,13 +444,21 @@ vtgpu_alloc_virtqueue(struct vtgpu_softc *sc)
+ 	return (virtio_alloc_virtqueues(dev, nvqs, vq_info));
+ }
+ 
++/*
++ * How long vtgpu_req_resp() waits for the device before giving up. Polled,
++ * pre-interrupt, at attach time only, so a generous bound costs nothing on a
++ * working device and bounds the damage on a broken one.
++ */
++#define	VTGPU_POLL_TIMEOUT_US	5000000
++#define	VTGPU_POLL_INTERVAL_US	10
++
+ static int
+ vtgpu_req_resp(struct vtgpu_softc *sc, void *req, size_t reqlen,
+     void *resp, size_t resplen)
+ {
+ 	struct sglist sg;
+ 	struct sglist_seg segs[2];
+-	int error;
++	int error, i;
+ 
+ 	sglist_init(&sg, 2, segs);
+ 
+@@ -474,9 +482,31 @@ vtgpu_req_resp(struct vtgpu_softc *sc, void *req, size_t reqlen,
+ 	}
+ 
+ 	virtqueue_notify(sc->vtgpu_ctrl_vq);
+-	virtqueue_poll(sc->vtgpu_ctrl_vq, NULL);
+ 
+-	return (0);
++	/*
++	 * Bounded wait. virtqueue_poll(9) is an unbounded busy-wait
++	 * (while (virtqueue_dequeue(...) == NULL) cpu_spinwait();), and every
++	 * caller of this function runs from vtgpu_attach(), so a device that
++	 * never completes the request wedges a CPU during boot with no console
++	 * and no way out. Observed on Apple's Virtualization.framework, where
++	 * the first VIRTIO_GPU_CMD_GET_DISPLAY_INFO never completes.
++	 *
++	 * Reset the device on timeout: req and resp are stack-allocated by the
++	 * callers, so a late completion would otherwise write into a stack
++	 * frame that no longer exists.
++	 */
++	for (i = 0; i < VTGPU_POLL_TIMEOUT_US; i += VTGPU_POLL_INTERVAL_US) {
++		if (virtqueue_dequeue(sc->vtgpu_ctrl_vq, NULL) != NULL)
++			return (0);
++		DELAY(VTGPU_POLL_INTERVAL_US);
++	}
++
++	device_printf(sc->vtgpu_dev,
++	    "timed out after %d ms waiting for the device to complete a "
++	    "control-queue request; disabling\n", VTGPU_POLL_TIMEOUT_US / 1000);
++	virtio_stop(sc->vtgpu_dev);
++
++	return (ETIMEDOUT);
+ }
+ 
+ static int
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -8,3 +8,4 @@
 0008-NextBSD-enable-unprivileged-mounts-vfs-usermount-1.patch
 0009-NextBSD-default-elf64-fallback_brand-to-ELFOSABI_LINU.patch
 0010-virtio_console-register-a-low-level-console-for-the-console-port.patch
+0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch


### PR DESCRIPTION
Found while chasing the Apple VZ boot failure, but it is a plain base FreeBSD robustness bug, and it is **measured working**.

## The bug

`vtgpu_req_resp2()` (15.1; `vtgpu_req_resp()` in 15.0) finishes with `virtqueue_poll(9)`, which is literally:

```c
while ((cookie = virtqueue_dequeue(vq, len)) == NULL)
        cpu_spinwait();
```

with no bound — and every caller runs from `vtgpu_attach()`. A virtio-gpu that does not answer therefore wedges a CPU during boot, with no console, no timeout and no recovery.

## Evidence

Measured on macOS 26.5.2 / Apple Silicon under Virtualization.framework. Every kernel containing `virtio_gpu(4)` pegs two vCPUs at 199 % and never boots — NextBSD stock, NextBSD patched, **and stock FreeBSD 16.0-CURRENT alike**. A kernel built `nodevice virtio_gpu` does not spin, which is what isolated it to this driver. Apple's device never completes the first `VIRTIO_GPU_CMD_GET_DISPLAY_INFO`.

With this patch, on the same host:

```
t=5s   cpu=199.1%      <- the poll, now bounded
t=11s  cpu=1.1%        <- 5s timeout fires, attach fails, boot continues
t=16s+ cpu=0.2%
```

## The patch

Poll with a 5 second bound, and **reset the device on timeout** — the request and response buffers are stack-allocated by the callers, so a late completion would write into a stack frame that no longer exists. Attach then fails cleanly and the machine carries on without a virtio-gpu console.

Rebased onto `releng/15.1` (the branch this repo's workflow builds against — 15.1 restructured the function into `vtgpu_req_resp2()` with a three-segment sglist; the unbounded poll is unchanged). Verified `git apply --check` clean and built green on arm64.

## Worth sending upstream

Nothing about this is Apple-specific: the same hang is reachable on any host whose virtio-gpu stops responding, and "device stops answering ⇒ kernel wedges at boot" is a bug on its own terms. I'd offer it to freebsd-virtualization@ rather than carry it indefinitely.

## What it does *not* fix

NextBSD still does not boot under VZ. Removing the spin exposes a **second, earlier failure**: the guest then sits idle at 0.2 % with no console output and no DHCP. That one is unidentified and needs the PSCI-tracer approach, since the guest is mute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)