### PR TITLE
mach: wire mach_port_get_attributes as a syscall trap (unblocks on-demand launch)

### DIFF
--- a/.claude/skills/mach-syscall/SKILL.md
+++ b/.claude/skills/mach-syscall/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: mach-syscall
+description: Working in the NextBSD kernel repo — where a change belongs (patches/ vs src-overlay/), how to add or wire a Mach syscall trap, and how to build and validate a kernel change without a hot-reload loop. Use when touching src-overlay/sys/compat/mach, adding a trap, changing config/NEXTBSD, or wondering why a change compiled but nothing happened.
+---
+
+# Kernel changes and Mach syscall traps
+
+## Where a change belongs
+
+**`patches/` patches FreeBSD's own kernel. `src-overlay/` is NextBSD's own kernel code.**
+
+That is the whole rule, and it is about *intent*, not about whether the file is
+new — three patches (`0015`, `0018`, `0025`) add brand-new files, because they
+are FreeBSD-shaped drivers.
+
+| Change | Goes in |
+|---|---|
+| Edit an existing freebsd-src file | `patches/` + a line in `patches/series` |
+| New FreeBSD-shaped driver, wired via `sys/conf/files*` | `patches/` (wire it in the same patch) |
+| Anything under `compat/mach`, `dev/iokit`, `sys/sys/mach`, `sys/apple`, `kern/vfs_pivot.c` | `src-overlay/sys/…` + a line in the matching `src-overlay/conf/files.*` |
+| Option stock FreeBSD declares (`FUSEFS`, `UNIONFS`, …) | `config/NEXTBSD` |
+| Option only the overlay declares (`COMPAT_MACH`, `COMPAT_LINUX`, `LINPROCFS`, `LINSYSFS`) | a wiring step in `build.yml` — **never** `config/NEXTBSD` |
+
+### The trap in that last row
+
+`nextbsd-kernel-modules` reuses `patches/series` and `config/NEXTBSD` to build a
+KBI-matched kernel, and it **never lays in `src-overlay/`**. So an option the
+overlay declares makes that repo's `config(8)` die with `unknown option`. Naming
+them in the shared file is what broke both legs of the modules build on
+2026-08-03. `config/NEXTBSD:114-122` says so; believe it.
+
+Mechanically: `patches/` is `git apply`'d first (`build.yml:37-43`), then
+`src-overlay/sys/` is `cp -R`'d over `/usr/src/sys/` (`build.yml:111`), then five
+wiring steps `cat` fragments from `src-overlay/conf/` onto `sys/conf/files*`.
+A patch can therefore never depend on an overlay file; the overlay may assume
+patched base sources, and does.
+
+Patches target **freebsd-src `releng/15.1`** (`build.yml:15`), baked into the
+toolchain container. Application is plain `git apply` in `series` order — not
+idempotent, no `--check`, no reverse detection. Safe only because every CI run
+starts from a pristine tree. `series` order is authoritative and **not**
+numerically sorted (`0021` currently precedes `0020`); no comments, no blank
+lines.
+
+## Adding a Mach syscall trap
+
+### First, the trap that eats an afternoon
+
+**`mach_module.c`'s `osx_syscalls[]` array is dead code for registration.**
+`compat_shim.h` defines every `SYS_<name>` as `-1` (`NO_SYSCALL`), and
+`kern_syscall_helper_register` treats `NO_SYSCALL` as the end-of-array sentinel —
+so its loop exits on the first entry and registers nothing. Adding your trap
+there does exactly nothing, silently.
+
+All real wiring lives in `mach_syscall_wire.c`, which calls
+`kern_syscall_register()` directly with `offset = NO_SYSCALL`, lets the kernel
+pick a slot, and publishes it as `sysctl mach.syscall.<name>` for libmach's
+`resolve_syscall()` to find at runtime.
+
+Slot supply: 58 (10 stock `lkmnosys` + 48 from `patches/0001`), 15 in use. You
+will not need `wire_one_at()` — it exists and has never been called.
+
+### The procedure
+
+**1. Args struct** — `src-overlay/sys/sys/mach/_mach_sysproto.h`.
+
+Use the `PADL_/PADR_` pattern for *every* field:
+
+```c
+struct mach_port_get_attributes_trap_args {
+	char name_l_[PADL_(mach_port_name_t)]; mach_port_name_t name; char name_r_[PADR_(mach_port_name_t)];
+	char flavor_l_[PADL_(int)]; int flavor; char flavor_r_[PADR_(int)];
+	...
+};
+```
+
+Bare fields **silently corrupt arguments** — 4-byte fields do not line up with
+the kernel's 8-byte `register_t` slot writes, and values bleed across fields.
+Zero-arg traps use `syscallarg_t dummy;`.
+
+**Maximum 6 arguments.** FreeBSD's libc `syscall()` passes only 6 reliably on
+amd64. If you need more, drop an argument instead — `mach_port_request_notification`
+was redesigned to drop its `target`, and traps that need the task read
+`current_task()->itk_space` rather than taking it as an argument.
+
+**2. Handler** — `mach_traps.c` for the Apple trap family, or a new file under
+`src-overlay/sys/compat/mach/` for a NextBSD-original subsystem.
+
+Return `0` and put the Mach `kern_return_t` in `td->td_retval[0]`. Return
+non-zero only for real errno propagation (a failed `copyin`/`copyout`).
+
+**3. New `.c` file?** Add it to `src-overlay/conf/files.compat_mach`, keeping the
+exact form and the alphabetical order:
+
+```
+compat/mach/<file>.c    optional compat_mach compile-with "${NORMAL_C} ${COMPAT_MACH_C}"
+```
+
+Its header claims it is generated; there is no generator in this repo. Hand-maintain it.
+
+**4. Apple trap family?** Add `_MACH_KMOD_APPLE_SYSCALL_STUB(<name>);` to
+`compat_shim.h`. Skip for NextBSD-original traps — `mach_wait_quiet` is not there.
+
+**5. Six edits in `mach_syscall_wire.c`**, all required:
+
+| | What |
+|---|---|
+| a | `struct <name>_args;` forward decl |
+| b | `int sys_<name>(struct thread *, struct <name>_args *);` prototype |
+| c | `static int sys_<name>_guarded(...)` wrapper |
+| d | `static struct sysent <name>_sysent = { .sy_narg = N, .sy_call = …_guarded, … };` |
+| e | `static int <name>_offset = NO_SYSCALL;` **and** `static struct sysent <name>_old_sysent;` |
+| f | `SYSCTL_INT(_mach_syscall, OID_AUTO, <name>, CTLFLAG_RD, &<name>_offset, 0, "…");` |
+
+**6. Register and deregister**, and this is the pair most often half-done:
+
+- `wire_one("<name>", …)` — **appended last** in `mach_syscall_wire_register()`
+- `unwire_one("<name>", …)` — **prepended first** in `mach_syscall_wire_deregister()`
+
+The deregister list is the **exact reverse** of the register list. Check it:
+
+```sh
+sed -n '/^mach_syscall_wire_register/,/^}/p'   f | grep -oE 'wire_one\("[a-z_]+"'
+sed -n '/^mach_syscall_wire_deregister/,/^}/p' f | grep -oE 'unwire_one\("[a-z_]+"'
+```
+
+The counts must match and the second must be the first reversed.
+
+### Guard-wrapper shapes
+
+Three established forms — pick the closest, don't invent an error code:
+
+- **Needs Mach task state** — `mach_task_init_lazy()`, then bail with
+  `KERN_INVALID_ARGUMENT` (4). The `_kernelrpc_mach_port_*` family uses
+  `KERN_RESOURCE_SHORTAGE` (6); the `*_self_trap` family returns `0`
+  (`MACH_PORT_NULL`).
+- **Needs task *and* thread state** — also `mach_thread_init_lazy()`.
+- **Needs neither** — thin pass-through, kept for symmetry (`mach_wait_quiet`).
+
+### Naming
+
+**The sysctl uses the userland name; the kernel symbol keeps Apple's
+`_kernelrpc_*_trap` form.** `sysctl mach.syscall.mach_port_move_member` publishes
+`_kernelrpc_mach_port_move_member_offset`, because libmach does
+`resolve_syscall("mach_port_move_member")`. The string passed to `wire_one()` is
+the userland form.
+
+### Include order
+
+`#include <sys/sysproto.h>` **must precede** `<sys/mach/_mach_sysproto.h>` in
+every `.c`. Getting this backwards silently corrupts syscall arguments. There are
+shouting comments about it in both `mach_syscall_wire.c` and `mach_busystate.c`.
+
+### Before writing a new trap, check it isn't already there
+
+Several handlers exist in `mach_traps.c` but were never wired — as of writing,
+`_kernelrpc_mach_port_mod_refs_trap` and `_kernelrpc_mach_port_insert_member_trap`.
+And several *implementations* exist in `ipc/mach_port.c` reachable only via MIG,
+with no trap at all. Wiring an existing implementation is a fraction of the work
+of writing one. `sysctl mach.syscall` on a booted image lists what is currently
+exposed; `grep -n '^mach_port_' ipc/mach_port.c` lists what exists.
+
+## Provenance — check before editing
+
+Four strata under `src-overlay/sys/compat/mach/`, with different rules:
+
+- **OSF/CMU Mach** (`ipc/*.c`, `kern/*.c`) — vendored 1991-1998. Edit in place,
+  leave a `nextbsd#NNN` comment. Not frozen.
+- **Apple/XNU, APSL** (`sys/sys/mach/*.h`, all of `sys/apple/`) — same.
+- **NextBSD 2014-15, Matthew Macy** (`mach_traps.c`, `mach_task.c`, `mach_vm.c`, …).
+- **MIG-generated** (`*_server.c`, `*_server.h`) — **do not hand-edit.** Frozen
+  2015 artefacts; there are no `.defs` in this repo and no MIG in the build.
+
+## Building and testing
+
+**There is no hot-reload loop.** Mach is compiled *into* the kernel
+(`options COMPAT_MACH`, `NO_MODULES=yes`), there is no `mach.ko`, and image
+assembly deletes `/boot/kernel/*.ko`. Any change here costs a full kernel build
+and a reboot. Budget ~10-13 min per CI iteration; arm64 is the long pole because
+it builds two kernels.
+
+**Open a PR — do not just push a branch.** A PR is the only event that assembles
+a `disk.img` and boot-tests it. And because there is no `concurrency:` block and
+`push` has no branch filter, pushing to a PR branch fires *two* full builds; the
+`push` one is pure waste.
+
+### Getting something you can run
+
+```sh
+gh run list --repo nextbsd-redux/nextbsd-kernel --branch <branch> --limit 5
+# bootable image — PR runs only, amd64 only:
+gh run download <run-id> -n nextbsd-ci-image-amd64      # 575 MB
+# kernel binary for an existing VM — any run, either arch:
+gh run download <run-id> -n nextbsd-kernel-arm64        # 153 MB
+```
+
+The kernel binary is inside at a path matching `*sys/NEXTBSD/kernel`.
+
+Installing on a running VM:
+
+```sh
+# make a fallback FIRST — images ship without one
+mkdir -p /boot/kernel.old && cp -p /boot/kernel/kernel /boot/kernel.old/kernel
+install -m555 kernel /boot/kernel/kernel
+reboot
+```
+
+If it does not boot, escape at the loader prompt with `boot /boot/kernel.old/kernel`.
+**Know that escape before you install**, because a NextBSD image has no
+`kernel.old` until you make one.
+
+Caveat: kexts in `/System/Library/Extensions` are built against the last **main**
+`continuous` obj tree. A PR kernel that changes KBI can make them fail to load,
+and CI never sees it — the CI image has the same mismatched pairing.
+
+### Green CI is not evidence
+
+The boot test is `continue-on-error: true`. The **only** gate is grepping
+`boot.log` for a getty `login:` line. Everything after it — the whole Mach and
+userland marker census — is informational. A run has shipped green with
+`FBSDGLUE-FAIL` and ~20 later markers never executed.
+
+**Download the `boot-log` artifact and read it.** Compare the marker census
+against a known-good run; a missing marker looks identical to a passing one in
+the job summary. The Mach-specific ones are `MACH-SMOKE-OK`, `MACH-PORT-OK`,
+`EVFILT-MACHPORT-OK`, `EVFILT-MACHPORT-CONCURRENT-OK`.
+
+Also: the boot-test script is fetched **unpinned** from `nextbsd` main at run
+time, so your PR's result can change without your PR changing. And the `disk.img`
+is assembled from *other repos'* `continuous` artifacts — a red smoke test may be
+a stale sibling, not your change. Check whether it reproduces on an unrelated PR.
+
+### In-kernel tests nothing runs
+
+`mach_test.c` is compiled into every kernel and exposes two sysctls that no CI
+job and no on-image script ever reads:
+
+```sh
+sysctl mach.test_port_lifecycle       # returns ports cycled (default 100)
+sysctl mach.test_in_kernel_mqueue     # returns kmsg enqueue/dequeue cycles
+sysctl mach.test_port_lifecycle=10000 # bump N first (max 100000) to stress
+```
+
+A returned count below the requested N is a failure. Use them after any IPC
+change — they are the cheapest real signal available, and currently free.
+
+`sysctl mach.debug_enable=1` gives verbose Mach logging, but floods the emulated
+UART and perturbs timing-sensitive handshakes. Do not leave it on during a boot test.
+
+## Publishing
+
+`publish` is main-only and refreshes the rolling `continuous` prerelease. It
+needs the arm64 leg, so arm64 is load-bearing even for an amd64-only change.
+A merged kernel change does **not** automatically reach an ISO — `nextbsd-pkg`
+auto-triggers on `userland-updated` only, so a kernel-only change needs a manual
+`workflow_dispatch` there.
+
+`main` is not branch-protected. Nothing mechanically stops a merge on red.

