### PR TITLE
rpi500: MSI, inbound DMA windows, and the bus view of memory

### DIFF
--- a/patches/0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
+++ b/patches/0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
@@ -64,7 +64,7 @@ block that remaps to GIC SPIs.
  arm/broadcom/bcm2835/raspberrypi_virtgpio.c		optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt
 --- a/sys/arm/broadcom/bcm2835/bcm2838_pci.c
 +++ b/sys/arm/broadcom/bcm2835/bcm2838_pci.c
-@@ -61,6 +61,39 @@
+@@ -61,6 +61,52 @@
  #define BRIDGE_DISABLE_FLAG	0x1
  #define BRIDGE_RESET_FLAG	0x2
  #define REG_PCIE_HARD_DEBUG			0x4204
@@ -97,6 +97,19 @@ block that remaps to GIC SPIs.
 + * does the right thing; it is only the register that moved.
 + */
 +#define REG_MISC_PCIE_CTRL			0x4064
++
++/*
++ * Inbound windows. Note that REG_BRIDGE_GISB_WINDOW above is the same
++ * register as RC_BAR1_CONFIG_LO -- the existing name describes what the 2711
++ * code happens to use it for, not what it is.
++ */
++#define REG_RC_BAR_CONFIG_LO(n)			(0x402c + (n) * 8)
++#define  RC_BAR_CONFIG_SIZE_MASK	0x1f
++#define REG_RC_BAR_CONFIG_HI(n)			(0x4030 + (n) * 8)
++#define REG_UBUS_BAR_CONFIG_REMAP_LO(n)		(0x40ac + (n) * 8)
++#define  UBUS_BAR_CONFIG_REMAP_ENABLE	(1 << 0)
++#define REG_UBUS_BAR_CONFIG_REMAP_HI(n)		(0x40b0 + (n) * 8)
++#define NUM_INBOUND_WINDOWS	3
 +#define  MISC_PCIE_CTRL_PERSTB	(1 << 2)
 +#define REG_RC_PL_PHY_CTL_15			0x184c
 +#define  PHY_CTL_15_PM_CLK_PERIOD_MASK	0xff
@@ -104,7 +117,7 @@ block that remaps to GIC SPIs.
  #define REG_DMA_CONFIG				0x4008
  #define REG_DMA_WINDOW_LOW			0x4034
  #define REG_DMA_WINDOW_HIGH			0x4038
-@@ -119,9 +152,15 @@
+@@ -119,9 +165,15 @@
  	bool			allocated;
  };
  
@@ -120,7 +133,7 @@ block that remaps to GIC SPIs.
  	bus_dma_tag_t			dmat;
  	struct mtx			config_mtx;
  	struct mtx			msi_mtx;
-@@ -132,9 +171,10 @@
+@@ -132,9 +184,10 @@
  };
  
  static struct ofw_compat_data compat_data[] = {
@@ -134,7 +147,7 @@ block that remaps to GIC SPIs.
  	{NULL,					0}
  };
  
-@@ -149,7 +189,7 @@
+@@ -149,7 +202,7 @@
  		return (ENXIO);
  
  	device_set_desc(dev,
@@ -143,10 +156,12 @@ block that remaps to GIC SPIs.
  	return (BUS_PROBE_DEFAULT);
  }
  
-@@ -176,13 +216,117 @@
- 	return (le32toh(bus_read_4(sc->base.base.res, reg)));
- }
+@@ -174,15 +227,218 @@
+ {
  
+ 	return (le32toh(bus_read_4(sc->base.base.res, reg)));
++}
++
 +/*
 + * MDIO access to the SerDes PHY. Ported from OpenBSD's bcmpcie(4)
 + * (sys/dev/fdt/bcm2711_pcie.c, ISC).
@@ -173,8 +188,8 @@ block that remaps to GIC SPIs.
 +	}
 +
 +	return (EIO);
-+}
-+
+ }
+ 
 +/*
 + * BCM2712 needs its 54 MHz reference clock selected explicitly before the
 + * link will train. The register sequence is opaque -- it comes from the
@@ -219,13 +234,112 @@ block that remaps to GIC SPIs.
 +}
 +
 +/*
++ * Encode a window size the way the controller wants it: a code, not a length.
++ */
++static uint32_t
++bcm_pcib_encode_window_size(uint64_t size)
++{
++	u_int shift;
++
++	if (size == 0)
++		return (0);
++	for (shift = 0; (1ULL << shift) < size; shift++)
++		continue;
++	if (shift >= 12 && shift <= 15)
++		return (0x1c + (shift - 12));
++	if (shift >= 16 && shift <= 36)
++		return (shift - 15);
++	return (0);
++}
++
++/*
++ * Program the inbound windows from dma-ranges.
++ *
++ * On this SoC memory is not presented to devices at its physical address --
++ * a Pi 500+ puts RAM at PCI 0x1000000000 -- and the MSI doorbell is itself an
++ * inbound window onto the MSI controller's registers. So without these, DMA
++ * reaches the wrong place and MSIs are never delivered at all.
++ *
++ * 2711 has no UBUS and its window is set through MISC_CTRL's SCB0 size field
++ * instead; that path is left alone.
++ */
++static int
++bcm_pcib_set_inbound_windows(device_t dev)
++{
++	struct bcm_pcib_softc *sc;
++	pcell_t *cells;
++	phandle_t node;
++	uint64_t pci_base, cpu_base, size;
++	uint32_t code;
++	int i, n, nranges, tuple, acells, pacells, scells;
++
++	sc = device_get_softc(dev);
++	node = ofw_bus_get_node(dev);
++
++	acells = 3;			/* PCI child addresses */
++	pacells = 2;
++	scells = 2;
++	tuple = acells + pacells + scells;
++
++	n = OF_getencprop_alloc_multi(node, "dma-ranges", sizeof(pcell_t),
++	    (void **)&cells);
++	if (n <= 0) {
++		device_printf(dev, "no dma-ranges; inbound windows unset\n");
++		return (ENXIO);
++	}
++	if ((n % tuple) != 0) {
++		device_printf(dev, "malformed dma-ranges\n");
++		OF_prop_free(cells);
++		return (EINVAL);
++	}
++	nranges = n / tuple;
++
++	for (i = 0; i < nranges; i++) {
++		const pcell_t *e = &cells[i * tuple];
++
++		if (i >= NUM_INBOUND_WINDOWS) {
++			device_printf(dev,
++			    "note: dma-range %d ignored, only %d windows\n",
++			    i, NUM_INBOUND_WINDOWS);
++			break;
++		}
++
++		/* e[0] is the PCI phys.hi flags word. */
++		pci_base = ((uint64_t)e[1] << 32) | e[2];
++		cpu_base = ((uint64_t)e[3] << 32) | e[4];
++		size     = ((uint64_t)e[5] << 32) | e[6];
++		code = bcm_pcib_encode_window_size(size);
++
++		bcm_pcib_set_reg(sc, REG_RC_BAR_CONFIG_LO(i),
++		    (uint32_t)(pci_base & ~(uint64_t)RC_BAR_CONFIG_SIZE_MASK) |
++		    code);
++		bcm_pcib_set_reg(sc, REG_RC_BAR_CONFIG_HI(i),
++		    (uint32_t)(pci_base >> 32));
++
++		bcm_pcib_set_reg(sc, REG_UBUS_BAR_CONFIG_REMAP_LO(i),
++		    (uint32_t)cpu_base | UBUS_BAR_CONFIG_REMAP_ENABLE);
++		bcm_pcib_set_reg(sc, REG_UBUS_BAR_CONFIG_REMAP_HI(i),
++		    (uint32_t)(cpu_base >> 32));
++
++		if (bootverbose)
++			device_printf(dev,
++			    "inbound window %d: PCI %#jx -> CPU %#jx size %#jx\n",
++			    i, (uintmax_t)pci_base, (uintmax_t)cpu_base,
++			    (uintmax_t)size);
++	}
++
++	OF_prop_free(cells);
++	return (0);
++}
++
++/*
 + * Assert or deassert PERST#, the downstream device reset. On 2711 this is bit 0
 + * of REG_BRIDGE_CTRL (confusingly named BRIDGE_DISABLE_FLAG); on 2712 it is
 + * PERSTB in REG_MISC_PCIE_CTRL, with the opposite sense. Leaving a 2712 device
 + * held in reset means the link never trains and the controller never reports
 + * ready, which looks exactly like a controller that failed to start.
 + */
