### PR TITLE
rp1: make the peripherals behind the bridge reachable

### DIFF
--- a/patches/0020-rp1-translate-child-addresses-through-the-bars.patch
+++ b/patches/0020-rp1-translate-child-addresses-through-the-bars.patch
@@ -1,0 +1,286 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sun, 23 Aug 2026 22:30:00 -0500
+Subject: [PATCH] rp1: translate child addresses through the BARs
+
+Every peripheral behind RP1 failed to map memory:
+
+  snps_dwc3_fdt0: <DWC3> mem 0xc040200000-0xc0402fffff irq 172 on rp10
+  snps_dwc3_fdt0: Failed to map memory
+  mmio_sram0: <MMIO SRAM> mem 0xc040400000-0xc04040ffff on rp10
+  mmio_sram0: Can't allocate resources for device.
+
+simplebus_fill_ranges() cannot describe this bus, and the way it fails
+is quiet. RP1 is a PCIe endpoint, so the rp1 node's parent is a PCI node
+with #address-cells = 3, and that code folds every parent cell into one
+uint64_t:
+
+	for (k = 0; k < host_address_cells; k++) {
+		sc->ranges[i].host <<= 32;
+		sc->ranges[i].host |= base_ranges[j++];
+	}
+
+A parent address of <0x02000000 0x0 0x0> therefore shifts 0x02000000 up
+twice and straight off the top of the word, and every child is mapped at
+host address 0. Nothing warns; the arithmetic is perfectly legal.
+
+The first cell is phys.hi, a type encoding rather than address bits. The
+address is (phys.mid << 32) | phys.lo, and it is an offset into RP1's own
+flat window rather than a CPU address -- only this driver knows where the
+BARs landed, which is the part no generic code could have done.
+
+Measured on the board rather than inferred:
+
+  rp1:  #address-cells = 2, #size-cells = 2
+  pcie: #address-cells = 3
+  rp1/ranges:      child 0xc0_4000_0000 -> <0x02000000 0 0>, size 0x41_0000
+  usb@200000/reg:        0xc0_4020_0000                       size 0x10_0000
+
+That 0x410000 is wider than BAR1's 4 MB, because the flat window spans
+more than one BAR -- sram@400000 lands in BAR2. So BAR2 is mapped as a
+second window and a range is emitted per BAR covered rather than one per
+device-tree entry. Nothing assumes the BARs were assigned contiguously,
+which they need not be.
+
+BAR2 failing is not fatal: everything except the SRAM is in BAR1, so it
+costs one peripheral rather than the bridge.
+---
+diff --git a/sys/arm/broadcom/bcm2835/rp1.c b/sys/arm/broadcom/bcm2835/rp1.c
+index 03507c8..210ff81 100644
+--- a/sys/arm/broadcom/bcm2835/rp1.c
++++ b/sys/arm/broadcom/bcm2835/rp1.c
+@@ -66,12 +66,27 @@
+ /* FDT interrupt cell 1: 4 is level-triggered, per the GIC binding. */
+ #define	RP1_INTR_LEVEL		4
+ 
++/* BAR1 then BAR2; BAR0 holds the MSI-X table and is not part of the window. */
++#define	RP1_NWINDOWS		2
++
+ struct rp1_irqsrc {
+ 	struct intr_irqsrc	isrc;
+ 	u_int			vec;
+ 	bool			level;
+ };
+ 
++/*
++ * RP1 presents its peripherals as one flat window in its own address space,
++ * and the host sees that window through more than one BAR. The device-tree
++ * `ranges` describes the flat view; these describe how it is cut up.
++ */
++struct rp1_window {
++	struct resource	*res;
++	int		rid;
++	uint64_t	dev_off;	/* where this BAR starts in the flat window */
++	uint64_t	size;
++};
++
+ struct rp1_softc {
+ 	struct simplebus_softc	base;	/* must be first */
+ 	device_t		dev;
+@@ -80,6 +95,9 @@ struct rp1_softc {
+ 	struct resource		*msix_bar;
+ 	int			msix_rid;
+ 
++	struct rp1_window	win[RP1_NWINDOWS];
++	int			nwin;
++
+ 	int			nvec;
+ 	struct resource		**irq_res;
+ 	void			**cookie;
+@@ -303,6 +321,129 @@ rp1_probe(device_t dev)
+ 	return (BUS_PROBE_DEFAULT);
+ }
+ 
++/*
++ * Build the child-address -> CPU-address map.
++ *
++ * simplebus_fill_ranges() cannot be used here, and not for a subtle reason:
++ * RP1 is a PCIe endpoint, so the rp1 node's parent is a PCI node with
++ * #address-cells = 3. That generic code folds every parent cell into one
++ * uint64_t --
++ *
++ *	for (k = 0; k < host_address_cells; k++) {
++ *		sc->ranges[i].host <<= 32;
++ *		sc->ranges[i].host |= base_ranges[j++];
++ *	}
++ *
++ * -- so a parent address of <0x02000000 0x0 0x0> shifts 0x02000000 up twice
++ * and straight off the top of the word. Every child ends up mapped at host
++ * address 0. On the board that surfaced as "Failed to map memory" from every
++ * peripheral, which reads like a resource shortage rather than arithmetic.
++ *
++ * The first parent cell is phys.hi -- a type encoding, not address bits. The
++ * address is (phys.mid << 32) | phys.lo, and it is an offset into RP1's own
++ * flat window rather than a CPU address: only this driver knows where the
++ * BARs actually landed.
++ *
++ * Measured on the board:
++ *
++ *	rp1:  #address-cells = 2, #size-cells = 2
++ *	pcie: #address-cells = 3
++ *	rp1/ranges:      child 0xc0_4000_0000 -> <0x02000000 0 0>, size 0x41_0000
++ *	usb@200000/reg:        0xc0_4020_0000                       size 0x10_0000
++ *
++ * That 0x410000 is wider than BAR1 (4 MB), because the flat window spans more
++ * than one BAR -- sram@400000 lands in BAR2. So a range is emitted per BAR it
++ * covers rather than one per device-tree entry, and nothing here assumes the
++ * BARs were assigned contiguously.
++ */
++static int
++rp1_fill_ranges(device_t dev, phandle_t node)
++{
++	struct rp1_softc *sc = device_get_softc(dev);
++	struct simplebus_range *r;
++	cell_t *cells;
++	ssize_t len;
++	uint64_t bus, pci, size;
++	int host_acells, i, j, k, nent, n;
++
++	if (OF_searchencprop(OF_parent(node), "#address-cells", &host_acells,
++	    sizeof(host_acells)) <= 0)
++		return (ENXIO);
++	if (host_acells != 3) {
++		device_printf(dev, "parent is not a PCI node (#address-cells "
++		    "= %d, expected 3)\n", host_acells);
++		return (ENXIO);
++	}
++
++	len = OF_getproplen(node, "ranges");
++	if (len <= 0)
++		return (ENXIO);
++
++	nent = len / sizeof(cell_t) / (sc->base.acells + host_acells +
++	    sc->base.scells);
++	if (nent == 0)
++		return (ENXIO);
++
++	cells = malloc(len, M_DEVBUF, M_WAITOK);
++	OF_getencprop(node, "ranges", cells, len);
++
++	/* At worst every entry spans every window. */
++	sc->base.ranges = malloc(nent * sc->nwin * sizeof(*sc->base.ranges),
++	    M_DEVBUF, M_WAITOK | M_ZERO);
++
++	n = 0;
++	for (i = 0, j = 0; i < nent; i++) {
++		bus = 0;
++		for (k = 0; k < sc->base.acells; k++)
++			bus = (bus << 32) | cells[j++];
++
++		/* Skip phys.hi; the address is the remaining two cells. */
++		j++;
++		pci = (uint64_t)cells[j] << 32;
++		j++;
++		pci |= cells[j];
++		j++;
++
++		size = 0;
++		for (k = 0; k < sc->base.scells; k++)
++			size = (size << 32) | cells[j++];
++
++		/* Emit the intersection of this entry with each BAR. */
++		for (k = 0; k < sc->nwin; k++) {
++			uint64_t wstart = sc->win[k].dev_off;
++			uint64_t wend = wstart + sc->win[k].size;
++			uint64_t start = MAX(pci, wstart);
++			uint64_t end = MIN(pci + size, wend);
++
++			if (start >= end)
++				continue;
++
++			r = &sc->base.ranges[n++];
++			r->bus = bus + (start - pci);
++			r->host = rman_get_start(sc->win[k].res) +
++			    (start - wstart);
++			r->size = end - start;
++
++			if (bootverbose)
++				device_printf(dev,
++				    "range %#jx-%#jx -> %#jx (BAR%d)\n",
++				    (uintmax_t)r->bus,
++				    (uintmax_t)(r->bus + r->size - 1),
++				    (uintmax_t)r->host,
++				    sc->win[k].rid == PCIR_BAR(1) ? 1 : 2);
++		}
++	}
++
++	free(cells, M_DEVBUF);
++	sc->base.nranges = n;
++
++	if (n == 0) {
++		device_printf(dev, "ranges cover none of the mapped BARs\n");
++		return (ENXIO);
++	}
++	return (0);
++}
++
+ static int
+ rp1_attach(device_t dev)
+ {
+@@ -320,9 +461,10 @@ rp1_attach(device_t dev)
+ 	}
+ 
+ 	/*
+-	 * BAR1 is the window every peripheral lives in. Keep it mapped for as
+-	 * long as the bridge is attached; children address into it through
+-	 * the node's ranges.
++	 * BAR1 is where almost every peripheral lives, and BAR2 carries the
++	 * tail of the same flat window -- sram@400000 onwards. Both stay
++	 * mapped for as long as the bridge is attached; children address into
++	 * them through the node's ranges.
+ 	 */
+ 	sc->bar_rid = PCIR_BAR(1);
+ 	sc->bar = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &sc->bar_rid,
+@@ -331,6 +473,27 @@ rp1_attach(device_t dev)
+ 		device_printf(dev, "could not map BAR1\n");
+ 		return (ENXIO);
+ 	}
++	sc->win[0].res = sc->bar;
++	sc->win[0].rid = sc->bar_rid;
++	sc->win[0].dev_off = 0;
++	sc->win[0].size = rman_get_size(sc->bar);
++	sc->nwin = 1;
++
++	/*
++	 * BAR2 is optional in the sense that the driver is still useful
++	 * without it -- everything except the SRAM is in BAR1 -- so a failure
++	 * here costs one peripheral rather than the bridge.
++	 */
++	sc->win[1].rid = PCIR_BAR(2);
++	sc->win[1].res = bus_alloc_resource_any(dev, SYS_RES_MEMORY,
++	    &sc->win[1].rid, RF_ACTIVE);
++	if (sc->win[1].res != NULL) {
++		sc->win[1].dev_off = sc->win[0].size;
++		sc->win[1].size = rman_get_size(sc->win[1].res);
++		sc->nwin = 2;
++	} else
++		device_printf(dev, "could not map BAR2; the SRAM window will "
++		    "be unavailable\n");
+ 
+ 	/*
+ 	 * BAR0 holds the MSI-X table and the PBA -- both of them, measured
+@@ -386,11 +549,11 @@ rp1_attach(device_t dev)
+ 	if (error != 0)
+ 		goto fail;
+ 
+-	/* Become an FDT bus for the peripherals behind the BAR. */
++	/* Become an FDT bus for the peripherals behind the BARs. */
+ 	simplebus_init(dev, node);
+-	if (simplebus_fill_ranges(node, &sc->base) < 0) {
++	error = rp1_fill_ranges(dev, node);
++	if (error != 0) {
+ 		device_printf(dev, "could not parse ranges\n");
+-		error = ENXIO;
+ 		goto fail;
+ 	}
+ 
+@@ -403,6 +566,9 @@ rp1_attach(device_t dev)
+ fail:
+ 	bus_release_resource(dev, SYS_RES_MEMORY, sc->msix_rid, sc->msix_bar);
+ fail_bar:
++	if (sc->nwin > 1)
++		bus_release_resource(dev, SYS_RES_MEMORY, sc->win[1].rid,
++		    sc->win[1].res);
+ 	bus_release_resource(dev, SYS_RES_MEMORY, sc->bar_rid, sc->bar);
+ 	return (error);
+ }

