### PR TITLE
mach: define KERNEL_SERVER when generating — restores the ipc_space_t intran

### DIFF
--- a/ci/gen-mig-servers.sh
+++ b/ci/gen-mig-servers.sh
@@ -112,10 +112,15 @@ gen_one() {
     sub=$1
     out="$SRCDIR/compat/mach/${sub}_server.c"
     echo "==> generating $sub -> $out"
-    # NEXTBSD_KERNEL_SERVER, deliberately NOT KERNEL_SERVER: we want the kernel
-    # server WITHOUT Apple's modern *_from_user entry-point renames, which this
-    # kernel does not implement.
-    ${HOSTCC:-cc} -E -x c -D__MACH30__ -DNEXTBSD_KERNEL_SERVER=1 \
+    # KERNEL_SERVER must be defined. It does two unrelated jobs in Apple's
+    # headers: it selects the *_from_user entry-point names, and it activates
+    # the intran/destructor translations in mach_types.defs. We collapsed the
+    # name blocks in mach_port.defs so only the translations remain -- without
+    # them the dispatch passes the raw request port where an ipc_space_t is
+    # required and the kernel page-faults in ipc_right_lookup(). See the header
+    # of mach_port.defs. NEXTBSD_KERNEL_SERVER still gates the KernelServer
+    # subsystem directive.
+    ${HOSTCC:-cc} -E -x c -D__MACH30__ -DNEXTBSD_KERNEL_SERVER=1 -DKERNEL_SERVER=1 \
         -I "$WORK/incl" "$WORK/incl/mach/${sub}.defs" \
       | "$WORK/migcom" \
             -server "$out" \

--- a/src-overlay/sys/sys/mach/mach_port.defs
+++ b/src-overlay/sys/sys/mach/mach_port.defs
@@ -15,16 +15,43 @@
  * cannot be substituted for this file.  Verify with the dispatch-table diff
  * before changing anything here.
  *
- * Routine bodies are Apple's, kept verbatim including their #ifdef blocks --
- * the C preprocessor resolves them, exactly as mig(1) intends.  We define
- * neither KERNEL_SERVER nor LIBSYSCALL_INTERFACE: our kernel implements the
- * plain entry-point names (no _from_user suffix) and the frozen server uses
- * mach_vm_address_t for port context.  Signatures were cross-checked against
- * the frozen __Request__/__Reply__ structs: 35/35 agree.
+ * Routine bodies are Apple's, with ONE change: their
  *
- * KernelServer is therefore gated on our own NEXTBSD_KERNEL_SERVER rather
- * than KERNEL_SERVER, so that asking for a kernel server does not also opt
- * into Apple's modern *_from_user renames.
+ *     #ifdef KERNEL_SERVER
+ *     <name>_from_user( port : mach_port_t;
+ *     #else
+ *     <name>( task : ipc_space_t;
+ *     #endif
+ *
+ * name blocks are collapsed to the plain spelling, because this kernel
+ * implements <name>, not <name>_from_user.
+ *
+ * That collapse is what lets the generation step define KERNEL_SERVER, and
+ * it MUST define it. KERNEL_SERVER does two unrelated jobs in Apple's
+ * headers: it selects those *_from_user names, and it activates the intran /
+ * destructor translations in mach_types.defs --
+ *
+ *     type ipc_space_t = mach_port_t
+ *     #if KERNEL_SERVER
+ *             intran: ipc_space_t convert_port_to_space(mach_port_t)
+ *             destructor: space_deallocate(ipc_space_t)
+ *     #endif
+ *
+ * Generating with a private NEXTBSD_KERNEL_SERVER instead avoided the renames
+ * but silently lost the translations, so every dispatch passed the raw
+ * request port where an ipc_space_t was required:
+ *
+ *     mach_port_mod_refs(In0P->Head.msgh_request_port, ...)   /* faults *_/
+ *     mach_port_mod_refs(task, ...)                           /* correct *_/
+ *
+ * which page-faulted in ipc_right_lookup() the first time anything actually
+ * called into this server. The wire format is identical either way, so the
+ * msgid/ABI gate cannot see the difference -- only the dispatch argument
+ * changes. LIBSYSCALL_INTERFACE stays undefined (we want mach_vm_address_t
+ * for port context, matching the frozen server).
+ *
+ * Signatures were cross-checked against the frozen __Request__/__Reply__
+ * structs: 35/35 agree.
  *
  * mach_port_kobject: object_type is natural_t (our ipc_info.h defines no
  * ipc_info_object_type_t alias, and the frozen server spells it natural_t).
@@ -169,13 +196,8 @@ routine mach_port_set_mscount(
 
 /* 3214 */
 routine
-#ifdef KERNEL_SERVER
-mach_port_get_set_status_from_user(
-		port        : mach_port_t;
-#else
 mach_port_get_set_status(
 		task		: ipc_space_t;
-#endif
 		name		: mach_port_name_t;
 	out	members		: mach_port_name_array_t);
 
@@ -196,13 +218,8 @@ routine mach_port_set_seqno(
 
 /* 3217 */
 routine
-#ifdef KERNEL_SERVER
-mach_port_get_attributes_from_user(
-		port        : mach_port_t;
-#else
 mach_port_get_attributes(
 		task		: ipc_space_t;
-#endif
 		name		: mach_port_name_t;
 		flavor		: mach_port_flavor_t;
 	out	port_info_out	: mach_port_info_t, CountInOut);
@@ -242,13 +259,8 @@ routine	mach_port_get_srights(
 
 /* 3223 */
 routine
-#ifdef KERNEL_SERVER
-mach_port_space_info_from_user(
-		port        : mach_port_t;
-#else
 mach_port_space_info(
 		space		: ipc_space_t;
-#endif
 	out	space_info	: ipc_info_space_t;
 	out	table_info	: ipc_info_name_array_t;
 	out	tree_info	: ipc_info_tree_name_array_t);
@@ -276,13 +288,8 @@ routine mach_port_extract_member(
 
 /* 3228 */
 routine
-#ifdef KERNEL_SERVER
-mach_port_get_context_from_user(
-		port		: mach_port_t;
-#else
 mach_port_get_context(
 		task		: ipc_space_t;
-#endif
 		name		: mach_port_name_t;
 #ifdef LIBSYSCALL_INTERFACE
 	out context		: mach_port_context_t
@@ -304,13 +311,8 @@ routine mach_port_set_context(
 
 /* 3230 */
 routine
-#ifdef KERNEL_SERVER
-mach_port_kobject_from_user(
-		port		: mach_port_t;
-#else
 mach_port_kobject(
 		task		: ipc_space_t;
-#endif
 		name		: mach_port_name_t;
 	out	object_type	: natural_t;
 	out	object_addr	: mach_vm_address_t);


### PR DESCRIPTION
The generated `mach_port` server passed the **raw request port** where an `ipc_space_t` was required, so the first thing that actually called into it page-faulted:

```
#5  ipc_right_lookup+0x88
#6  mach_port_mod_refs+0x44
#7  _Xmach_port_mod_refs+0x32
#8  ipc_kobject_server+0x134
#9  ipc_mqueue_send+0x179
... Fatal trap 12, fault virtual address = 0x488
```

```c
generated:  mach_port_mod_refs(In0P->Head.msgh_request_port, ...)   /* faults */
correct:    mach_port_mod_refs(task, ...)
```

**This is a defect introduced by #128, not a pre-existing one.**

## Cause

`KERNEL_SERVER` does two unrelated jobs in Apple's headers. It selects the `*_from_user` entry-point names, **and** it activates the intran/destructor translations in `mach_types.defs`:

```
type ipc_space_t = mach_port_t
#if KERNEL_SERVER
        intran: ipc_space_t convert_port_to_space(mach_port_t)
        destructor: space_deallocate(ipc_space_t)
#endif
```

#128 generated with a private `NEXTBSD_KERNEL_SERVER` specifically to avoid the `*_from_user` renames this kernel doesn't implement. That worked for the naming and silently threw away every type translation along with it.

## Fix

Collapse the five `*_from_user` name blocks in `mach_port.defs` to the plain spelling, so `KERNEL_SERVER` can be defined for what we actually need. `NEXTBSD_KERNEL_SERVER` still gates the `KernelServer` subsystem directive.

## Why nothing caught it

Two reasons worth recording, because both are gaps in checks I built:

1. **The ABI gate can't see it.** The wire format is identical either way — same msgids, same request/reply layouts. Only the dispatch argument differs. `MIG-ABI-OK` reports 36/36 both before and after.
2. **The runtime probes in #125 tested the frozen server**, before #128 replaced it. They proved the kernel MIG *path* works; they never exercised the generated server.

Nothing called into the generated server at all until `mach_port_mod_refs` was wired to it in nextbsd-userland#90 — which is exactly when it panicked. Every other `mach_port` entry point in libmach reaches the kernel through syscall traps, not MIG.

## Correction to #131 / #132

I misdiagnosed this the first time. Working from frame #12 (`sys_mach_msg_trap`) alone, I concluded the fault was a use-after-free in `ipc_mqueue_deliver` → `ipc_pset_signal`, wrote #132 for it, and closed #131 saying it was fixed. It wasn't — the panic is identical with #132 merged, and the full backtrace (frames #5–#9, which I hadn't looked at) shows a different path entirely.

#132 itself is still defensible as hardening: `pset` really was dereferenced after `ip_unlock()` with no reference held. But it did not fix #131, and I should not have closed that ticket on it. Reopening.

## Verified

- dispatch is `mach_port_mod_refs(task, ...)` and `mach_port_get_set_status(task, ...)`
- zero `_from_user` in the generated server
- `MIG-ABI-OK: mach_port 3200-3236, 36 slots match the frozen contract`

Refs #125, #131.