- static void
++static void
 +bcm_pcib_perst(struct bcm_pcib_softc *sc, bool assert)
 +{
 +	uint32_t val;
@@ -249,7 +363,7 @@ block that remaps to GIC SPIs.
 +	DELAY(100);
 +}
 +
-+static void
+ static void
  bcm_pcib_reset_controller(struct bcm_pcib_softc *sc)
  {
  	uint32_t val;
@@ -262,7 +376,7 @@ block that remaps to GIC SPIs.
  	bcm_pcib_set_reg(sc, REG_BRIDGE_CTRL, val);
  
  	DELAY(100);
-@@ -193,7 +337,7 @@
+@@ -193,7 +449,7 @@
  
  	DELAY(100);
  
@@ -271,7 +385,7 @@ block that remaps to GIC SPIs.
  
  	DELAY(100);
  }
-@@ -201,13 +345,9 @@
+@@ -201,13 +457,9 @@
  static void
  bcm_pcib_enable_controller(struct bcm_pcib_softc *sc)
  {
@@ -287,18 +401,18 @@ block that remaps to GIC SPIs.
  }
  
  static int
-@@ -621,6 +761,10 @@
- 
+@@ -622,6 +874,10 @@
  	sc = device_get_softc(dev);
  	sc->dev = dev;
-+
+ 
 +	sc->soc = ofw_bus_search_compatible(dev, compat_data)->ocd_data;
 +	sc->hard_debug = (sc->soc == BCM_PCIB_SOC_2712) ?
 +	    REG_PCIE_HARD_DEBUG_2712 : REG_PCIE_HARD_DEBUG;
- 
++
  	/*
  	 * This tag will be used in preference to the one created in
-@@ -656,17 +800,56 @@
+ 	 * pci_host_generic.c.
+@@ -656,17 +912,56 @@
  	device_printf(dev, "hardware identifies as revision 0x%x.\n",
  	    hardware_rev);
  
@@ -352,15 +466,15 @@ block that remaps to GIC SPIs.
  
 +		bcm_pcib_set_reg(sc, REG_BRIDGE_GISB_WINDOW, 0);
 +
-+		if (bootverbose)
-+			device_printf(dev, "note: inbound DMA window not "
-+			    "programmed; dma-ranges support is required.\n");
++		if (bcm_pcib_set_inbound_windows(dev) != 0)
++			device_printf(dev, "warning: inbound windows not "
++			    "programmed; DMA and MSI will not work.\n");
 +	}
 +
  	bcm_pcib_enable_controller(sc);
  
  	/* Wait for controller to start. */
-@@ -722,7 +905,7 @@
+@@ -722,7 +1017,7 @@
  	bcm_pcib_set_reg(sc, PCI_ID_VAL3,
  	    PCIC_BRIDGE << CLASS_SHIFT | PCIS_BRIDGE_PCI << SUBCLASS_SHIFT);
  
@@ -369,7 +483,7 @@ block that remaps to GIC SPIs.
  	tmp |= CLKREQ_ENABLE;
  
  	if (ofw_bus_has_prop(dev, "brcm,enable-l1ss")) {
-@@ -733,7 +916,7 @@
+@@ -733,7 +1028,7 @@
  		tmp |= L1SS_ENABLE;
  	}
  

--- a/patches/0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
+++ b/patches/0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
@@ -117,7 +117,7 @@ block that remaps to GIC SPIs.
  #define REG_DMA_CONFIG				0x4008
  #define REG_DMA_WINDOW_LOW			0x4034
  #define REG_DMA_WINDOW_HIGH			0x4038
-@@ -119,9 +165,15 @@
+@@ -119,9 +165,21 @@
  	bool			allocated;
  };
  
@@ -130,10 +130,16 @@ block that remaps to GIC SPIs.
  	device_t			dev;
 +	int				soc;
 +	bus_size_t			hard_debug;
++	struct {
++		uint64_t	pci_base;
++		uint64_t	cpu_base;
++		uint64_t	size;
++	}				dma_window[NUM_INBOUND_WINDOWS];
++	int				num_dma_windows;
  	bus_dma_tag_t			dmat;
  	struct mtx			config_mtx;
  	struct mtx			msi_mtx;
-@@ -132,9 +184,10 @@
+@@ -132,9 +190,10 @@
  };
  
  static struct ofw_compat_data compat_data[] = {
@@ -147,7 +153,7 @@ block that remaps to GIC SPIs.
  	{NULL,					0}
  };
  
-@@ -149,7 +202,7 @@
+@@ -149,7 +208,7 @@
  		return (ENXIO);
  
  	device_set_desc(dev,
@@ -156,7 +162,7 @@ block that remaps to GIC SPIs.
  	return (BUS_PROBE_DEFAULT);
  }
  
-@@ -174,15 +227,218 @@
+@@ -174,6 +233,244 @@
  {
  
  	return (le32toh(bus_read_4(sc->base.base.res, reg)));
@@ -188,8 +194,8 @@ block that remaps to GIC SPIs.
 +	}
 +
 +	return (EIO);