--- a/patches/0022-rp1-suballocate-the-window.patch
+++ b/patches/0022-rp1-suballocate-the-window.patch
@@ -1,0 +1,287 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sun, 23 Aug 2026 23:15:00 -0500
+Subject: [PATCH] rp1: suballocate the window instead of delegating upward
+
+Fixing the ranges arithmetic was necessary and not sufficient. With
+correct addresses every peripheral still failed:
+
+  snps_dwc3_fdt0: Failed to map memory
+  mmio_sram0: Can't allocate resources for device.
+
+simplebus translates a child's address and then asks its parent to
+satisfy the allocation:
+
+	return (bus_generic_alloc_resource(bus, child, ...));
+
+That reaches pci_alloc_resource() on the PCI bus above, which forwards
+it again because the requester is not one of its own children:
+
+	if (device_get_parent(child) != dev)
+		return (BUS_ALLOC_RESOURCE(device_get_parent(dev), child, ...));
+
+So the request sails past the PCI bus and lands in the host bridge's
+memory rman -- the same rman that already granted this driver BAR1 as
+RF_ACTIVE. The child asks for a subrange of a region we are holding,
+rman refuses the overlap, and the failure reads as a resource shortage
+rather than as the ownership conflict it is.
+
+Holding the BAR and delegating children upward are mutually exclusive,
+and we cannot stop holding it: the interrupt controller lives in BAR1 at
+MSIX_CFG. So RP1 owns its window and hands out pieces of it, from an
+rman of its own over the mapped BARs.
+
+Children get a subregion of a mapping that already exists -- the BAR's
+bus tag, and its handle plus an offset -- rather than a second mapping
+of the same physical pages. Nothing here calls bus_space_map().
+
+Interrupts still go upward: those are system IRQs, mapped through this
+node as a PIC and owned above us.
+
+OpenBSD's rpone(4) arrives at the same arrangement through
+bus_space_subregion.
+---
+diff --git a/sys/arm/broadcom/bcm2835/rp1.c b/sys/arm/broadcom/bcm2835/rp1.c
+index 210ff81..fd59410 100644
+--- a/sys/arm/broadcom/bcm2835/rp1.c
++++ b/sys/arm/broadcom/bcm2835/rp1.c
+@@ -98,6 +98,15 @@ struct rp1_softc {
+ 	struct rp1_window	win[RP1_NWINDOWS];
+ 	int			nwin;
+ 
++	/*
++	 * RP1 owns its window, so it hands out pieces of it rather than
++	 * passing children up to its parent. range_win[i] says which BAR
++	 * base.ranges[i] was cut from, so an allocation can be turned into a
++	 * subregion of that BAR's existing mapping.
++	 */
++	struct rman		rman;
++	int			*range_win;
++
+ 	int			nvec;
+ 	struct resource		**irq_res;
+ 	void			**cookie;
+@@ -390,6 +399,8 @@ rp1_fill_ranges(device_t dev, phandle_t node)
+ 	/* At worst every entry spans every window. */
+ 	sc->base.ranges = malloc(nent * sc->nwin * sizeof(*sc->base.ranges),
+ 	    M_DEVBUF, M_WAITOK | M_ZERO);
++	sc->range_win = malloc(nent * sc->nwin * sizeof(*sc->range_win),
++	    M_DEVBUF, M_WAITOK | M_ZERO);
+ 
+ 	n = 0;
+ 	for (i = 0, j = 0; i < nent; i++) {
+@@ -418,6 +429,7 @@ rp1_fill_ranges(device_t dev, phandle_t node)
+ 			if (start >= end)
+ 				continue;
+ 
++			sc->range_win[n] = k;
+ 			r = &sc->base.ranges[n++];
+ 			r->bus = bus + (start - pci);
+ 			r->host = rman_get_start(sc->win[k].res) +
+@@ -444,12 +456,162 @@ rp1_fill_ranges(device_t dev, phandle_t node)
+ 	return (0);
+ }
+ 
++/*
++ * Resource allocation for the peripherals behind the BARs.
++ *
++ * simplebus normally translates a child's address through `ranges` and then
++ * asks its parent to satisfy the allocation. That cannot work here, and the
++ * way it fails is worth writing down because it looks like a shortage rather
++ * than a design conflict.
++ *
++ * simplebus_alloc_resource() ends with:
++ *
++ *	return (bus_generic_alloc_resource(bus, child, ...));
++ *
++ * which reaches pci_alloc_resource() on the PCI bus above us, and that
++ * immediately forwards it again:
++ *
++ *	if (device_get_parent(child) != dev)
++ *		return (BUS_ALLOC_RESOURCE(device_get_parent(dev), child, ...));
++ *
++ * A child of rp1 is not a child of the PCI bus, so the request sails past it
++ * and lands in the host bridge's memory rman -- the same rman that already
++ * granted us BAR1 as RF_ACTIVE. The child asks for a subrange of a region we
++ * are holding, rman refuses the overlap, and every peripheral reports
++ * "Failed to map memory".
++ *
++ * Holding the BAR and delegating children upward are mutually exclusive, and
++ * we cannot stop holding it: the interrupt controller lives in BAR1 at
++ * MSIX_CFG. So RP1 owns its window and suballocates from it, handing each
++ * child a subregion of a mapping that already exists rather than a mapping of
++ * its own. OpenBSD's rpone(4) reaches the same place via bus_space_subregion.
++ */
++static struct resource *
++rp1_alloc_resource(device_t bus, device_t child, int type, int *rid,
++    rman_res_t start, rman_res_t end, rman_res_t count, u_int flags)
++{
++	struct rp1_softc *sc = device_get_softc(bus);
++	struct simplebus_devinfo *di;
++	struct resource_list_entry *rle;
++	struct resource *rv;
++	rman_res_t hstart, hend;
++	int i, w;
++
++	/*
++	 * Resolve a default-range request from the child's resource list
++	 * FIRST, and for every type. Children ask with bus_alloc_resource_any,
++	 * and nothing above this node can resolve an FDT child's rid -- so
++	 * passing an unresolved range upward fails an interrupt allocation
++	 * just as surely as a memory one.
++	 */
++	if (RMAN_IS_DEFAULT_RANGE(start, end)) {
++		if ((di = device_get_ivars(child)) == NULL)
++			return (NULL);
++		rle = resource_list_find(&di->rl, type, *rid);
++		if (rle == NULL) {
++			if (bootverbose)
++				device_printf(bus, "no default resource for "
++				    "rid %d, type %d\n", *rid, type);
++			return (NULL);
++		}
++		start = rle->start;
++		end = rle->end;
++		count = rle->count;
++	}
++
++	/*
++	 * Interrupts are not ours to hand out -- they are system IRQs, mapped
++	 * through this node as a PIC and owned above us.
++	 */
++	if (type != SYS_RES_MEMORY)
++		return (bus_generic_alloc_resource(bus, child, type, rid,
++		    start, end, count, flags));
++
++	w = -1;
++	for (i = 0; i < sc->base.nranges; i++) {
++		struct simplebus_range *r = &sc->base.ranges[i];
++
++		if (start >= r->bus && end < r->bus + r->size) {
++			hstart = start - r->bus + r->host;
++			hend = end - r->bus + r->host;
++			w = sc->range_win[i];
++			break;
++		}
++	}
++	if (w < 0) {
++		device_printf(bus, "no range covers %#jx-%#jx\n",
++		    (uintmax_t)start, (uintmax_t)end);
++		return (NULL);
++	}
++
++	rv = rman_reserve_resource(&sc->rman, hstart, hend, count,
++	    flags & ~RF_ACTIVE, child);
++	if (rv == NULL) {
++		device_printf(bus, "cannot reserve %#jx-%#jx in the window\n",
++		    (uintmax_t)hstart, (uintmax_t)hend);
++		return (NULL);
++	}
++	rman_set_rid(rv, *rid);
++	rman_set_type(rv, type);
++
++	/*
++	 * The BAR is already mapped, so the child gets a subregion of that
++	 * mapping. Nothing here calls bus_space_map(): mapping the same
++	 * physical page twice is exactly what we are avoiding.
++	 */
++	rman_set_bustag(rv, rman_get_bustag(sc->win[w].res));
++	rman_set_bushandle(rv, rman_get_bushandle(sc->win[w].res) +
++	    (hstart - rman_get_start(sc->win[w].res)));
++
++	if ((flags & RF_ACTIVE) != 0 &&
++	    bus_activate_resource(child, type, *rid, rv) != 0) {
++		rman_release_resource(rv);
++		return (NULL);
++	}
++	return (rv);
++}
++
++static int
++rp1_activate_resource(device_t bus, device_t child, struct resource *r)
++{
++
++	/* The tag and handle were set at allocation; just mark it live. */
++	if (rman_get_type(r) == SYS_RES_MEMORY)
++		return (rman_activate_resource(r));
++	return (bus_generic_activate_resource(bus, child, r));
++}
++
++static int
++rp1_deactivate_resource(device_t bus, device_t child, struct resource *r)
++{
++
++	if (rman_get_type(r) == SYS_RES_MEMORY)
++		return (rman_deactivate_resource(r));
++	return (bus_generic_deactivate_resource(bus, child, r));
++}
++
++static int
++rp1_release_resource(device_t bus, device_t child, struct resource *r)
++{
++	int error;
++
++	if (rman_get_type(r) != SYS_RES_MEMORY)
++		return (bus_generic_release_resource(bus, child, r));
++
++	if (rman_get_flags(r) & RF_ACTIVE) {
++		error = rman_deactivate_resource(r);
++		if (error != 0)
++			return (error);
++	}
++	return (rman_release_resource(r));
++}
++
+ static int
+ rp1_attach(device_t dev)
+ {
+ 	struct rp1_softc *sc;
+ 	phandle_t node, child;
+-	int error;
++	int error, i;
+ 
+ 	sc = device_get_softc(dev);
+ 	sc->dev = dev;
+@@ -495,6 +657,29 @@ rp1_attach(device_t dev)
+ 		device_printf(dev, "could not map BAR2; the SRAM window will "
+ 		    "be unavailable\n");
+ 
++	/*
++	 * One rman over the mapped BARs. Children are satisfied from here
++	 * rather than from the host bridge, which already counts these
++	 * regions as ours.
++	 */
++	sc->rman.rm_type = RMAN_ARRAY;
++	sc->rman.rm_descr = "RP1 peripheral window";
++	error = rman_init(&sc->rman);
++	if (error != 0) {
++		device_printf(dev, "could not initialise the window rman\n");
++		goto fail_bar;
++	}
++	for (i = 0; i < sc->nwin; i++) {
++		error = rman_manage_region(&sc->rman,
++		    rman_get_start(sc->win[i].res),
++		    rman_get_end(sc->win[i].res));
++		if (error != 0) {
++			device_printf(dev, "could not manage BAR%d\n",
++			    sc->win[i].rid == PCIR_BAR(1) ? 1 : 2);
++			goto fail_bar;
++		}
++	}
++
+ 	/*
+ 	 * BAR0 holds the MSI-X table and the PBA -- both of them, measured
+ 	 * from the endpoint itself:
+@@ -577,6 +762,12 @@ static device_method_t rp1_methods[] = {
+ 	DEVMETHOD(device_probe,		rp1_probe),
+ 	DEVMETHOD(device_attach,	rp1_attach),
+ 
++	/* RP1 owns its window and suballocates it; see rp1_alloc_resource. */
++	DEVMETHOD(bus_alloc_resource,		rp1_alloc_resource),
++	DEVMETHOD(bus_release_resource,		rp1_release_resource),
++	DEVMETHOD(bus_activate_resource,	rp1_activate_resource),
++	DEVMETHOD(bus_deactivate_resource,	rp1_deactivate_resource),
++
+ 	/* RP1 is an interrupt controller for everything behind it. */
+ 	DEVMETHOD(pic_map_intr,		rp1_map_intr),
+ 	DEVMETHOD(pic_enable_intr,	rp1_enable_intr),

--- a/patches/series
+++ b/patches/series
@@ -18,3 +18,5 @@
 0018-rp1-bridge-driver.patch
 0019-rp1-interrupt-controller.patch
 0021-arm64-accept-the-freebsd-bootargs-guard-anywhere.patch
+0020-rp1-translate-child-addresses-through-the-bars.patch
+0022-rp1-suballocate-the-window.patch


### PR DESCRIPTION
Fixes #95. **Board-tested** — with this, every child of RP1 attaches and USB works end to end.

Two defects, both required, neither sufficient alone.

## 1. `simplebus_fill_ranges()` cannot read PCI `ranges`

RP1 is a PCIe endpoint, so its parent is a PCI node with `#address-cells = 3`. The generic code folds every parent cell into one `uint64_t`:

```c
for (k = 0; k < host_address_cells; k++) {
        sc->ranges[i].host <<= 32;
        sc->ranges[i].host |= base_ranges[j++];
}
```

`<0x02000000 0x0 0x0>` shifts twice and **off the top of the word**, so every child maps to host address 0. The first cell is `phys.hi` — a type encoding, not address bits. Nothing warns; the arithmetic is legal.

Also emits **a range per BAR covered** rather than one per device-tree entry: RP1 presents one flat window (`0x410000`) that is wider than BAR1's 4 MB, and the tail lives in BAR2. Deliberately does not assume the BARs are contiguous.

## 2. The bridge cannot delegate its children upward

Correct addresses were still refused. `simplebus` asks its *parent* to satisfy a child's allocation, and `pci_alloc_resource()` forwards anything whose parent is not the PCI bus:

```c
if (device_get_parent(child) != dev)
        return (BUS_ALLOC_RESOURCE(device_get_parent(dev), child, ...));
```

So the request sails past the PCI bus into the **host bridge's rman** — which already granted this driver BAR1 as `RF_ACTIVE`. rman refuses the overlap, and it reads as a resource shortage rather than as the ownership conflict it is.

Holding the BAR and delegating children upward are mutually exclusive, and BAR1 has to stay held because the interrupt controller lives in it at `MSIX_CFG`. So RP1 owns an `rman` over its window and hands out **subregions of a mapping that already exists** — the BAR's bus tag, and its handle plus an offset. Nothing calls `bus_space_map()`. OpenBSD's `rpone(4)` reaches the same arrangement via `bus_space_subregion`.

This also sidesteps a subtlety worth noting: `rman_get_start()` on a `pci_host_generic` resource returns the **PCI** address, not the CPU one (translation happens at activation). Deriving each child's handle as an offset from the BAR's own mapping makes that distinction cancel.

## Measured on the board

```
rp10: range 0xc040000000-0xc0403fffff -> 0 (BAR1)
rp10: range 0xc040400000-0xc04040ffff -> 0x400000 (BAR2)

snps_dwc3_fdt0: <Synopsys Designware DWC3> mem 0xc040200000-0xc0402fffff irq 172 on rp10
snps_dwc3_fdt0: SNPS Version: DWC3 (5533 330b)
usbus0 on snps_dwc3_fdt0
snps_dwc3_fdt1: <Synopsys Designware DWC3> mem 0xc040300000-0xc0403fffff irq 173 on rp10
usbus1 on snps_dwc3_fdt1
mmio_sram0: <MMIO SRAM> mem 0xc040400000-0xc04040ffff on rp10

usbus0: 5.0Gbps Super Speed USB v3.0
uhub0: <Synopsys XHCI root HUB, class 9/0, rev 3.00/1.00, addr 1> on usbus0
uhub0: 3 ports with 3 removable, self powered
ugen1.2: <Innostor PenDrive> at usbus1
umass0: <Innostor PenDrive, class 0/0, rev 3.10/0.01, addr 1> on usbus1
da0 at umass-sim0 bus 0 scbus1 target 0 lun 0
```

**Nothing on `rp10` fails any more.** A USB stick enumerated end to end, exercising MSI-X → the RP1 PIC → xhci interrupts → DMA → CAM.

`mmio_sram0` is the one that matters for the design: it lives in **BAR2**, so its attaching is what proves the per-BAR splitting rather than a single linear map.

Ethernet is now reachable too, awaiting only a driver (#98):

```
rp10: <ethernet@100000> mem 0xc040100000-0xc040103fff irq 166 compat raspberrypi,rp1-gem (no driver attached)
```

## Note

The bootargs fix that made this diagnosable went out separately as #102 and is already merged — `bootverbose` had never worked on this board, so `simplebus_alloc_resource()`'s own `"Could not map resource"` message was invisible. Its **absence** under verbose is what distinguished "the ranges are wrong" from "the allocation is refused downstream", after two board tests of reasoning had got it wrong.

Downstream: #97 (USB — HID still untested, keyboard is physically disconnected), #98 (Ethernet). Milestone nextbsd#416.