### PR TITLE
rpi5: set the measured UART10 reference clock

### DIFF
--- a/config/rpi5.env
+++ b/config/rpi5.env
@@ -44,7 +44,15 @@
 #       opened the console. It cost three separate misdiagnoses -- the machine
 #       was running fine each time.
 #
-#       The real value is in the device tree, and it is not a guess:
+#       MEASURED WRONG. The value below came from the device tree and looked
+#       self-verifying, and the board disagreed: with xo:9216000 the console is
+#       garbage from the kernel's first line, where xo:0 at least gives a
+#       perfect early console. So clk-uart is not the clock actually feeding
+#       UART10, or the firmware runs it at another rate. Reverted to 0 until
+#       the true rclk is measured from the PL011's own IBRD/FBRD, which is the
+#       only source that cannot be argued with.
+#
+#       The device-tree value, kept for the record:
 #
 #         /soc@107c000000/serial@7d001000  compatible "arm,pl011"
 #             clocks -> /clocks/clk-uart
@@ -54,4 +62,4 @@
 #       It checks itself: a PL011 divides rclk by 16*baud, and
 #       9216000 / (16 * 115200) = 5 exactly. An integer divisor is what you
 #       expect from a clock chosen so that 115200 lands dead on.
-hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:9216000"
+hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:0"

--- a/config/rpi5.env
+++ b/config/rpi5.env
@@ -33,33 +33,26 @@
 #       are 32-bit and 4-byte spaced, so both must be given explicitly.
 #   xo: rclk, the UART reference clock in Hz.
 #
-#       This was 0, which sets bas.rclk_guess: keep whatever divisor the
-#       firmware programmed rather than recomputing it. That is fine for the
-#       early console, which never reprograms anything -- but the moment a tty
-#       is opened, uart(4) recomputes the divisor from an rclk it does not
-#       know, programs a wrong baud, and every byte after that arrives as NUL.
+#       0 sets bas.rclk_guess: keep whatever divisor the firmware programmed
+#       rather than recomputing it. That is right for the early console, which
+#       never reprograms anything, and wrong the moment a tty is opened --
+#       uart(4) then recomputes the divisor from an rclk it does not know,
+#       programs a wrong baud, and every byte after that arrives as NUL. On
+#       this board that looked exactly like a hung system three times over.
 #
-#       On the board that looked exactly like a hung system: perfect output
-#       through the whole kernel boot, then silence from the instant launchd
-#       opened the console. It cost three separate misdiagnoses -- the machine
-#       was running fine each time.
+#       MEASURED, from the running clock framework naming its consumer:
 #
-#       MEASURED WRONG. The value below came from the device tree and looked
-#       self-verifying, and the board disagreed: with xo:9216000 the console is
-#       garbage from the kernel's first line, where xo:0 at least gives a
-#       perfect early console. So clk-uart is not the clock actually feeding
-#       UART10, or the firmware runs it at another rate. Reverted to 0 until
-#       the true rclk is measured from the PL011's own IBRD/FBRD, which is the
-#       only source that cannot be argued with.
+#         clk_uart     50000000   1f00030000.serial    <- RP1 UART0, 40-pin
+#         uart-clock   44236800   107d001000.serial    <- UART10, this one
 #
-#       The device-tree value, kept for the record:
+#       and it divides exactly: 44236800 / (16 * 115200) = 24.
 #
-#         /soc@107c000000/serial@7d001000  compatible "arm,pl011"
-#             clocks -> /clocks/clk-uart
-#                 compatible      "fixed-clock"
-#                 clock-frequency 9216000
-#
-#       It checks itself: a PL011 divides rclk by 16*baud, and
-#       9216000 / (16 * 115200) = 5 exactly. An integer divisor is what you
-#       expect from a clock chosen so that 115200 lands dead on.
-hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:0"
+#       An earlier attempt used 9216000, taken from /clocks/clk-uart in the
+#       device tree, on the strength of it dividing evenly too (giving 5). It
+#       was wrong, and the board said so immediately -- the console was garbage
+#       from the kernel's first line. 44.2368 MHz is a standard PL011 clock
+#       chosen precisely because it divides cleanly into every common baud, so
+#       an integer divisor proves nothing on its own. The clock has to be
+#       identified by which device it feeds, not by arithmetic that flatters a
+#       guess.
+hw.uart.console="mm:0x107d001000,br:115200,dt:pl011,rs:2,rw:4,xo:44236800"


### PR DESCRIPTION
Fixes #93. Two commits: a revert of a wrong value, then the measured one.

## The bug

`xo:0` sets `bas.rclk_guess` — keep the firmware's divisor rather than recomputing. Correct for the early console, wrong the moment a tty is opened: `uart(4)` recomputes from an rclk it does not know and programs a wrong baud. Every byte after that arrives as NUL.

On the board that looked exactly like a hung machine, **three separate times**. It was running fine each time, with a working video console and keyboard.

## The wrong answer, and why it was convincing

I first used `9216000`, from `/clocks/clk-uart` in the device tree, and justified it like this:

```
9216000 / (16 * 115200) = 5.000000    exact integer divisor
```

The board rejected it immediately — console garbage from the kernel's **first line**, where `xo:0` at least gave a clean early console:

```
offset      0:  98% printable      <- firmware
offset   4000: 100% printable
offset   6000:  66% printable      <- kernel takes over
offset  18000:  62% printable
```

The reasoning was worthless. **44.2368 MHz is a standard PL011 clock chosen precisely because it divides cleanly into every common baud** — so an integer divisor is what you get from many candidates, not evidence for one. I let a satisfying number stand in for a measurement.

## The measured answer

From the running clock framework, which names each clock's consumer device:

```
clk_uart      50000000   1f00030000.serial    <- RP1 UART0, the 40-pin header
uart-clock    44236800   107d001000.serial    <- UART10, the one we use
```

`44236800 / (16 * 115200) = 24` exactly.

Note the trap in plain sight: there are **two** UART clocks on this SoC, and the device tree node I read described the wrong one. The clock has to be identified by which device it feeds.

## Why this matters beyond tidiness

The serial cable is the only remote access to this board. Losing it exactly when userland starts makes every userland problem invisible — which is how a healthy system got reported as hung three times, and why the IPConfiguration question is still unanswered.