### PR TITLE
cgem: match RP1's Cadence GEM, and take the MAC from the device tree

### DIFF
--- a/patches/0023-cgem-match-rp1-cadence-gem.patch
+++ b/patches/0023-cgem-match-rp1-cadence-gem.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Mon, 24 Aug 2026 00:15:00 -0500
+Subject: [PATCH] cgem: match RP1's Cadence GEM
+
+RP1, the southbridge on Raspberry Pi 5-family boards, presents a Cadence
+GEM behind PCIe. Nothing matched it, so the Pi 500+ had no ethernet:
+
+  rp10: <ethernet@100000> mem 0xc040100000-0xc040103fff irq 166
+      compat raspberrypi,rp1-gem (no driver attached)
+
+cgem(4) is already compiled in on arm64 -- GENERIC includes std.xilinx,
+which carries `device cgem` -- so this is only a question of matching.
+
+HWQUIRK_NONE rather than HWQUIRK_NEEDNULLQS, on the evidence of the
+vendor driver rather than by picking the safer-sounding one.  RP1's
+macb_config in Linux differs from zynqmp's in exactly two ways: it adds
+MACB_CAPS_CLK_HW_CHG and it omits MACB_CAPS_BD_RD_PREFETCH. Descriptor
+prefetch is the reason the Zynq parts need the null queue pointers
+programmed at all, so a part without it should not need them.
+
+Everything underneath this is already proven on the board: PCIe, MSI-X,
+the RP1 interrupt controller, address translation and DMA all work, and
+the USB stack comes up on the same bus in the same boot.
+
+Untested against real silicon at the time of writing; the point of the
+change is to find out how far it gets.
+---
+diff --git a/sys/dev/cadence/if_cgem.c b/sys/dev/cadence/if_cgem.c
+index 4a7180f..fe22d54 100644
+--- a/sys/dev/cadence/if_cgem.c
++++ b/sys/dev/cadence/if_cgem.c
+@@ -110,6 +110,15 @@ static struct ofw_compat_data compat_data[] = {
+ 	{ "microchip,mpfs-mss-gem",	HWQUIRK_NEEDNULLQS },
+ 	{ "sifive,fu540-c000-gem",	HWQUIRK_NONE },
+ 	{ "sifive,fu740-c000-gem",	HWQUIRK_NONE },
++	/*
++	 * RP1, the southbridge on Raspberry Pi 5-family boards, presents a
++	 * Cadence GEM behind PCIe. HWQUIRK_NONE rather than HWQUIRK_NEEDNULLQS
++	 * on the evidence of the vendor driver: RP1's macb_config differs from
++	 * zynqmp's only in carrying MACB_CAPS_CLK_HW_CHG and NOT carrying
++	 * MACB_CAPS_BD_RD_PREFETCH -- and descriptor prefetch is the reason
++	 * the Zynq parts need the null queue pointers programmed at all.
++	 */
++	{ "raspberrypi,rp1-gem",	HWQUIRK_NONE },
+ 	{ NULL,				0 }
+ };
+ 

--- a/patches/0024-cgem-take-the-mac-address-from-the-device-tree.patch
+++ b/patches/0024-cgem-take-the-mac-address-from-the-device-tree.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Mon, 24 Aug 2026 00:45:00 -0500
+Subject: [PATCH] cgem: take the MAC address from the device tree
+
+cgem_get_mac() looks in exactly one place -- the controller's own
+address registers, on the assumption that a boot loader programmed them.
+
+On a board booted directly by firmware there is no boot loader, so the
+registers are empty and every boot invents a new random address:
+
+  cgem0: no mac address found, assigning random: 62:73:64:bd:40:7c
+
+The real address is in the device tree, where the firmware patches it.
+Measured on a Pi 500+:
+
+  ethernet@100000/local-mac-address = 88 a2 9e 49 6e b3
+
+which is the address Linux uses for eth0 on the same board.
+
+Check the tree first, fall back to the registers, then to random. A
+multicast or all-zero property is treated as absent rather than trusted,
+because both are things a firmware writes when it does not know the
+answer.
+
+Refs #98.
+---
+diff --git a/sys/dev/cadence/if_cgem.c b/sys/dev/cadence/if_cgem.c
+index fe22d54..a5f1a37 100644
+--- a/sys/dev/cadence/if_cgem.c
++++ b/sys/dev/cadence/if_cgem.c
+@@ -252,9 +252,24 @@ static void cgem_mediachange(struct cgem_softc *, struct mii_data *);
+ static void
+ cgem_get_mac(struct cgem_softc *sc, u_char eaddr[])
+ {
++	phandle_t node;
+ 	int i;
+ 	uint32_t rnd;
+ 
++	/*
++	 * The device tree may carry one. On a board booted directly by
++	 * firmware there is no boot loader to have programmed the registers
++	 * below, but the firmware does patch local-mac-address into the node
++	 * -- so on a Raspberry Pi this is the only place the real address
++	 * exists, and without it every boot invents a new random one.
++	 */
++	node = ofw_bus_get_node(sc->dev);
++	if (node > 0 && OF_getprop(node, "local-mac-address", eaddr,
++	    ETHER_ADDR_LEN) == ETHER_ADDR_LEN) {
++		if (!ETHER_IS_MULTICAST(eaddr) && !ETHER_IS_ZERO(eaddr))
++			goto found;
++	}
++
+ 	/* See if boot loader gave us a MAC address already. */
+ 	for (i = 0; i < 4; i++) {
+ 		uint32_t low = RD4(sc, CGEM_SPEC_ADDR_LOW(i));
+@@ -286,6 +301,7 @@ cgem_get_mac(struct cgem_softc *sc, u_char eaddr[])
+ 		    eaddr[1], eaddr[2], eaddr[3], eaddr[4], eaddr[5]);
+ 	}
+ 
++found:
+ 	/* Move address to first slot and zero out the rest. */
+ 	WR4(sc, CGEM_SPEC_ADDR_LOW(0), (eaddr[3] << 24) |
+ 	    (eaddr[2] << 16) | (eaddr[1] << 8) | eaddr[0]);

