### PR TITLE
patches: give lkpinew_pci_dev() DMA tags

### DIFF
--- a/patches/0012-linuxkpi-give-lkpinew_pci_dev-DMA-tags.patch
+++ b/patches/0012-linuxkpi-give-lkpinew_pci_dev-DMA-tags.patch
@@ -1,0 +1,66 @@
+From 0ae76e043281ba0d254c4c2fd444d45a7ba9eaed Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 19 Aug 2026 07:16:43 -0500
+Subject: [PATCH] linuxkpi: give lkpinew_pci_dev() DMA tags
+
+lkpinew_pci_dev() wraps a device that some other, native driver attached so
+that LinuxKPI code can use it -- a vendored DRM driver sitting on FreeBSD's
+own virtio_pci(4), for instance. Such code legitimately calls dma_map_sg(),
+dma_map_sgtable() and friends.
+
+It never ran linux_pdev_dma_init(), so dev.dma_priv stayed NULL and any of
+those calls dereferenced it:
+
+  Fatal data abort ... far: 0x0000000000000038 esr: 0x0000000096000004
+  panic: vm_fault failed: linux_dma_map_sg_attrs+0x64
+
+A null-pointer panic rather than an error return, and callers cannot tell a
+pci_dev that can do DMA from one that cannot. Initialise the tags here as
+linux_pci_attach_common() does, and release them in
+lkpinew_pci_dev_release().
+
+Found on arm64 with a vendored virtio-gpu DRM driver whose shmem GEM
+objects are mapped with dma_map_sgtable().
+---
+ sys/compat/linuxkpi/common/src/linux_pci.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/src/linux_pci.c b/sys/compat/linuxkpi/common/src/linux_pci.c
+index c4f0564..87c2f8c 100644
+--- a/sys/compat/linuxkpi/common/src/linux_pci.c
++++ b/sys/compat/linuxkpi/common/src/linux_pci.c
+@@ -417,6 +417,8 @@ lkpinew_pci_dev_release(struct device *dev)
+ 		free(pdev->msi_desc, M_DEVBUF);
+ 	}
+ 	kfree(pdev->path_name);
++	if (pdev->dev.dma_priv != NULL)
++		linux_pdev_dma_uninit(pdev);
+ 	free(pdev, M_DEVBUF);
+ }
+ 
+@@ -434,6 +436,22 @@ lkpinew_pci_dev(device_t dev)
+ 	}
+ 	pdev->dev.release = lkpinew_pci_dev_release;
+ 
++	/*
++	 * Set up the DMA tags, exactly as linux_pci_attach_common() does for a
++	 * device LinuxKPI attached itself. Without this dev.dma_priv is NULL
++	 * and every dma_map_*() on the returned pci_dev dereferences it, which
++	 * is a null-pointer panic rather than an error return -- and callers
++	 * have no way to tell the two kinds of pci_dev apart.
++	 *
++	 * lkpinew_pci_dev() exists to wrap a device some other (native) driver
++	 * attached, so that LinuxKPI code such as a vendored DRM driver can use
++	 * it. Such code legitimately calls dma_map_sgtable() and friends.
++	 */
++	if (linux_pdev_dma_init(pdev) != 0) {
++		lkpinew_pci_dev_release(&pdev->dev);
++		return (NULL);
++	}
++
+ 	return (pdev);
+ }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -9,3 +9,4 @@
 0009-NextBSD-default-elf64-fallback_brand-to-ELFOSABI_LINU.patch
 0010-virtio_console-register-a-low-level-console-for-the-console-port.patch
 0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch
+0012-linuxkpi-give-lkpinew_pci_dev-DMA-tags.patch


### PR DESCRIPTION
A `pci_dev` manufactured for a natively-attached device gets no DMA tags, so **any** `dma_map_*()` on it is a null-pointer panic rather than an error return — and callers have no way to tell such a `pci_dev` from a working one.

```c
lkpinew_pci_dev(device_t dev)
{
        ...
        error = lkpifill_pci_dev(dev, pdev);
        pdev->dev.release = lkpinew_pci_dev_release;
        /* never calls linux_pdev_dma_init(), so dev.dma_priv stays NULL */
```

`linux_pdev_dma_init()` is `static` and only runs from `linux_pci_attach_common()`, i.e. when LinuxKPI attached the device itself. But `lkpinew_pci_dev()` exists precisely to wrap a device *another* driver attached, so LinuxKPI code can use it — and that code legitimately calls `dma_map_sgtable()`.

## How it showed up

The virtio-gpu DRM kext sits on FreeBSD's native `virtio_pci(4)`. Enabling its shmem fbdev console made `drm_gem_shmem_get_pages_sgt()` map pages for the first time:

```
[drm] Initialized virtio_gpu 0.1.0 for virtio_pci1 on minor 0
Fatal data abort ... far: 0x0000000000000038  esr: 0x0000000096000004
panic: vm_fault failed: 0xffff0000007bcd14 error 1
  -> linux_dma_map_sg_attrs+0x64
```

Working around it in the kext (skipping the mapping) removed the panic but left the host scanning out **garbage** — the mapping carries bus/cache synchronisation as well as address translation. With the tags in place the workarounds are reverted and the console renders correctly:

```
VT: Replacing driver "virtio_gpu" with new "drmfb".
/dev/dri/card0  /dev/dri/renderD128
=== NEXTBSD DRMFB CONSOLE TEST LINE 3 ===      <- legible on the guest display
```

## The change

Call `linux_pdev_dma_init()` in `lkpinew_pci_dev()` and release the tags in `lkpinew_pci_dev_release()`. 18 lines, `releng/15.1`, built green on arm64 and amd64.

Carried in `patches/` like the rest of the series. Nothing here is NextBSD-specific in nature, but it lives with us — re-check it whenever the base branch moves, since it touches a `static` helper's caller in `linux_pci.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
