### PR TITLE
mach: set UserPrefix _kernelrpc_ in mach_port.defs, matching Apple

### DIFF
--- a/src-overlay/sys/sys/mach/mach_port.defs
+++ b/src-overlay/sys/sys/mach/mach_port.defs
@@ -40,6 +40,27 @@ subsystem
 	mach_port 3200;
 
 /*
+ * UserPrefix _kernelrpc_ -- Apple's own mach_port.defs sets exactly this.
+ *
+ * It renames only the generated CLIENT stubs; server stub names are
+ * unaffected (verified by regenerating the server with and without it and
+ * diffing the _X* dispatch names -- identical, 5104 lines either way).
+ *
+ * libmach needs it. Nine of its mach_port entry points are real syscall
+ * traps today, and Apple's shape is trap-first with a MIG fallback:
+ *
+ *     rv = _kernelrpc_mach_port_allocate_trap(task, right, name);
+ *     if (rv == MACH_SEND_INVALID_DEST)
+ *             rv = _kernelrpc_mach_port_allocate(task, right, name);
+ *
+ * Without the prefix the generated client would define mach_port_allocate
+ * itself and collide with the trap wrapper that is supposed to call it.
+ * With it, the wrappers keep the public names and the MIG stubs sit
+ * underneath -- which is exactly how libsyscall is arranged.
+ */
+UserPrefix _kernelrpc_;
+
+/*
  * std_types.defs and mach_types.defs are NOT carried in this repo. They
  * describe the WIRE types, which must be byte-identical on both sides of the
  * RPC, so there is exactly one copy -- nextbsd-userland's, at


### PR DESCRIPTION
Apple's own `mach_port.defs` carries exactly this line. Ours didn't, because the reconstruction took routine *bodies* from Apple while the subsystem header was written here.

## It is client-only, and that is proven rather than assumed

Regenerating the server with and without `UserPrefix` produces a **byte-identical** file — 5,110 lines either way — and the ABI gate still reports 36/36 against the frozen contract. I checked this specifically because the server side is already merged and working, and I did not want to disturb it.

## Why libmach needs it

Nine of libmach's `mach_port` entry points are real syscall traps, and Apple's shape is trap-first with a MIG fallback:

```c
rv = _kernelrpc_mach_port_allocate_trap(task, right, name);
if (rv == MACH_SEND_INVALID_DEST)
        rv = _kernelrpc_mach_port_allocate(task, right, name);   /* MIG */
```

Without the prefix, the generated client would define `mach_port_allocate` itself and collide with the trap wrapper that is supposed to call it. With it, the wrappers keep the public names and the MIG stubs sit underneath — which is how `libsyscall` is arranged.

Verified the generated client emits the prefixed names and no unprefixed ones, including the four that matter for #83: `_kernelrpc_mach_port_get_set_status`, `_kernelrpc_mach_port_get_attributes`, `_kernelrpc_mach_port_type`, `_kernelrpc_mach_port_mod_refs`.

Refs #125. Unblocks nextbsd-userland#83.