--- a/patches/README.md
+++ b/patches/README.md
@@ -13,7 +13,7 @@ for p in $(cat patches/series); do git apply patches/$p; done
 ```
 
 so anything in `series` is treated as a filename. Keep it to real patch names.
-An empty `series` (the initial state) builds stock `releng/15.0` + the `NEXTBSD`
+An empty `series` (the initial state) builds stock `releng/15.1` + the `NEXTBSD`
 config — a clean baseline.
 
 ## Adding a patch
@@ -42,7 +42,7 @@ the base branch moves &mdash; they are carried, not owned.
 
 `0010` is required on Apple's Virtualization.framework: VZ publishes no GOP and
 its ACPI carries no SPCR, so a virtio-console consdev is the only console a
-guest can have. Verified to apply cleanly to `releng/15.0` and to reference only
+guest can have. Verified to apply cleanly to `releng/15.1` and to reference only
 symbols present there (`cnadd(9)`).
 
 A companion GIC patch (`aabce0c83`, detect the GIC version from `GICD_PIDR2`

--- a/src-overlay/sys/compat/mach/mach_syscall_wire.c
+++ b/src-overlay/sys/compat/mach/mach_syscall_wire.c
@@ -58,6 +58,7 @@ struct task_set_special_port_trap_args;
 struct host_set_special_port_trap_args;
 struct _kernelrpc_mach_port_move_member_trap_args;
 struct mach_wait_quiet_args;
+struct mach_port_get_attributes_trap_args;
 
 SYSCTL_DECL(_mach);
 static SYSCTL_NODE(_mach, OID_AUTO, syscall, CTLFLAG_RW, 0,
@@ -96,6 +97,8 @@ int sys_host_set_special_port_trap(struct thread *,
 int sys__kernelrpc_mach_port_move_member_trap(struct thread *,
     struct _kernelrpc_mach_port_move_member_trap_args *);
 int sys_mach_wait_quiet(struct thread *, struct mach_wait_quiet_args *);
+int sys_mach_port_get_attributes_trap(struct thread *,
+    struct mach_port_get_attributes_trap_args *);
 
 /*
  * Phase C2: lazy Mach init. If the calling process/thread has no
@@ -330,6 +333,24 @@ sys_mach_wait_quiet_guarded(struct thread *td, struct mach_wait_quiet_args *uap)
 	return (sys_mach_wait_quiet(td, uap));
 }
 
+/*
+ * mach_port_get_attributes — needs Mach task state; the handler reaches
+ * current_task()->itk_space. Same shape and same error code as
+ * mach_port_move_member above.
+ */
+static int
+sys_mach_port_get_attributes_trap_guarded(struct thread *td,
+    struct mach_port_get_attributes_trap_args *uap)
+{
+	if (td->td_proc->p_machdata == NULL)
+		mach_task_init_lazy(td->td_proc);
+	if (td->td_proc->p_machdata == NULL) {
+		td->td_retval[0] = 4;	/* KERN_INVALID_ARGUMENT */
+		return (0);
+	}
+	return (sys_mach_port_get_attributes_trap(td, uap));
+}
+
 static struct sysent mach_reply_port_sysent = {
 	.sy_narg	= 0,
 	.sy_call	= (sy_call_t *)sys_mach_reply_port_guarded,
@@ -466,6 +487,18 @@ static struct sysent mach_wait_quiet_sysent = {
 	.sy_flags	= 0,
 };
 
+/*
+ * mach_port_get_attributes sysent. 4 args: (name, flavor, info, count).
+ * The task is implicit (current_task()), as for mach_port_move_member.
+ * Backs launchd's demand-launch scan, which needs mps_msgcount.
+ */
+static struct sysent mach_port_get_attributes_sysent = {
+	.sy_narg	= 4,
+	.sy_call	= (sy_call_t *)sys_mach_port_get_attributes_trap_guarded,
+	.sy_auevent	= AUE_NULL,
+	.sy_flags	= 0,
+};
+
 static int mach_reply_port_offset = NO_SYSCALL;
 static struct sysent mach_reply_port_old_sysent;
 
@@ -507,6 +540,9 @@ static struct sysent _kernelrpc_mach_port_move_member_old_sysent;
 
 static int mach_wait_quiet_offset = NO_SYSCALL;
 static struct sysent mach_wait_quiet_old_sysent;
+
+static int mach_port_get_attributes_offset = NO_SYSCALL;
+static struct sysent mach_port_get_attributes_old_sysent;
 
 SYSCTL_INT(_mach_syscall, OID_AUTO, mach_reply_port, CTLFLAG_RD,
     &mach_reply_port_offset, 0,
@@ -596,6 +632,11 @@ SYSCTL_INT(_mach_syscall, OID_AUTO, mach_wait_quiet, CTLFLAG_RD,
     &mach_wait_quiet_offset, 0,
     "Dynamically-allocated FreeBSD syscall number for mach_wait_quiet "
     "(1-arg syscall; -1 if registration failed)");
+
+SYSCTL_INT(_mach_syscall, OID_AUTO, mach_port_get_attributes, CTLFLAG_RD,
+    &mach_port_get_attributes_offset, 0,
+    "Dynamically-allocated FreeBSD syscall number for "
+    "mach_port_get_attributes (4-arg syscall; -1 if registration failed)");
 
 static void
 wire_one(const char *name, int *offset, struct sysent *sy,
@@ -696,12 +737,18 @@ mach_syscall_wire_register(void *arg __unused)
 	    &_kernelrpc_mach_port_move_member_old_sysent);
 	wire_one("mach_wait_quiet", &mach_wait_quiet_offset,
 	    &mach_wait_quiet_sysent, &mach_wait_quiet_old_sysent);
+	wire_one("mach_port_get_attributes", &mach_port_get_attributes_offset,
+	    &mach_port_get_attributes_sysent,
+	    &mach_port_get_attributes_old_sysent);
 }
 
 static void
 mach_syscall_wire_deregister(void *arg __unused)
 {
 
+	unwire_one("mach_port_get_attributes",
+	    &mach_port_get_attributes_offset,
+	    &mach_port_get_attributes_old_sysent);
 	unwire_one("mach_wait_quiet", &mach_wait_quiet_offset,
 	    &mach_wait_quiet_old_sysent);
 	unwire_one("mach_port_move_member",

--- a/src-overlay/sys/compat/mach/mach_traps.c
+++ b/src-overlay/sys/compat/mach/mach_traps.c
@@ -447,6 +447,65 @@ sys__kernelrpc_mach_port_mod_refs_trap(struct thread *td, struct _kernelrpc_mach
 	return (0);
 }
 
+/*
+ * mach_port_get_attributes — MACH_PORT_RECEIVE_STATUS only.
+ *
+ * launchd's demand-launch scan needs one field, mps_msgcount: "does this
+ * machservice port have a message waiting?". Without it, mportset_callback()
+ * in launchd cannot tell which ports are hot and on-demand jobs never start
+ * (nextbsd-userland#79). The MIG server routine has always existed; only the
+ * direct trap was missing, so libmach stubbed the call out and returned
+ * KERN_RESOURCE_SHORTAGE.
+ *
+ * Deliberately narrow: other flavors (MACH_PORT_LIMITS_INFO, the DNREQUESTS
+ * and *_INFO variants) are implemented in mach_port_get_attributes() but have
+ * no in-tree caller, so wiring them would be untested surface. Add them when
+ * something needs them.
+ *
+ * The task is implicit (current_task()->itk_space) rather than an argument,
+ * matching _kernelrpc_mach_port_move_member_trap and keeping the argument
+ * count low -- see the 6-argument ceiling noted in _mach_sysproto.h.
+ */
+int
+sys_mach_port_get_attributes_trap(struct thread *td,
+    struct mach_port_get_attributes_trap_args *uap)
+{
+	ipc_space_t space = current_task()->itk_space;
+	mach_port_status_t status;
+	mach_msg_type_number_t count;
+	kern_return_t kr;
+	int error;
+
+	if (uap->flavor != MACH_PORT_RECEIVE_STATUS) {
+		td->td_retval[0] = KERN_INVALID_ARGUMENT;
+		return (0);
+	}
+	if ((error = copyin(uap->count, &count, sizeof(count))) != 0)
+		return (error);
+	if (count < MACH_PORT_RECEIVE_STATUS_COUNT) {
+		td->td_retval[0] = KERN_FAILURE;
+		return (0);
+	}
+
+	bzero(&status, sizeof(status));
+	count = MACH_PORT_RECEIVE_STATUS_COUNT;
+	kr = mach_port_get_attributes(space, uap->name, uap->flavor,
+	    (mach_port_info_t)&status, &count);
+	if (kr != KERN_SUCCESS) {
+		td->td_retval[0] = kr;
+		return (0);
+	}
+
+	if ((error = copyout(&status, uap->info,
+	    count * sizeof(integer_t))) != 0)
+		return (error);
+	if ((error = copyout(&count, uap->count, sizeof(count))) != 0)
+		return (error);
+
+	td->td_retval[0] = KERN_SUCCESS;
+	return (0);
+}
+
 int
 sys__kernelrpc_mach_port_move_member_trap(struct thread *td, struct _kernelrpc_mach_port_move_member_trap_args *uap)
 {

--- a/src-overlay/sys/sys/mach/_mach_sysproto.h
+++ b/src-overlay/sys/sys/mach/_mach_sysproto.h
@@ -115,6 +115,12 @@ struct _kernelrpc_mach_port_mod_refs_trap_args {
 	char right_l_[PADL_(mach_port_right_t)]; mach_port_right_t right; char right_r_[PADR_(mach_port_right_t)];
 	char delta_l_[PADL_(mach_port_delta_t)]; mach_port_delta_t delta; char delta_r_[PADR_(mach_port_delta_t)];
 };
+struct mach_port_get_attributes_trap_args {
+	char name_l_[PADL_(mach_port_name_t)]; mach_port_name_t name; char name_r_[PADR_(mach_port_name_t)];
+	char flavor_l_[PADL_(int)]; int flavor; char flavor_r_[PADR_(int)];
+	char info_l_[PADL_(mach_port_info_t)]; mach_port_info_t info; char info_r_[PADR_(mach_port_info_t)];
+	char count_l_[PADL_(mach_msg_type_number_t *)]; mach_msg_type_number_t * count; char count_r_[PADR_(mach_msg_type_number_t *)];
+};
 struct _kernelrpc_mach_port_move_member_trap_args {
 	char target_l_[PADL_(mach_port_name_t)]; mach_port_name_t target; char target_r_[PADR_(mach_port_name_t)];
 	char member_l_[PADL_(mach_port_name_t)]; mach_port_name_t member; char member_r_[PADR_(mach_port_name_t)];


### PR DESCRIPTION
Wires `mach_port_get_attributes` as a direct syscall trap. **Prerequisite for
`nextbsd-userland#79`** (on-demand Mach-service launch), which cannot be fixed
without it.

