### PR TITLE
rp1: acknowledge level-triggered interrupts from post_ithread

### DIFF
--- a/patches/0028-rp1-acknowledge-level-triggered-interrupts-from-post-ithread.patch
+++ b/patches/0028-rp1-acknowledge-level-triggered-interrupts-from-post-ithread.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Mon, 24 Aug 2026 14:30:00 -0500
+Subject: [PATCH] rp1: acknowledge level-triggered interrupts from post_ithread
+
+A level-triggered source with an ithread handler delivered exactly one
+interrupt and then stopped forever.
+
+MSIX_CFG_IACK was written only in pic_post_filter. A driver that uses a
+filter reaches that; a driver that uses an ithread handler does not --
+its path is pre_ithread, handler, post_ithread. So the level was never
+acknowledged, the vector never re-armed, and the device went silent
+after its first interrupt.
+
+Measured on a Pi 500+, where this presented as ethernet receiving
+nothing:
+
+  rp10,6: cgem0                        1      <- one interrupt, ever
+  rp10,31:-_dwc3_fdt0                158
+  rp10,36:-_dwc3_fdt1               8024
+
+  dev.cgem.0.stats.rx_frames:        303      <- MAC received frames
+  dev.cgem.0.stats.rx_resource_errs:  42      <- ring filled, then dropped
+  netstat Ipkts:                       0      <- stack saw none
+
+The MAC was fine the whole time. cgem_recv() ran once and never again,
+so the ring filled and the hardware started discarding.
+
+Both USB controllers worked throughout, which is why this survived
+review: they are edge-triggered, and edge sources must NOT be acked.
+The device tree makes the split explicit --
+
+  ethernet@100000   vec=6   LEVEL_HIGH
+  usb@200000        vec=31  EDGE_RISING
+  usb@300000        vec=36  EDGE_RISING
+
+-- so every interrupt that had ever worked on this board took the edge
+path, and nothing exercised the level path until ethernet arrived.
+---
+diff --git a/sys/arm/broadcom/bcm2835/rp1.c b/sys/arm/broadcom/bcm2835/rp1.c
+index fd59410..e8c0dc4 100644
+--- a/sys/arm/broadcom/bcm2835/rp1.c
++++ b/sys/arm/broadcom/bcm2835/rp1.c
+@@ -228,6 +228,25 @@ rp1_pre_ithread(device_t dev, struct intr_irqsrc *isrc)
+ static void
+ rp1_post_ithread(device_t dev, struct intr_irqsrc *isrc)
+ {
++	struct rp1_softc *sc = device_get_softc(dev);
++	struct rp1_irqsrc *ri = (struct rp1_irqsrc *)isrc;
++
++	/*
++	 * Acknowledge a level-triggered source here as well as in
++	 * post_filter. A driver using an ithread handler -- cgem(4) does --
++	 * never goes through post_filter at all, so acknowledging only there
++	 * leaves the level asserted, the vector never re-arms, and the device
++	 * delivers exactly one interrupt for the lifetime of the system.
++	 *
++	 * That is what happened to Ethernet: the MAC received frames happily
++	 * (rx_frames climbing, rx_resource_errs climbing as the ring filled)
++	 * while the stack saw Ipkts=0, because cgem_recv() ran once and never
++	 * again. Both USB controllers were fine throughout -- they are
++	 * edge-triggered, and edge sources must NOT be acked, so nothing had
++	 * ever exercised this path.
++	 */
++	if (ri->level)
++		RP1_WR4(sc, MSIX_CFG_SET(ri->vec), MSIX_CFG_IACK);
+ 
+ 	rp1_enable_intr(dev, isrc);
+ }

--- a/patches/series
+++ b/patches/series
@@ -25,3 +25,4 @@
 0025-rp1-gpio-driver.patch
 0026-cgem-release-the-phy-from-reset.patch
 0027-bcm2835-vcbus-describe-bcm2712-and-enable-the-framebuffer.patch
+0028-rp1-acknowledge-level-triggered-interrupts-from-post-ithread.patch


### PR DESCRIPTION
Fixes #109. Ethernet receives nothing because its interrupt fires exactly once.

## The bug

`MSIX_CFG_IACK` was written **only** in `pic_post_filter`. That is reached by drivers using a *filter*; a driver using an *ithread handler* goes `pre_ithread` → handler → `post_ithread` and never touches it.

So for a level-triggered source with an ithread handler, the level is never acknowledged, the vector never re-arms, and the device delivers one interrupt for the lifetime of the system.

## Measured on the board

```
rp10,6: cgem0                        1      <- one interrupt, ever
rp10,31:-_dwc3_fdt0                158
rp10,36:-_dwc3_fdt1               8024

dev.cgem.0.stats.rx_frames:        303      <- MAC received frames fine
dev.cgem.0.stats.rx_resource_errs:  42      <- ring filled, then dropped
netstat Ipkts:                       0      <- stack saw none
```

The MAC was healthy throughout — receiving, filtering and counting frames. `cgem_recv()` ran once and never again, so the ring filled and the hardware began discarding.

## Why it survived until now

Every interrupt that had ever worked on this board is edge-triggered, and edge sources must **not** be acked. The device tree makes the split explicit:

```
ethernet@100000   vec=6   LEVEL_HIGH
usb@200000        vec=31  EDGE_RISING
usb@300000        vec=36  EDGE_RISING
```

USB exercised the edge path 8000+ times and proved nothing about the level path. Ethernet is the first level-triggered consumer on this SoC.

## Diagnosis note

Worth recording how this was found, because the first three hypotheses were all wrong: it looked like a dead PHY, then a receive-filter problem, then a DMA-translation problem. What settled it was reading the **MAC hardware counters** rather than the interface counters — `rx_frames` climbing while `Ipkts` stayed 0 proves the silicon is fine and the driver is not being told. `vmstat -i` then localised it to a single vector.

Not board-tested yet — building.