- }
- 
++}
++
 +/*
 + * BCM2712 needs its 54 MHz reference clock selected explicitly before the
 + * link will train. The register sequence is opaque -- it comes from the
@@ -231,6 +237,38 @@ block that remaps to GIC SPIs.
 +	bcm_pcib_set_reg(sc, REG_RC_PL_PHY_CTL_15, reg);
 +
 +	return (0);
++}
++
++/*
++ * Translate a physical address into what devices behind this bridge see.
++ *
++ * Installed on the bridge's DMA tag with bus_dma_tag_set_mapseg() and
++ * inherited by every child tag, so busdma stops handing devices physical
++ * addresses that mean something else on the bus. On a Pi 500+ RAM is at
++ * PCI 0x1000000000 + phys; without this, DMA silently targets the wrong
++ * place and transfers time out.
++ */
++static int
++bcm_pcib_mapseg(void *arg, bus_dma_tag_t dmat __unused, bus_addr_t *addr,
++    bus_size_t size)
++{
++	struct bcm_pcib_softc *sc = arg;
++	uint64_t a = (uint64_t)*addr;
++	int i;
++
++	for (i = 0; i < sc->num_dma_windows; i++) {
++		uint64_t base = sc->dma_window[i].cpu_base;
++		uint64_t len = sc->dma_window[i].size;
++
++		if (a >= base && a + size <= base + len) {
++			*addr = (bus_addr_t)(sc->dma_window[i].pci_base +
++			    (a - base));
++			return (0);
++		}
++	}
++
++	/* No window covers it; the transfer would go nowhere. */
++	return (EINVAL);
 +}
 +
 +/*
@@ -321,6 +359,11 @@ block that remaps to GIC SPIs.
 +		bcm_pcib_set_reg(sc, REG_UBUS_BAR_CONFIG_REMAP_HI(i),
 +		    (uint32_t)(cpu_base >> 32));
 +
++		sc->dma_window[i].pci_base = pci_base;
++		sc->dma_window[i].cpu_base = cpu_base;
++		sc->dma_window[i].size = size;
++		sc->num_dma_windows = i + 1;
++
 +		if (bootverbose)
 +			device_printf(dev,
 +			    "inbound window %d: PCI %#jx -> CPU %#jx size %#jx\n",
@@ -361,10 +404,10 @@ block that remaps to GIC SPIs.
 +	}
 +
 +	DELAY(100);
-+}
-+
+ }
+ 
  static void
- bcm_pcib_reset_controller(struct bcm_pcib_softc *sc)
+@@ -181,8 +478,10 @@
  {
  	uint32_t val;
  
@@ -376,7 +419,7 @@ block that remaps to GIC SPIs.
  	bcm_pcib_set_reg(sc, REG_BRIDGE_CTRL, val);
  
  	DELAY(100);
-@@ -193,7 +449,7 @@
+@@ -193,7 +492,7 @@
  
  	DELAY(100);
  
@@ -385,7 +428,7 @@ block that remaps to GIC SPIs.
  
  	DELAY(100);
  }
-@@ -201,13 +457,9 @@
+@@ -201,13 +500,9 @@
  static void
  bcm_pcib_enable_controller(struct bcm_pcib_softc *sc)
  {
@@ -401,7 +444,7 @@ block that remaps to GIC SPIs.
  }
  
  static int
-@@ -622,6 +874,10 @@
+@@ -622,6 +917,10 @@
  	sc = device_get_softc(dev);
  	sc->dev = dev;
  
@@ -412,10 +455,34 @@ block that remaps to GIC SPIs.
  	/*
  	 * This tag will be used in preference to the one created in
  	 * pci_host_generic.c.
-@@ -656,17 +912,56 @@
+@@ -643,6 +942,22 @@
+ 	error = pci_host_generic_setup_fdt(dev);
+ 	if (error != 0)
+ 		return (error);
++
++	if (sc->soc == BCM_PCIB_SOC_2712) {
++		/*
++		 * DMA_HIGH_LIMIT is a 2711 value, chosen by experiment on a
++		 * board whose window this code hardcoded. Here the windows
++		 * come from dma-ranges and cover all of memory, so bouncing
++		 * everything above 960 MiB on a 16 GiB machine would be both
++		 * wrong and ruinous.
++		 */
++		error = bus_dma_tag_create(bus_get_dma_tag(dev), 1, 0,
++		    BUS_SPACE_MAXADDR, BUS_SPACE_MAXADDR, NULL, NULL,
++		    BUS_SPACE_MAXSIZE, BUS_SPACE_UNRESTRICTED,
++		    BUS_SPACE_MAXSIZE, 0, NULL, NULL, &sc->dmat);
++		if (error != 0)
++			return (error);
++	}
+ 
+ 	error = bcm_pcib_check_ranges(dev);
+ 	if (error != 0)
+@@ -655,18 +970,59 @@
+ 	hardware_rev = bcm_pcib_read_reg(sc, REG_CONTROLLER_HW_REV) & 0xffff;
  	device_printf(dev, "hardware identifies as revision 0x%x.\n",
  	    hardware_rev);
- 
++
 +	if (sc->soc == BCM_PCIB_SOC_2712) {
 +		error = bcm_pcib_setup_2712(sc);
 +		if (error != 0) {
@@ -424,7 +491,7 @@ block that remaps to GIC SPIs.
 +			return (error);
 +		}
 +	}
-+
+ 
  	/*
  	 * Set PCI->CPU memory window. This encodes the inbound window showing
  	 * the system memory to the controller.
@@ -469,12 +536,14 @@ block that remaps to GIC SPIs.
 +		if (bcm_pcib_set_inbound_windows(dev) != 0)
 +			device_printf(dev, "warning: inbound windows not "
 +			    "programmed; DMA and MSI will not work.\n");
++		else
++			bus_dma_tag_set_mapseg(sc->dmat, bcm_pcib_mapseg, sc);
 +	}
 +
  	bcm_pcib_enable_controller(sc);
  
  	/* Wait for controller to start. */
-@@ -722,7 +1017,7 @@
+@@ -722,7 +1078,7 @@
  	bcm_pcib_set_reg(sc, PCI_ID_VAL3,
  	    PCIC_BRIDGE << CLASS_SHIFT | PCIS_BRIDGE_PCI << SUBCLASS_SHIFT);
  
@@ -483,7 +552,7 @@ block that remaps to GIC SPIs.
  	tmp |= CLKREQ_ENABLE;
  
  	if (ofw_bus_has_prop(dev, "brcm,enable-l1ss")) {
-@@ -733,7 +1028,7 @@
+@@ -733,7 +1089,7 @@
  		tmp |= L1SS_ENABLE;
  	}
  

--- a/patches/0015-bcm2712_mip-MSI-support.patch
+++ b/patches/0015-bcm2712_mip-MSI-support.patch
@@ -30,10 +30,10 @@ MSI" on this board today.
 ---
 diff --git a/sys/arm/broadcom/bcm2835/bcm2712_mip.c b/sys/arm/broadcom/bcm2835/bcm2712_mip.c
 new file mode 100644
-index 0000000..8933516
+index 0000000..7b3dde7
 --- /dev/null
 +++ b/sys/arm/broadcom/bcm2835/bcm2712_mip.c
-@@ -0,0 +1,338 @@
+@@ -0,0 +1,342 @@
 +/*-
 + * SPDX-License-Identifier: BSD-2-Clause
 + *
@@ -101,7 +101,6 @@ index 0000000..8933516
 +struct bcm_mip_softc {
 +	device_t		dev;
 +	struct resource		*ctrl_res;	/* reg[0] */
-+	struct resource		*door_res;	/* reg[1], the doorbell page */
 +	bus_addr_t		msi_addr;
 +	device_t		gic_dev;
 +	uint32_t		ranges[MIP_RANGES_CELLS];
@@ -141,6 +140,7 @@ index 0000000..8933516
 +	struct bcm_mip_softc *sc;
 +	phandle_t node;
 +	intptr_t xref;
++	rman_res_t door_start, door_count;
 +	int rid;
 +
 +	sc = device_get_softc(dev);
@@ -169,15 +169,19 @@ index 0000000..8933516
 +		device_printf(dev, "could not map control registers\n");
 +		return (ENXIO);
 +	}