## Why

launchd's demand scan asks the kernel which member ports of `demand_port_set`
have queued messages. libmach's `mach_port_get_attributes` is a stub returning
`KERN_RESOURCE_SHORTAGE`, because no such trap is exposed:

```
$ sysctl mach.syscall.mach_port_get_attributes
NOT PRESENT
```

So `mportset_callback()` can never identify a hot port, no job is kickstarted,
and the client blocks forever waiting for a reply nobody sends. Measured on
hardware: **210 seconds** with a demand message queued on
`com.apple.system.logger` and no spawn attempt, while `launchctl start` returned
instantly in the same window.

## What this actually adds

Very little — **the kernel implementation already exists and is complete.**
`ipc/mach_port.c`'s `mach_port_get_attributes()` handles
`MACH_PORT_RECEIVE_STATUS` and populates `mps_msgcount`, the single field
launchd reads. It was reachable only through MIG. This adds the direct trap
around existing, working code.

## Scope

**`MACH_PORT_RECEIVE_STATUS` only.** The other flavors are implemented but have
no in-tree caller; wiring them would add untested surface for no consumer.

**`mach_port_get_set_status` is deliberately NOT wired**, even though it is the
function launchd literally calls today. It is the only trap in the set returning
out-of-line memory, and libmach's `vm_deallocate` is a no-op (it is also called
on `malloc`'d `mig_allocate` buffers) — so a caller would leak a page per wakeup
in PID 1, forever, and fixing that drags an unrelated `mig_allocate` provenance
refactor into scope. launchd will instead enumerate its own `port_hash[]`, which
it already owns, and ask the kernel only for the message count. That also
repairs `job_keepalive`'s dead queued-message check (`core.c:6404`) for free.

