### PR TITLE
rpi500: move the console to UART10, the internal debug connector

### DIFF
--- a/config/NEXTBSD-RPI500
+++ b/config/NEXTBSD-RPI500
@@ -8,17 +8,17 @@
 # until a bcm2712-pcie driver exists (phase 3). Until then the early console
 # is the only console, and it needs a compile-time address.
 #
-# SOCDEV_PA is the address the FIRMWARE maps RP1 at. Measured on the board,
-# from the bootloader's own first line over serial:
+# SOCDEV_PA is UART10, the PL011 inside the BCM2712, reached through the 3-pin
+# JST-SH debug connector on the main board. Confirmed on the hardware: Linux
+# reports `107d001000.serial: ttyAMA10 ... is a PL011 rev3`, and the serial10
+# alias resolves to /soc@107c000000/serial@7d001000 -- soc@, not pcie@.
 #
-#     RP1_UART 0000001c00030000
-#
-# Linux reports 0x1f00030000 for the same register block, and the native-boot
-# plan originally specified that -- but 0x1f is the window Linux programs
-# AFTER it brings up PCIe. A kernel loaded directly by the firmware (route
-# (a): no loader, no UEFI) inherits the firmware's window, so 0x1c00030000 is
-# what is live at kernel entry. Using 0x1f here produces a kernel that runs
-# correctly and prints into unmapped space -- indistinguishable from a hang.
+# This was 0x1c00030000 (RP1 UART0, the 40-pin header) until that connector was
+# found. Two reasons it moved. RP1 is behind PCIe, so that console dies the
+# moment a driver owns the controller -- fatal for the RP1 work itself, since a
+# working driver then looks exactly like a dead one. And UART10 is audible
+# earlier: it carries the boot ROM and SDRAM training, which the header never
+# saw.
 #
 # locore.S maps one 2MB device block at SOCDEV_PA and keeps the offset within
 # it, so the exact register address is the right value to give here.
@@ -27,7 +27,7 @@ include NEXTBSD
 
 ident		NEXTBSD-RPI500
 
-options 	SOCDEV_PA=0x1c00030000
+options 	SOCDEV_PA=0x107d001000
 options 	EARLY_PRINTF=pl011
 
 # A real console for the whole boot, not just the early window. SOCDEV_PA above

--- a/config/rpi500.env
+++ b/config/rpi500.env
@@ -1,22 +1,30 @@
 # Static kernel environment for the Raspberry Pi 500+ bring-up kernel.
 #
 # Route (a) boots the kernel straight from the Pi firmware, so there is no
-# loader and no loader.conf -- a compiled-in environment is the only way to
-# set a tunable. config(5)'s `env` directive exists for exactly this.
+# loader and no loader.conf -- a compiled-in environment is the only way to set
+# a tunable. config(5)'s `env` directive exists for exactly this.
 #
-# Why this is needed at all: cninit() selects the console the FDT advertises,
-# which on this board is RP1 UART0 behind PCIe. Nothing can drive that until a
-# bcm2712-pcie driver exists (phase 3), so the kernel goes mute the moment it
-# would start talking. hw.uart.console overrides the FDT and points uart(4) at
-# the same PL011 the firmware left mapped -- a real console with a durable
-# mapping, unlike EARLY_PRINTF's socdev_va, which dies with the early
-# pagetables.
+# This points uart(4) at UART10, the PL011 inside the BCM2712 itself, reached
+# through the 3-pin JST-SH debug connector on the main board.
+#
+# It used to point at 0x1c00030000, which is RP1 UART0 on the 40-pin header --
+# the only console we had until the internal connector was found. That one is
+# behind PCIe, so it dies the instant a driver takes ownership of the
+# controller, and a working driver becomes indistinguishable from a dead one.
+# Since everything worth driving on this board hangs off RP1, that was a hard
+# block rather than an inconvenience. UART10 is in the SoC and does not care
+# what PCIe is doing.
+#
+# The FDT does name a console, but the ordinary path cannot reach it: on this
+# board /chosen/stdout-path is RP1 UART0 unless dtparam=uart0_console is
+# dropped, and nothing can drive that until bcm2712-pcie exists. Overriding
+# here is what makes the kernel audible at all.
 #
 # Every tag is load-bearing (sys/dev/uart/uart_subr.c:uart_getenv):
-#   mm: memory-mapped address. 0x1c00030000 is the FIRMWARE's RP1 window,
-#       measured from the bootloader's own "RP1_UART 0000001c00030000" and
-#       confirmed by booting Linux with earlycon there. Linux's 0x1f00030000
-#       is the window it reprograms later and is NOT live at kernel entry.
+#   mm: memory-mapped address. 0x107d001000 -- confirmed on the board, both
+#       from Linux (`107d001000.serial: ttyAMA10 ... is a PL011 rev3`) and from
+#       the device tree alias serial10 -> /soc@107c000000/serial@7d001000.
+#       Note `soc@`, not `pcie@`.
 #   dt: the uart class. uart_cpu_getdev() defaults to uart_ns8250_class, so
 #       without this an ns8250 driver is pointed at a PL011 -- garbage output
 #       rather than none.
