### PR TITLE
rpi5: give uart(4) the real reference clock

### DIFF
--- a/config/rpi5.env
+++ b/config/rpi5.env
@@ -31,7 +31,27 @@
 #   rs:/rw: register shift and width. uart_getenv() hardcodes 0 and 1 and does
 #       NOT inherit uc_rshift/uc_riowidth from the class, but PL011 registers
 #       are 32-bit and 4-byte spaced, so both must be given explicitly.
-#   xo: rclk. 0 sets bas.rclk_guess, telling the driver to keep the divisor the
-#       firmware already programmed instead of recomputing the baud from an
-#       rclk we do not know.
-hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:0"
+#   xo: rclk, the UART reference clock in Hz.
+#
+#       This was 0, which sets bas.rclk_guess: keep whatever divisor the
+#       firmware programmed rather than recomputing it. That is fine for the
+#       early console, which never reprograms anything -- but the moment a tty
+#       is opened, uart(4) recomputes the divisor from an rclk it does not
+#       know, programs a wrong baud, and every byte after that arrives as NUL.
+#
+#       On the board that looked exactly like a hung system: perfect output
+#       through the whole kernel boot, then silence from the instant launchd
+#       opened the console. It cost three separate misdiagnoses -- the machine
+#       was running fine each time.
+#
+#       The real value is in the device tree, and it is not a guess:
+#
+#         /soc@107c000000/serial@7d001000  compatible "arm,pl011"
+#             clocks -> /clocks/clk-uart
+#                 compatible      "fixed-clock"
+#                 clock-frequency 9216000
+#
+#       It checks itself: a PL011 divides rclk by 16*baud, and
+#       9216000 / (16 * 115200) = 5 exactly. An integer divisor is what you
+#       expect from a clock chosen so that 115200 lands dead on.
+hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:9216000"


### PR DESCRIPTION
Fixes the serial console dying the moment userland starts. Refs #93.

## The symptom

Perfect console output through the entire kernel boot, then **every byte arrives as NUL** from the instant launchd opens the console:

```
early-init: opened /dev/klog (kernel.log_open=1; console quiet)
com.apple.launchd  ...  plist scan: dispatch .../com.apple.DiskArbitration.plist -> ok
<NUL NUL NUL NUL ...>
```

This looked exactly like a hang, and I diagnosed it as one **three separate times** — "stalled after DiskArbitration", "launchd hung", "board wedged". The machine was running fine every time, with a working video console and a keyboard. What was broken was my receiver's idea of the baud rate.

The tell: writing to `/dev/ttyu0` from the running system produced 64 bytes on the wire, all `0x00`. Bytes *are* being transmitted — they are just being sampled at the wrong rate.

## The cause

```
hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:0"
```

`xo:0` sets `bas.rclk_guess`: keep whatever divisor the firmware programmed rather than recomputing it. That is correct for the early console, which never reprograms anything.

It is wrong the moment a tty is **opened**. `uart(4)` then recomputes the divisor from an rclk it does not know, programs a wrong baud, and the console is garbage from that point on.

## The value, and why it is not a guess

Straight out of the device tree:

```
/soc@107c000000/serial@7d001000   compatible "arm,pl011"
    clocks -> /clocks/clk-uart
        compatible      "fixed-clock"
        clock-frequency 9216000
```

And it checks itself. A PL011 divides rclk by `16 * baud`:

```
9216000 / (16 * 115200) = 5.000000
```

An exact integer divisor is what a clock chosen so 115200 lands dead-on looks like. A wrong clock would not divide evenly.

## Why it matters beyond tidiness

On this board the serial cable is the only remote access. Losing it at the exact moment userland starts means every userland problem is invisible — which is how a perfectly healthy system got reported as hung three times running.