## Conformance

Follows the existing pattern end to end:

- `PADL_/PADR_` args struct — bare fields silently corrupt arguments
- Task implicit via `current_task()->itk_space`, keeping this to 4 args and well
  inside the 6-argument ceiling
- Guarded wrapper with `mach_task_init_lazy` + `KERN_INVALID_ARGUMENT`, matching
  `mach_port_move_member`
- Sysctl uses the userland name; kernel symbol keeps its own
- All six wiring edits in `mach_syscall_wire.c`

**Register/deregister symmetry verified** — 15 each, exact mirror, new entry
appended last in register and prepended first in deregister.

## Also in this PR

**`.claude/skills/mach-syscall/SKILL.md`** — the conventions I had to reverse
engineer to write this, so the next person doesn't: the `patches/` vs
`src-overlay/` rule and the `config/NEXTBSD` trap that broke the modules build
in August; the full add-a-trap procedure; and the build/validation loop
including the fact that green CI is not evidence (the boot test is
`continue-on-error`, gated only on reaching `login:`).

It also records two things worth knowing that cost me time here: that
`mach_module.c`'s `osx_syscalls[]` is dead code for registration, and that
several trap handlers already exist in `mach_traps.c` unwired
(`_kernelrpc_mach_port_mod_refs_trap`, `_kernelrpc_mach_port_insert_member_trap`)
— the `mod_refs` one being a plausible cause of stale ports lingering in
`demand_port_set`.

**`patches/README.md`** — two stale `releng/15.0` references corrected to
`releng/15.1`, which is what `build.yml:15` actually pins, including a claim
that the patches were "verified to apply cleanly to releng/15.0".

## Testing

**Not yet booted.** CI is the first exercise; I will install the arm64 kernel on
a live VM and verify before this is merged.

The check is a clean single variable — on the current kernel:

```
$ sysctl mach.syscall.mach_port_get_attributes
NOT PRESENT
```

and after, it should return a slot number. Then the real test: stop syslogd,
send to `com.apple.system.logger`, and confirm launchd spawns it — the exact
experiment that failed for 210 s.

**Review focus:** the `copyout` bounds in the handler. `count` is validated
against `MACH_PORT_RECEIVE_STATUS_COUNT` before the call and reset to it after,
so the copyout length is fixed, but a second pair of eyes on that is worth having
in PID-1-adjacent code.