-+	rid = 1;
-+	sc->door_res = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &rid,
-+	    RF_ACTIVE);
-+	if (sc->door_res == NULL) {
-+		device_printf(dev, "could not map the doorbell page\n");
-+		bus_free_resource(dev, SYS_RES_MEMORY, sc->ctrl_res);
++	/*
++	 * reg[1] is the doorbell page. Only its address is wanted -- the CPU
++	 * never touches it; devices write to it to raise an MSI. Read the
++	 * resource list rather than allocating it, which would try to map a
++	 * page nothing dereferences.
++	 */
++	if (bus_get_resource(dev, SYS_RES_MEMORY, 1, &door_start,
++	    &door_count) != 0) {
++		device_printf(dev, "no doorbell address in reg[1]\n");
++		bus_release_resource(dev, SYS_RES_MEMORY, 0, sc->ctrl_res);
 +		return (ENXIO);
 +	}
-+	sc->msi_addr = rman_get_start(sc->door_res);
++	sc->msi_addr = door_start;
 +
 +	/* The GIC is named by the first cell of msi-ranges, not by
 +	 * interrupt-parent -- this node has no interrupts of its own. */

--- a/patches/0015-bcm2712_mip-MSI-support.patch
+++ b/patches/0015-bcm2712_mip-MSI-support.patch
@@ -1,0 +1,386 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sun, 23 Aug 2026 16:10:00 -0500
+Subject: [PATCH] bcm2712_mip: MSI support for the BCM2712 MIP block
+
+BCM2712 does not deliver MSIs the way BCM2711 does. Rather than the PCIe
+host bridge demultiplexing one interrupt, a separate block -- the MIP --
+translates each MSI into a distinct GIC SPI: a write to its doorbell
+page with data N raises SPI (spi_base + N).
+
+That makes it a translator, not a dispatcher. It owns no interrupt
+handler and the sources it hands out are the GIC's own, obtained with
+PIC_MAP_INTR() against fabricated FDT interrupt cells. The same shape as
+arm/annapurna/alpine/alpine_pci_msix.c, which this is modelled on; the
+register layout and init sequence are from OpenBSD's bcmmip(4), which is
+ISC.
+
+Measured on a Pi 500+, which has two instances:
+
+    msi-controller@1000130000  64 MSIs at SPI 128, offset 0 -> pcie2/RP1
+    msi-controller@1000131000   8 MSIs at SPI 247, offset 8 -> pcie1/NVMe
+
+reg[0] is the control block and reg[1] is the doorbell page; the GIC is
+named by the first cell of msi-ranges rather than by interrupt-parent,
+since this node has no interrupts of its own.
+
+Without it, every device behind PCIe falls back to legacy interrupts --
+nvme reports "unable to allocate MSI-X" and then "unable to allocate
+MSI" on this board today.
+---
+diff --git a/sys/arm/broadcom/bcm2835/bcm2712_mip.c b/sys/arm/broadcom/bcm2835/bcm2712_mip.c
+new file mode 100644
+index 0000000..8933516
+--- /dev/null
++++ b/sys/arm/broadcom/bcm2835/bcm2712_mip.c
+@@ -0,0 +1,338 @@
++/*-
++ * SPDX-License-Identifier: BSD-2-Clause
++ *
++ * MSI support for the BCM2712 "MIP" block.
++ *
++ * BCM2712 does not deliver MSIs the way BCM2711 does. Instead of the PCIe
++ * host bridge demultiplexing a single interrupt, each MSI is translated by a
++ * separate block -- the MIP -- into a distinct GIC SPI. Writing to the MIP's
++ * doorbell page with a given data value raises SPI (spi_base + data).
++ *
++ * That makes this a translator rather than a dispatcher: it owns no interrupt
++ * handler of its own, and the interrupt sources it hands out are the GIC's.
++ * The same shape as arm/annapurna/alpine/alpine_pci_msix.c, which this is
++ * modelled on; the register layout is from OpenBSD's bcmmip(4) (ISC).
++ *
++ * A Pi 500+ has two of these:
++ *   msi-controller@1000130000  64 MSIs at SPI 128, offset 0  -> pcie2 (RP1)
++ *   msi-controller@1000131000   8 MSIs at SPI 247, offset 8  -> pcie1 (NVMe)
++ */
++
++#include <sys/param.h>
++#include <sys/systm.h>
++#include <sys/bus.h>
++#include <sys/kernel.h>
++#include <sys/lock.h>
++#include <sys/malloc.h>
++#include <sys/module.h>
++#include <sys/mutex.h>
++#include <sys/rman.h>
++#include <sys/vmem.h>
++
++#include <machine/bus.h>
++#include <machine/intr.h>
++
++#include <dev/ofw/ofw_bus.h>
++#include <dev/ofw/ofw_bus_subr.h>
++
++#include "msi_if.h"
++#include "pic_if.h"
++
++/* Control registers, reg[0]. */
++#define	MIP_INT_RAISE		0x00
++#define	MIP_INT_CLEAR		0x10
++#define	MIP_INT_CFGL_HOST	0x20
++#define	MIP_INT_CFGH_HOST	0x30
++#define	MIP_INT_MASKL_HOST	0x40
++#define	MIP_INT_MASKH_HOST	0x50
++#define	MIP_INT_MASKL_VPU	0x60
++#define	MIP_INT_MASKH_VPU	0x70
++#define	MIP_INT_STATUSL_HOST	0x80
++#define	MIP_INT_STATUSH_HOST	0x90
++
++#define	MIP_MAX_MSI		64
++
++/* msi-ranges is <&gic type spi-base flags count>. */
++#define	MIP_RANGES_CELLS	5
++#define	MIP_RANGE_IPARENT	0
++#define	MIP_RANGE_TYPE		1
++#define	MIP_RANGE_SPI_BASE	2
++#define	MIP_RANGE_FLAGS		3
++#define	MIP_RANGE_COUNT		4
++
++#define	GIC_INTR_CELLS		3
++
++struct bcm_mip_softc {
++	device_t		dev;
++	struct resource		*ctrl_res;	/* reg[0] */
++	struct resource		*door_res;	/* reg[1], the doorbell page */
++	bus_addr_t		msi_addr;
++	device_t		gic_dev;
++	uint32_t		ranges[MIP_RANGES_CELLS];
++	u_int			msi_offset;
++	u_int			msi_count;
++	struct mtx		mtx;
++	vmem_t			*irq_alloc;
++	struct intr_irqsrc	*isrcs[MIP_MAX_MSI];
++};
++
++static MALLOC_DEFINE(M_BCM_MIP, "bcm_mip", "BCM2712 MIP MSI");
++
++static struct ofw_compat_data compat_data[] = {
++	{ "brcm,bcm2712-mip",	1 },
++	{ NULL,			0 }
++};
++
++#define	MIP_WR4(sc, reg, val)	bus_write_4((sc)->ctrl_res, (reg), (val))
++#define	MIP_RD4(sc, reg)	bus_read_4((sc)->ctrl_res, (reg))
++
++static int
++bcm_mip_probe(device_t dev)
++{
++
++	if (!ofw_bus_status_okay(dev))
++		return (ENXIO);
++	if (!ofw_bus_search_compatible(dev, compat_data)->ocd_data)
++		return (ENXIO);
++
++	device_set_desc(dev, "BCM2712 MSI Interrupt Peripheral");
++	return (BUS_PROBE_DEFAULT);
++}
++
++static int
++bcm_mip_attach(device_t dev)
++{
++	struct bcm_mip_softc *sc;
++	phandle_t node;
++	intptr_t xref;
++	int rid;
++
++	sc = device_get_softc(dev);
++	sc->dev = dev;
++	node = ofw_bus_get_node(dev);
++
++	if (OF_getencprop(node, "msi-ranges", sc->ranges,
++	    sizeof(sc->ranges)) != sizeof(sc->ranges)) {
++		device_printf(dev, "missing or malformed msi-ranges\n");
++		return (ENXIO);
++	}
++	if (OF_getencprop(node, "brcm,msi-offset", &sc->msi_offset,
++	    sizeof(sc->msi_offset)) != sizeof(sc->msi_offset))
++		sc->msi_offset = 0;
++
++	sc->msi_count = sc->ranges[MIP_RANGE_COUNT];
++	if (sc->msi_count == 0 || sc->msi_count > MIP_MAX_MSI) {
++		device_printf(dev, "unsupported MSI count %u\n", sc->msi_count);
++		return (ENXIO);
++	}
++
++	rid = 0;
++	sc->ctrl_res = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &rid,
++	    RF_ACTIVE);
++	if (sc->ctrl_res == NULL) {
++		device_printf(dev, "could not map control registers\n");
++		return (ENXIO);
++	}
++	rid = 1;
++	sc->door_res = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &rid,
++	    RF_ACTIVE);
++	if (sc->door_res == NULL) {
++		device_printf(dev, "could not map the doorbell page\n");
++		bus_free_resource(dev, SYS_RES_MEMORY, sc->ctrl_res);
++		return (ENXIO);
++	}
++	sc->msi_addr = rman_get_start(sc->door_res);
++
++	/* The GIC is named by the first cell of msi-ranges, not by
++	 * interrupt-parent -- this node has no interrupts of its own. */
++	sc->gic_dev = OF_device_from_xref(sc->ranges[MIP_RANGE_IPARENT]);
++	if (sc->gic_dev == NULL) {
++		device_printf(dev, "cannot find the interrupt controller\n");
++		return (ENXIO);
++	}
++
++	/*
++	 * Route everything to the host and nothing to the VPU, then unmask.
++	 * Register layout and sequence from OpenBSD's bcmmip(4).
++	 */
++	MIP_WR4(sc, MIP_INT_MASKL_VPU, 0xffffffff);
++	MIP_WR4(sc, MIP_INT_MASKH_VPU, 0xffffffff);
++	MIP_WR4(sc, MIP_INT_CFGL_HOST, 0xffffffff);
++	MIP_WR4(sc, MIP_INT_CFGH_HOST, 0xffffffff);
++	MIP_WR4(sc, MIP_INT_MASKL_HOST, 0);
++	MIP_WR4(sc, MIP_INT_MASKH_HOST, 0);
++
++	mtx_init(&sc->mtx, "bcm_mip", NULL, MTX_DEF);
++	sc->irq_alloc = vmem_create("BCM2712 MIP MSIs", 0, sc->msi_count, 1, 0,
++	    M_FIRSTFIT | M_WAITOK);
++
++	xref = OF_xref_from_node(node);
++	OF_device_register_xref(xref, dev);
++	if (intr_msi_register(dev, xref) != 0) {
++		device_printf(dev, "could not register as an MSI controller\n");
++		return (ENXIO);
++	}
++
++	if (bootverbose)
++		device_printf(dev,
++		    "%u MSIs -> SPI %u-%u, data offset %u, doorbell %#jx\n",
++		    sc->msi_count, sc->ranges[MIP_RANGE_SPI_BASE],
++		    sc->ranges[MIP_RANGE_SPI_BASE] + sc->msi_count - 1,
++		    sc->msi_offset, (uintmax_t)sc->msi_addr);
++
++	return (0);
++}
++
++/*
++ * Hand back the GIC's own interrupt sources for the SPIs this block will
++ * raise. Nothing here dispatches interrupts; the GIC does.
++ */
++static int
++bcm_mip_alloc_msi(device_t dev, device_t child, int count, int maxcount,
++    device_t *pic, struct intr_irqsrc **srcs)
++{
++	struct intr_map_data_fdt *fdt_data;
++	struct bcm_mip_softc *sc;
++	vmem_addr_t irq_base;
++	int error;
++	u_int i, j;
++
++	sc = device_get_softc(dev);
++
++	if (!powerof2(count) || count > (int)sc->msi_count)
++		return (EINVAL);
++
++	if (vmem_alloc(sc->irq_alloc, count, M_FIRSTFIT | M_NOWAIT,
++	    &irq_base) != 0)
++		return (ENOMEM);
++
++	fdt_data = malloc(sizeof(*fdt_data) + GIC_INTR_CELLS * sizeof(pcell_t),
++	    M_BCM_MIP, M_WAITOK | M_ZERO);
++	fdt_data->hdr.type = INTR_MAP_DATA_FDT;
++	fdt_data->iparent = 0;
++	fdt_data->ncells = GIC_INTR_CELLS;
++	fdt_data->cells[0] = sc->ranges[MIP_RANGE_TYPE];
++	fdt_data->cells[2] = sc->ranges[MIP_RANGE_FLAGS];
++
++	mtx_lock(&sc->mtx);
++	for (i = irq_base; i < irq_base + count; i++) {
++		fdt_data->cells[1] = sc->ranges[MIP_RANGE_SPI_BASE] + i;
++		error = PIC_MAP_INTR(sc->gic_dev,
++		    (struct intr_map_data *)fdt_data, srcs);
++		if (error != 0) {
++			for (j = irq_base; j < i; j++)
++				sc->isrcs[j] = NULL;
++			mtx_unlock(&sc->mtx);
++			vmem_free(sc->irq_alloc, irq_base, count);
++			free(fdt_data, M_BCM_MIP);
++			return (error);
++		}
++		sc->isrcs[i] = *srcs;
++		srcs++;
++	}
++	mtx_unlock(&sc->mtx);
++	free(fdt_data, M_BCM_MIP);
++
++	*pic = sc->gic_dev;
++	return (0);
++}
++
++static int
++bcm_mip_find_slot(struct bcm_mip_softc *sc, struct intr_irqsrc *isrc)
++{
++	u_int i;
++
++	for (i = 0; i < sc->msi_count; i++)
++		if (sc->isrcs[i] == isrc)
++			return ((int)i);
++	return (-1);
++}
++
++static int
++bcm_mip_release_msi(device_t dev, device_t child, int count,
++    struct intr_irqsrc **isrc)
++{
++	struct bcm_mip_softc *sc;
++	int i, slot;
++
++	sc = device_get_softc(dev);
++
++	mtx_lock(&sc->mtx);
++	for (i = 0; i < count; i++) {
++		slot = bcm_mip_find_slot(sc, isrc[i]);
++		if (slot < 0)
++			continue;
++		sc->isrcs[slot] = NULL;
++		vmem_free(sc->irq_alloc, slot, 1);
++	}
++	mtx_unlock(&sc->mtx);
++
++	return (0);
++}
++
++static int
++bcm_mip_alloc_msix(device_t dev, device_t child, device_t *pic,
++    struct intr_irqsrc **isrc)
++{
++
++	return (bcm_mip_alloc_msi(dev, child, 1, 1, pic, isrc));
++}
++
++static int
++bcm_mip_release_msix(device_t dev, device_t child, struct intr_irqsrc *isrc)
++{
++
++	return (bcm_mip_release_msi(dev, child, 1, &isrc));
++}
++
++/*
++ * The doorbell page is the target address for every MSI; the data value
++ * selects which SPI is raised.
++ */
++static int
++bcm_mip_map_msi(device_t dev, device_t child, struct intr_irqsrc *isrc,
++    uint64_t *addr, uint32_t *data)
++{
++	struct bcm_mip_softc *sc;
++	int slot;
++
++	sc = device_get_softc(dev);
++
++	slot = bcm_mip_find_slot(sc, isrc);
++	if (slot < 0)
++		return (EINVAL);
++
++	*addr = (uint64_t)sc->msi_addr;
++	*data = (uint32_t)slot + sc->msi_offset;
++
++	if (bootverbose)
++		device_printf(dev, "MSI: SPI %u addr %#jx data %#x\n",
++		    sc->ranges[MIP_RANGE_SPI_BASE] + slot,
++		    (uintmax_t)*addr, *data);
++
++	return (0);
++}
++
++static device_method_t bcm_mip_methods[] = {
++	DEVMETHOD(device_probe,		bcm_mip_probe),
++	DEVMETHOD(device_attach,	bcm_mip_attach),
++
++	DEVMETHOD(msi_alloc_msi,	bcm_mip_alloc_msi),
++	DEVMETHOD(msi_release_msi,	bcm_mip_release_msi),
++	DEVMETHOD(msi_alloc_msix,	bcm_mip_alloc_msix),
++	DEVMETHOD(msi_release_msix,	bcm_mip_release_msix),
++	DEVMETHOD(msi_map_msi,		bcm_mip_map_msi),
++
++	DEVMETHOD_END
++};
++
++static driver_t bcm_mip_driver = {
++	"bcm_mip",
++	bcm_mip_methods,
++	sizeof(struct bcm_mip_softc),
++};
++
++EARLY_DRIVER_MODULE(bcm_mip, ofwbus, bcm_mip_driver, 0, 0,
++    BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
++EARLY_DRIVER_MODULE(bcm_mip, simplebus, bcm_mip_driver, 0, 0,
++    BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
+diff --git a/sys/conf/files.arm64 b/sys/conf/files.arm64
+index 1f3a072..e8362b0 100644
+--- a/sys/conf/files.arm64
++++ b/sys/conf/files.arm64
+@@ -590,6 +590,7 @@ arm/broadcom/bcm2835/bcm2835_wdog.c			optional soc_brcm_bcm2837 fdt | soc_brcm_b
+ arm/broadcom/bcm2835/bcm2836.c				optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
+ arm/broadcom/bcm2835/bcm283x_dwc_fdt.c			optional dwcotg fdt soc_brcm_bcm2837 | dwcotg fdt soc_brcm_bcm2838
+ arm/broadcom/bcm2835/bcm2838_pci.c			optional soc_brcm_bcm2838 fdt pci
++arm/broadcom/bcm2835/bcm2712_mip.c			optional soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/bcm2838_xhci.c			optional soc_brcm_bcm2838 fdt pci xhci
+ arm/broadcom/bcm2835/raspberrypi_gpio.c			optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt
+ arm/broadcom/bcm2835/raspberrypi_virtgpio.c		optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt

--- a/patches/0015-bcm2712_mip-MSI-support.patch
+++ b/patches/0015-bcm2712_mip-MSI-support.patch
@@ -30,10 +30,10 @@ MSI" on this board today.
 ---
 diff --git a/sys/arm/broadcom/bcm2835/bcm2712_mip.c b/sys/arm/broadcom/bcm2835/bcm2712_mip.c
 new file mode 100644
-index 0000000..7b3dde7
+index 0000000..fa2b062
 --- /dev/null
 +++ b/sys/arm/broadcom/bcm2835/bcm2712_mip.c
-@@ -0,0 +1,342 @@
+@@ -0,0 +1,351 @@
 +/*-
 + * SPDX-License-Identifier: BSD-2-Clause
 + *
@@ -215,9 +215,11 @@ index 0000000..7b3dde7
 +
 +	if (bootverbose)
 +		device_printf(dev,
-+		    "%u MSIs -> SPI %u-%u, data offset %u, doorbell %#jx\n",
-+		    sc->msi_count, sc->ranges[MIP_RANGE_SPI_BASE],
-+		    sc->ranges[MIP_RANGE_SPI_BASE] + sc->msi_count - 1,
++		    "%u MSIs -> SPI %u-%u, index offset %u, doorbell %#jx\n",
++		    sc->msi_count,
++		    sc->ranges[MIP_RANGE_SPI_BASE] + sc->msi_offset,
++		    sc->ranges[MIP_RANGE_SPI_BASE] + sc->msi_offset +
++		    sc->msi_count - 1,
 +		    sc->msi_offset, (uintmax_t)sc->msi_addr);
 +
 +	return (0);
@@ -256,7 +258,14 @@ index 0000000..7b3dde7
 +
 +	mtx_lock(&sc->mtx);
 +	for (i = irq_base; i < irq_base + count; i++) {
-+		fdt_data->cells[1] = sc->ranges[MIP_RANGE_SPI_BASE] + i;
++		/*
++		 * brcm,msi-offset shifts the MSI index within this block, and
++		 * it applies to BOTH the data value a device writes and the
++		 * SPI that results. Adding it to only one of them allocates
++		 * successfully and then listens on the wrong interrupt.
++		 */
++		fdt_data->cells[1] = sc->ranges[MIP_RANGE_SPI_BASE] + i +
++		    sc->msi_offset;
 +		error = PIC_MAP_INTR(sc->gic_dev,
 +		    (struct intr_map_data *)fdt_data, srcs);
 +		if (error != 0) {
@@ -347,7 +356,7 @@ index 0000000..7b3dde7
 +
 +	if (bootverbose)
 +		device_printf(dev, "MSI: SPI %u addr %#jx data %#x\n",
-+		    sc->ranges[MIP_RANGE_SPI_BASE] + slot,
++		    sc->ranges[MIP_RANGE_SPI_BASE] + slot + sc->msi_offset,
 +		    (uintmax_t)*addr, *data);
 +
 +	return (0);

--- a/patches/0015-bcm2712_mip-MSI-support.patch
+++ b/patches/0015-bcm2712_mip-MSI-support.patch
@@ -373,13 +373,13 @@ index 0000000..8933516
 +EARLY_DRIVER_MODULE(bcm_mip, simplebus, bcm_mip_driver, 0, 0,
 +    BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
 diff --git a/sys/conf/files.arm64 b/sys/conf/files.arm64
-index 1f3a072..e8362b0 100644
+index 27488a2..33d8698 100644
 --- a/sys/conf/files.arm64
 +++ b/sys/conf/files.arm64
-@@ -590,6 +590,7 @@ arm/broadcom/bcm2835/bcm2835_wdog.c			optional soc_brcm_bcm2837 fdt | soc_brcm_b
- arm/broadcom/bcm2835/bcm2836.c				optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
+@@ -591,6 +591,7 @@ arm/broadcom/bcm2835/bcm2836.c				optional soc_brcm_bcm2837 fdt | soc_brcm_bcm28
  arm/broadcom/bcm2835/bcm283x_dwc_fdt.c			optional dwcotg fdt soc_brcm_bcm2837 | dwcotg fdt soc_brcm_bcm2838
- arm/broadcom/bcm2835/bcm2838_pci.c			optional soc_brcm_bcm2838 fdt pci
+ arm/broadcom/bcm2835/bcm2838_pci.c			optional soc_brcm_bcm2838 fdt pci | \
+ 	soc_brcm_bcm2712 fdt pci
 +arm/broadcom/bcm2835/bcm2712_mip.c			optional soc_brcm_bcm2712 fdt pci
  arm/broadcom/bcm2835/bcm2838_xhci.c			optional soc_brcm_bcm2838 fdt pci xhci
  arm/broadcom/bcm2835/raspberrypi_gpio.c			optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt

--- a/patches/0016-busdma-arm64-bus-view-of-DMA-address-space-D58105.patch
+++ b/patches/0016-busdma-arm64-bus-view-of-DMA-address-space-D58105.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Meloun <mmel@FreeBSD.org>
+Date: Tue, 8 Jul 2026 00:00:00 +0000
+Subject: [PATCH] busdma, arm64: implement support for bus view of DMA address
+ space
+
+Carried from FreeBSD review D58105 <https://reviews.freebsd.org/D58105>,
+which is still in review upstream. Not our work -- authorship left with
+mmel@.
+
+Some buses do not present system memory to devices at its physical
+address. The Raspberry Pi 500+ is one: BCM2712's PCIe controllers reach
+RAM at PCI 0x1000000000 + phys, a 64 GiB offset, and busdma has no way
+to know that. Devices are handed physical addresses and write to the
+wrong place, or to nowhere.
+
+This adds a per-tag mapseg callback, inherited from the parent tag, that
+_bus_dmamap_addseg() invokes to translate each segment address into the
+bus's view. A bus driver installs one with bus_dma_tag_set_mapseg().
+
+We need it for MSI before we need it for DMA: on this board the MSI
+doorbell is itself an inbound window (PCI 0xfffffff000 maps onto the MIP
+controller's own registers), so a device's MSI write is a DMA write that
+has to be translated like any other. Without this, MSIs are allocated
+successfully and never delivered.
+
+Carried rather than reimplemented because the alternative -- translating
+addresses inside one controller driver -- fixes this board and no other,
+and leaves busdma still lying to every consumer about where memory is.
+---
+diff --git a/sys/arm64/arm64/busdma_bounce.c b/sys/arm64/arm64/busdma_bounce.c
+--- a/sys/arm64/arm64/busdma_bounce.c
++++ b/sys/arm64/arm64/busdma_bounce.c
+@@ -142,6 +142,8 @@
+ #define	dmat_lockfuncarg(dmat)	((dmat)->common.lockfuncarg)
+ #define	dmat_maxsegsz(dmat)	((dmat)->common.maxsegsz)
+ #define	dmat_nsegments(dmat)	((dmat)->common.nsegments)
++#define	dmat_mapseg(dmat)	((dmat)->common.mapseg)
++#define	dmat_mapseg_arg(dmat)	((dmat)->common.mapseg_arg)
+ 
+ #include "../../kern/subr_busdma_bounce.c"
+ 
+diff --git a/sys/arm64/arm64/busdma_machdep.c b/sys/arm64/arm64/busdma_machdep.c
+--- a/sys/arm64/arm64/busdma_machdep.c
++++ b/sys/arm64/arm64/busdma_machdep.c
+@@ -107,6 +107,8 @@
+ 		}
+ 
+ 		common->domain = parent->domain;
++		common->mapseg = parent->mapseg;
++		common->mapseg_arg = parent->mapseg_arg;
+ 	}
+ 	common->domain = vm_phys_domain_match(common->domain, 0ul,
+ 	    common->lowaddr);
+@@ -188,3 +190,13 @@
+ 	tc->domain = domain;
+ 	return (tc->impl->tag_set_domain(dmat));
+ }
++
++void
++bus_dma_tag_set_mapseg(bus_dma_tag_t dmat, bus_dma_mapseg_t *mapseg, void *arg)
++{
++	struct bus_dma_tag_common *tc;
++
++	tc = (struct bus_dma_tag_common *)dmat;
++	tc->mapseg = mapseg;
++	tc->mapseg_arg = arg;
++}
+diff --git a/sys/arm64/include/bus_dma_impl.h b/sys/arm64/include/bus_dma_impl.h
+--- a/sys/arm64/include/bus_dma_impl.h
++++ b/sys/arm64/include/bus_dma_impl.h
+@@ -42,6 +42,8 @@
+ 	bus_dma_lock_t	 *lockfunc;
+ 	void		 *lockfuncarg;
+ 	int		  domain;
++	bus_dma_mapseg_t *mapseg;
++	void		 *mapseg_arg;
+ };
+ 
+ struct bus_dma_impl {
+diff --git a/sys/kern/subr_busdma_bounce.c b/sys/kern/subr_busdma_bounce.c
+--- a/sys/kern/subr_busdma_bounce.c
++++ b/sys/kern/subr_busdma_bounce.c
+@@ -450,7 +450,7 @@
+ _bus_dmamap_addseg(bus_dma_tag_t dmat, bus_dmamap_t map, bus_addr_t curaddr,
+     bus_size_t sgsize, bus_dma_segment_t *segs, int *segp)
+ {
+-	int seg;
++	int seg, rv;
+ 
+ 	KASSERT(curaddr <= BUS_SPACE_MAXADDR,
+ 	    ("ds_addr %#jx > BUS_SPACE_MAXADDR %#jx; dmat %p fl %#x low %#jx "
+@@ -464,6 +464,14 @@
+ 	 */
+ 	if (!vm_addr_bound_ok(curaddr, sgsize, dmat_boundary(dmat)))
+ 		sgsize = roundup2(curaddr, dmat_boundary(dmat)) - curaddr;
++	if (dmat_mapseg(dmat) != NULL) {
++		rv = dmat_mapseg(dmat)(dmat_mapseg_arg(dmat), dmat, &curaddr,
++		    sgsize);
++		if (rv != 0) {
++			panic("%s: Cannot map DMA segment: (0x%jX, %ju)\n",
++			__func__, (uintmax_t)curaddr, (uintmax_t)sgsize);
++		}
++	}
+ 
+ 	/*
+ 	 * Insert chunk into a segment, coalescing with
+diff --git a/sys/sys/bus_dma.h b/sys/sys/bus_dma.h
+--- a/sys/sys/bus_dma.h
++++ b/sys/sys/bus_dma.h
+@@ -145,6 +145,12 @@
+  */
+ typedef int bus_dma_filter_t(void *, bus_addr_t);
+ 
++/*
++ * A function which maps PA of buffer to bus address(aka bus view).
++ */
++typedef int bus_dma_mapseg_t(void *arg, bus_dma_tag_t dmat, bus_addr_t *addr,
++    bus_size_t sizeg);
++
+ /*
+  * Generic helper function for manipulating mutexes.
+  */
+@@ -269,6 +275,12 @@
+  */
+ int bus_dma_tag_set_domain(bus_dma_tag_t dmat, int domain);
+ 
++/*
++ * Set the buffer segment mapping function. It maps PA of buffer to bus view.
++ */
++void bus_dma_tag_set_mapseg(bus_dma_tag_t dmat, bus_dma_mapseg_t *mapseg,
++     void *arg);
++
+ int bus_dma_tag_destroy(bus_dma_tag_t dmat);
+ 
+ /*
+

--- a/patches/0017-busdma-guard-the-mapseg-hook-for-non-arm64.patch
+++ b/patches/0017-busdma-guard-the-mapseg-hook-for-non-arm64.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sun, 23 Aug 2026 17:30:00 -0500
+Subject: [PATCH] busdma: guard the D58105 mapseg hook for non-arm64
+
+D58105 adds a mapseg hook to sys/kern/subr_busdma_bounce.c, but defines
+the dmat_mapseg()/dmat_mapseg_arg() accessors only in
+sys/arm64/arm64/busdma_bounce.c. That file is shared -- x86 includes it
+too -- so amd64 stops building:
+
+    sys/x86/x86/../../kern/subr_busdma_bounce.c:467:6: error: call to
+    undeclared function 'dmat_mapseg'
+
+Guard the hook on the macro being defined rather than stubbing it out on
+every other architecture, so anything without a bus view pays nothing at
+all -- not even a NULL test. `rv` moves under the same guard, since it
+is otherwise unused.
+
+Kept as a separate patch from 0016 so that what was carried from the
+review stays distinguishable from what we changed to make it build here.
+---
+diff --git a/sys/kern/subr_busdma_bounce.c b/sys/kern/subr_busdma_bounce.c
+index f95fac2..53916e9 100644
+--- a/sys/kern/subr_busdma_bounce.c
++++ b/sys/kern/subr_busdma_bounce.c
+@@ -450,7 +450,10 @@ static bus_size_t
+ _bus_dmamap_addseg(bus_dma_tag_t dmat, bus_dmamap_t map, bus_addr_t curaddr,
+     bus_size_t sgsize, bus_dma_segment_t *segs, int *segp)
+ {
+-	int seg, rv;
++	int seg;
++#ifdef dmat_mapseg
++	int rv;
++#endif
+ 
+ 	KASSERT(curaddr <= BUS_SPACE_MAXADDR,
+ 	    ("ds_addr %#jx > BUS_SPACE_MAXADDR %#jx; dmat %p fl %#x low %#jx "
+@@ -464,6 +467,13 @@ _bus_dmamap_addseg(bus_dma_tag_t dmat, bus_dmamap_t map, bus_addr_t curaddr,
+ 	 */
+ 	if (!vm_addr_bound_ok(curaddr, sgsize, dmat_boundary(dmat)))
+ 		sgsize = roundup2(curaddr, dmat_boundary(dmat)) - curaddr;
++#ifdef dmat_mapseg
++	/*
++	 * Only the arm64 bounce implementation defines dmat_mapseg; this file
++	 * is included by sys/x86/x86/busdma_bounce.c too, where it does not
++	 * exist. Guard rather than stub it out, so an architecture with no bus
++	 * view pays nothing -- not even a NULL test.
++	 */
+ 	if (dmat_mapseg(dmat) != NULL) {
+ 		rv = dmat_mapseg(dmat)(dmat_mapseg_arg(dmat), dmat, &curaddr,
+ 		    sgsize);
+@@ -472,6 +482,7 @@ _bus_dmamap_addseg(bus_dma_tag_t dmat, bus_dmamap_t map, bus_addr_t curaddr,
+ 			__func__, (uintmax_t)curaddr, (uintmax_t)sgsize);
+ 		}
+ 	}
++#endif
+ 
+ 	/*
+ 	 * Insert chunk into a segment, coalescing with

--- a/patches/series
+++ b/patches/series
@@ -12,3 +12,4 @@
 0012-linuxkpi-give-lkpinew_pci_dev-DMA-tags.patch
 0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
 0014-arm64-locore-load-SOCDEV_PA-as-a-literal.patch
+0015-bcm2712_mip-MSI-support.patch

--- a/patches/series
+++ b/patches/series
@@ -14,3 +14,4 @@
 0014-arm64-locore-load-SOCDEV_PA-as-a-literal.patch
 0015-bcm2712_mip-MSI-support.patch
 0016-busdma-arm64-bus-view-of-DMA-address-space-D58105.patch
+0017-busdma-guard-the-mapseg-hook-for-non-arm64.patch

--- a/patches/series
+++ b/patches/series
@@ -13,3 +13,4 @@
 0013-bcm2838_pci-support-the-BCM2712-PCIe-controller.patch
 0014-arm64-locore-load-SOCDEV_PA-as-a-literal.patch
 0015-bcm2712_mip-MSI-support.patch
+0016-busdma-arm64-bus-view-of-DMA-address-space-D58105.patch


### PR DESCRIPTION
Closes #82. Closes #83.

Measured on the board:

```
bcm_mip0: <BCM2712 MSI Interrupt Peripheral> mem 0x1000130000-0x10001300bf,0xfffffff000-0xffffffffff
bcm_mip1: <BCM2712 MSI Interrupt Peripheral> mem 0x1000131000-0x10001310bf,0xfffffff000-0xffffffffff
nvme0: <Generic NVMe Device> at device 0.0 on pci1
nvme0: Allocated 64MB host memory buffer
nda0: <XP1000F256G V1.28 QDT2014102964>
nda0: 244198MB (500118192 512 byte sectors)
mountroot>
```

No `unable to allocate MSI-X`, no `System interrupt issues?`, no controller timeout. `nda0` attaches about two seconds after `nvme0`, where previously it took fifteen seconds of `Root mount waiting for: CAM` and then wedged the board — polling versus interrupts.

## These were one problem

They were filed as two tickets and turned out to be inseparable. **The MSI doorbell is an inbound window.** `reg[1]` of the MIP node is `0xfffffff000`, a PCI address, and a `dma-range` maps it onto the MIP’s own control block. A device raising an MSI performs a posted write that needs translating exactly like any other DMA. With no windows programmed, MSIs allocate perfectly and land nowhere.

## Four pieces

**`bcm2712_mip.c`** — 2712 does not demultiplex MSIs at the bridge the way 2711 does; a separate block translates each into a distinct GIC SPI. So it is a translator, not a dispatcher: it owns no handler, and the sources it hands out are the GIC’s, obtained via `PIC_MAP_INTR()`. Modelled on `alpine_pci_msix.c`; register layout from OpenBSD’s ISC `bcmmip(4)`.

**Inbound windows** — `RC_BAR{1,2,3}_CONFIG` plus the UBUS remap registers, one per `dma-range`, using the controller’s size *code* rather than a length. 2711 has no UBUS and keeps its `MISC_CTRL` SCB0 path untouched.

**D58105, carried** (`patches/0016`) — 42 lines, applies to releng/15.1 unmodified, authorship left with `mmel@`. Adds a per-tag `mapseg` callback that `_bus_dmamap_addseg()` invokes to translate segments into the bus’s view. Carried rather than reimplemented because doing this inside one controller driver fixes this board and no other, and leaves `busdma` still lying to every consumer about where memory is.

**`patches/0017`** — ours, not the review’s. `subr_busdma_bounce.c` is shared with x86, which has no `dmat_mapseg` accessors, so amd64 stopped building. Guarded on the macro rather than stubbed out, so an architecture with no bus view pays nothing.

## Also

`DMA_HIGH_LIMIT` is no longer used on 2712. It is a 2711 value reached by experiment, whose own comment concedes the constraints “are not wholly clear to the author”. The windows now come from `dma-ranges` and cover all of memory; bouncing everything above 960 MiB on a 16 GiB machine would be both wrong and ruinous.

A segment no window covers returns `EINVAL` rather than passing through — passing through means a silent transfer to nowhere, which is how every bug in this class failed today.

## Register names, third time

`REG_BRIDGE_GISB_WINDOW` (`0x402c`) is `RC_BAR1_CONFIG_LO`. After `REG_DMA_CONFIG` (MISC_CTRL) and `BRIDGE_DISABLE_FLAG` (PERST), that is three registers in this driver whose FreeBSD name actively misleads. Each cost a debugging cycle.