### PR TITLE
mach: fix use-after-free of the port set in ipc_mqueue_deliver (#131)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_mqueue.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_mqueue.c
@@ -503,12 +503,37 @@ ipc_mqueue_deliver(
 			return (MACH_MSG_SUCCESS);
 		}
 	}
+	/*
+	 * Hold a reference across the unlock (nextbsd-kernel#131).
+	 *
+	 * pset was read from port->ip_pset under the port lock and is stable
+	 * only while that lock is held -- ipc_pset_destroy() clears
+	 * port->ip_pset with the port locked. Dropping the lock and THEN
+	 * dereferencing pset is a use-after-free: a concurrent
+	 * mach_port_mod_refs() on the set can run ipc_pset_destroy(), release
+	 * the last reference and free it, and ipc_pset_signal() below then
+	 * touches freed memory:
+	 *
+	 *     Fatal trap 12: page fault while in kernel mode
+	 *     fault virtual address = 0x488        (~ips_note_lock)
+	 *     ... sys_mach_msg_trap+0x30
+	 *
+	 * Take the reference while still locked, so the set cannot be freed
+	 * under us, and drop it once the signal has been delivered. Nothing
+	 * above returns after this point without going through the release
+	 * below -- the earlier returns all happen before the reference is
+	 * taken.
+	 */
+	if (pset != NULL)
+		ips_reference(pset);
 	ip_unlock(port);
 
 	LAUNCHD_TRACE("deliver enqueued kmsg, no receiver, ip_msgcount=%d", port->ip_msgcount);
 
-	if (pset)
+	if (pset != NULL) {
 		ipc_pset_signal(pset);
+		ips_release(pset);
+	}
 
 	TR_IPC_MQEX("exit: wakeup 0x%x", receiver);
 	return MACH_MSG_SUCCESS;


### PR DESCRIPTION
Userland could panic the kernel by destroying a port set while a message was being delivered to one of its members.

```
Fatal trap 12: page fault while in kernel mode
fault virtual address = 0x488
current process       = 42 (test_evfilt_machpor)
... sys_mach_msg_trap+0x30
Uptime: 1s
```

## The bug

`ipc_mqueue_deliver()` reads `pset` from `port->ip_pset` under the port lock, drops that lock, and *then* dereferences it:

```c
ip_unlock(port);
...
if (pset)
        ipc_pset_signal(pset);
```

`port->ip_pset` is stable **only while the port is locked** — `ipc_pset_destroy()` clears it with the port held. So in the window after `ip_unlock()`, a concurrent `mach_port_mod_refs()` can run `ipc_pset_destroy()`, drop the last reference and `uma_zfree()` the set. `ipc_pset_signal()` then takes `sx_slock()` on freed memory — and `0x488` is about where `ips_note_lock` sits in `struct ipc_pset`.

## The fix

Take a reference while the port is still locked; drop it after the signal. Every earlier return happens before the reference is taken, so no path leaks it.

## Why that alone is sufficient

Worth spelling out, because it is not obvious. `ipc_pset_destroy()` also calls `knlist_destroy()`, so you might reasonably expect the knlist to be torn down under us even with a reference held. It is not:

- `ips_note_lock` is an **external** sx (`sx_init` at ipc_pset.c:209, handed to `knlist_init`). FreeBSD's `knlist_destroy()` clears list state and nulls its own lock callbacks; it does not destroy a caller-supplied lock.
- Nothing ever calls `sx_destroy()` on it, so the sx stays valid until the pset memory is freed — which the reference now prevents.
- `ipc_pset_signal()` uses `sx_slock()` and `KNLIST_EMPTY()` **directly**, not through the knlist callbacks, so the nulled callbacks are irrelevant.

A signal racing a destroy therefore finds a valid sx and an already-cleared knlist, and returns immediately.

## How it surfaced

Found while wiring `mach_port_mod_refs()` to the real MIG client in nextbsd-userland#83. That stub returned `KERN_SUCCESS` without doing anything, so **port sets were never actually destroyed** and this race had nothing to race against. `test_evfilt_machport_concurrent` has been passing for that reason, not because the path was sound.

Closes #131. Unblocks the last routine in nextbsd-userland#83.