--- a/patches/series
+++ b/patches/series
@@ -20,3 +20,5 @@
 0021-arm64-accept-the-freebsd-bootargs-guard-anywhere.patch
 0020-rp1-translate-child-addresses-through-the-bars.patch
 0022-rp1-suballocate-the-window.patch
+0023-cgem-match-rp1-cadence-gem.patch
+0024-cgem-take-the-mac-address-from-the-device-tree.patch


### PR DESCRIPTION
Two patches toward #98. **Board-tested** — the driver attaches. It does not yet have link; see below for exactly what remains.

## 1. Match `raspberrypi,rp1-gem`

`cgem(4)` is already compiled in on arm64 (GENERIC includes `std.xilinx`, which carries `device cgem`), so this was only a matching question.

`HWQUIRK_NONE` rather than `HWQUIRK_NEEDNULLQS`, chosen on evidence rather than caution. RP1's `macb_config` in the vendor kernel differs from `zynqmp_config` in exactly two ways: it adds `MACB_CAPS_CLK_HW_CHG` and omits `MACB_CAPS_BD_RD_PREFETCH`. Descriptor prefetch is *why* the Zynq parts need the null queue pointers programmed, so a part without it should not need them.

Result on the board:

```
cgem0: <Cadence CGEM Gigabit Ethernet Interface> mem 0xc040100000-0xc040103fff irq 166 on rp10
```

It attaches. The quirk call looks right.

## 2. Take the MAC address from the device tree

```
cgem0: no mac address found, assigning random: 62:73:64:bd:40:7c
```

`cgem_get_mac()` reads only the controller's address registers, assuming a boot loader filled them in. Route (a) has no boot loader. The real address is in the device tree, where the firmware patches it:

```
ethernet@100000/local-mac-address = 88 a2 9e 49 6e b3
```

— the same address Linux uses for `eth0` on this board. Now checked first, falling back to the registers and then to random. A multicast or all-zero property is treated as absent rather than trusted, since both are what firmware writes when it does not know.

## What still blocks link

```
cgem0: could not retrieve pclk.
cgem0: could not retrieve hclk.
cgem0: warning: attaching PHYs failed
```

The clock failures are **not** fatal and are expected — `cgem` deliberately tolerates them, and the MDC divider is a fixed `CGEM_NET_CFG_MDC_CLK_DIV_48` rather than derived from `pclk`.

The PHY is the real blocker. `mii_attach(..., MII_PHY_ANY, MII_OFFSET_ANY, 0)` scans every address and finds nothing, even though the tree describes one:

```
ethernet@100000/
    phy-mode = "rgmii-id"
    phy-handle -> ethernet-phy@1
    phy-reset-gpios
    phy-reset-duration
    ethernet-phy@1/          <- a direct child, not under an mdio node
```

`phy-reset-gpios` is the strong suspect: the PHY likely needs a reset pulse before it will answer on MDIO, and RP1's GPIO block has no driver yet. That is the next thing to establish, and it is not a guess I want to bake into a patch.

Everything underneath is proven in the same boot — PCIe, MSI-X, the RP1 interrupt controller, address translation and DMA all work, and the USB stack comes up on the same bus.