@@ -26,4 +34,4 @@
 #   xo: rclk. 0 sets bas.rclk_guess, telling the driver to keep the divisor the
 #       firmware already programmed instead of recomputing the baud from an
 #       rclk we do not know.
-hw.uart.console="mm:0x1c00030000,br:115200,dt:pl011,rs:2,rw:4,xo:0"
+hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:0"

--- a/patches/0014-arm64-locore-load-SOCDEV_PA-as-a-literal.patch
+++ b/patches/0014-arm64-locore-load-SOCDEV_PA-as-a-literal.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sun, 23 Aug 2026 15:30:00 -0500
+Subject: [PATCH] arm64 locore: load SOCDEV_PA as a literal, not a mov immediate
+
+SOCDEV_PA's 2 MiB-aligned base is materialised with
+
+    mov x9, #(SOCDEV_PA & ~L2_OFFSET)
+
+which only assembles when that value happens to fit a single arm64 mov
+immediate -- one 16-bit field, optionally shifted. That is an accident
+of the address, not a property of the mechanism.
+
+It held for the addresses this had been used with so far. It does not
+hold for the Raspberry Pi 500+'s UART10 at 0x107d001000, whose base
+0x107d000000 needs two 16-bit fields (0x7d00 << 16 and 0x10 << 32) and
+therefore a MOVZ/MOVK pair:
+
+    locore.S:762: error: expected compatible register or logical immediate
+     mov x9, #(0x107d001000 & ~(((1) << 21) - 1))
+
+Use `ldr xN, =expr` instead, which the assembler materialises via the
+literal pool and which places no constraint on the value. The block
+already uses exactly that form two lines above for L2_SIZE, so this is
+the same idiom rather than a new one.
+
+No functional change for any address that assembled before.
+---
+--- a/sys/arm64/arm64/locore.S
++++ b/sys/arm64/arm64/locore.S
+@@ -759,7 +759,7 @@
+ 	adrp	x9, socdev_va
+ 	str	x17, [x9, :lo12:socdev_va]
+ 
+-	mov	x9, #(SOCDEV_PA & ~L2_OFFSET)	/* PA start */
++	ldr	x9, =(SOCDEV_PA & ~L2_OFFSET)	/* PA start */
+ 	mov	x10, #1
+ 	bl	build_l2_block_pagetable
+ #endif

--- a/patches/series
+++ b/patches/series
@@ -11,3 +11,4 @@
 0011-virtio_gpu-bound-the-attach-time-control-queue-wait.patch
 0012-linuxkpi-give-lkpinew_pci_dev-DMA-tags.patch
 0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
+0014-arm64-locore-load-SOCDEV_PA-as-a-literal.patch


### PR DESCRIPTION
Closes #80. Unblocks #81 and #84.

The Pi 500+ has a 3-pin JST-SH debug connector on the main board, above the 40-pin header. No teardown showing it had ever been published, and this repo concluded twice that it was not fitted — I zoomed past it in photos and called it a crystal. It was found by opening the case and looking.

## What it changes

`hw.uart.console` and `SOCDEV_PA` move from `0x1c00030000` (RP1 UART0, on the 40-pin header, **behind PCIe**) to `0x107d001000` (UART10, **inside the BCM2712**).

That was a hard block, not an inconvenience. Writing the RP1 driver means resetting the PCIe link RP1 lives on, and on the old console the board simply goes silent at the first reset — a working driver and a dead one look identical. Everything that makes this machine usable hangs off RP1: ethernet, both USB controllers, the keyboard.

## Measured, with the overlay removed

Both controllers now attach and the kernel keeps talking:

```
pcib0: <BCM2838/BCM2712-compatible PCI-express controller> mem 0x1000110000 irq 50,51
pci1: <PCI bus> on pcib1
nda0: <XP1000F256G V1.28 QDT2014102964>
pcib2: <BCM2838/BCM2712-compatible PCI-express controller> mem 0x1000120000 irq 52,53
pcib3: <PCI-PCI bridge> irq 74 at device 0.0 on pci2
pci3: <network, ethernet> at device 0.0 (no driver attached)     <- RP1
Release APs...done
mountroot>
```

`pcib2` is the controller that silently killed the board earlier today. The `nopcie2` device-tree overlay that was masking it off is gone.

It is also simply a better console: this capture starts at the boot ROM and includes SDRAM training, OTP, USB-PD negotiation and TF-A’s `BL31` banner, none of which ever reached the 40-pin header.

## The locore patch

Moving the address broke the build:

```
locore.S:762: error: expected compatible register or logical immediate
 mov x9, #(0x107d001000 & ~(((1) << 21) - 1))
```

`locore` materialises `SOCDEV_PA`’s aligned base with a `mov` immediate, which only assembles when the value fits one 16-bit field. The old address got away with it by luck (`0x1c << 32`); UART10’s base needs two fields. Switched to `ldr xN, =expr`, the same idiom the block already uses two lines earlier for `L2_SIZE`.

Worth noting it failed at **build** time. Had it assembled with a wrong address it would have surfaced as a silent board — the exact failure mode this whole exercise exists to eliminate.