### PR TITLE
config: bake snd_hda so emulated HDA audio attaches on arm64

### DIFF
--- a/config/NEXTBSD
+++ b/config/NEXTBSD
@@ -201,3 +201,37 @@ options 	IICHID_SAMPLING
 # a stock config token (sys/conf/files:3192, sys/conf/NOTES:2137), valid on
 # amd64 and arm64 alike -- one line covers the shared config for both.
 device		snd_uaudio
+
+# PCI HDA audio. The companion to snd_uaudio above, and the same unbaked-leaf
+# problem one bus over: arm64's std.dev:107 bakes `device sound` -- the pcm
+# core, the feeder chain, /dev/sndstat -- but unlike amd64 GENERIC it bakes
+# none of the PCI leaves that bind actual controllers. snd_hda is the one that
+# matters here, because it is what every hypervisor emits by default.
+#
+# Measured on virt-10-0 (arm64, UTM/qemu, 20260819-200048) before this change:
+#
+#   none0@pci0:0:3:0:  vendor=0x8086 device=0x2668
+#       'Intel 82801FB/FBM/FR/FW/FRW (ICH6 Family) HD Audio Controller'
+#   pci0: <multimedia, HDA> at device 3.0 (no driver attached)
+#   # cat /dev/sndstat
+#   No devices installed.
+#
+# UTM emits ich6-intel-hda for every guest regardless of arch -- an arm64 VM
+# gets the same emulated Intel controller a Linux x86 guest does -- so this is
+# the default-configuration path, not an exotic one. The hw.snd.* sysctl tree
+# is already fully populated on that box; the framework is present and idle,
+# waiting for a leaf driver that was never compiled in.
+#
+# kldload is not an escape hatch: ci/assemble-image.sh:168 rm's the .ko tree,
+# so /boot/kernel on a shipped image holds exactly one file (`kernel`) and the
+# userland has no kldstat at all. Anything that must attach has to be static.
+#
+# snd_hda is declared in the MI sys/conf/files (dev/sound/pci/hda/*.c, optional
+# snd_hda pci), not files.amd64, so the token is valid on arm64 and the driver
+# builds there. Its MODULE_DEPENDs are sound and pci, both already compiled in
+# on both arches -- purely additive, and it cannot regress the USB path above.
+#
+# Not virtio-sound: FreeBSD base ships no virtio_snd driver, and qemu does not
+# put a virtio-sound device on the bus here anyway (net, gpu, block, console
+# and rng are the only virtio functions present). HDA is the supported path.
+device		snd_hda


### PR DESCRIPTION
## What

One line in `config/NEXTBSD`: `device snd_hda`, plus the comment block explaining why, in the same style as the `snd_uaudio` entry directly above it.

## Why

arm64's `std.dev` bakes `device sound` — the pcm core, feeder chain, `/dev/sndstat` — but unlike amd64 `GENERIC` it bakes none of the PCI leaf drivers. The result is that the Intel HDA controller every hypervisor emits by default sits on the bus with nothing to claim it.

Measured on `virt-10-0` (arm64, UTM/qemu, kernel `20260819-200048`) **before** this change:

```
none0@pci0:0:3:0:  vendor=0x8086 device=0x2668
    'Intel 82801FB/FBM/FR/FW/FRW (ICH6 Family) HD Audio Controller'
pci0: <multimedia, HDA> at device 3.0 (no driver attached)

# cat /dev/sndstat
No devices installed.
No devices installed from userspace.
```

The framework is present and idle on that box — the full `hw.snd.*` sysctl tree is populated — it simply has no driver to bind `pci0:0:3:0`.

UTM emits `ich6-intel-hda` for every guest regardless of guest architecture, so an arm64 VM gets the same emulated Intel controller an x86 Linux guest does. This is the default-configuration path, not an exotic one.

## Why it has to be static

`kldload` is not an option here: `ci/assemble-image.sh:168` removes the `.ko` tree, so a shipped image has exactly one file in `/boot/kernel` (`kernel`) and no `kldstat` in the userland at all. This is the same constraint that forced `snd_uaudio` static, one bus over.

## Why it is safe

`snd_hda` is declared in the MI `sys/conf/files` (`dev/sound/pci/hda/*.c optional snd_hda pci`), not `files.amd64`, so the token is valid on arm64 and the driver builds there. Its `MODULE_DEPEND`s are `sound` and `pci`, both already compiled in on both arches. Purely additive; it cannot regress the USB audio path above it.

## Not virtio-sound

FreeBSD base ships no `virtio_snd` driver, and qemu puts no virtio-sound device on the bus here regardless — net, gpu, block, console and rng are the only virtio functions present. HDA is the supported path.

## Verification status

- **Measured:** the unclaimed controller and idle sound framework on `virt-10-0`, quoted above.
- **Reasoned, not yet measured:** that `snd_hda` builds clean for arm64, and that `hdac0` actually attaches and produces a pcm device under qemu's emulated ICH6.

Holding for CI to build, then installing the `nextbsd-kernel-arm64` branch artifact on `virt-10-0` and reporting the post-change `pciconf` / `/dev/sndstat` output before this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)