### PR TITLE
mach: generate clock_server.c instead of shipping it (#125)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,11 +181,11 @@ jobs:
             /usr/src/sys/compat/mach/mach_port_server.c \
             "$GITHUB_WORKSPACE/src-overlay/sys/sys/mach/mach_port.msgids"
 
-          # The other six are still the FROZEN committed servers (#127 added
-          # their .defs/.msgids; the conversion is separate). Checking them
-          # here pins the contract against the servers actually being built,
-          # so a bad `skip;` or a renumbering cannot land unnoticed. Without
-          # this, nothing in CI touches these six at all.
+          # clock is now GENERATED too (#125). The remaining five are still the
+          # frozen committed servers; #127 added their .defs/.msgids and the
+          # conversion is per-subsystem. Either way this pins the contract
+          # against the servers actually being built, so a bad `skip;` or a
+          # renumbering cannot land unnoticed.
           for sub in task vm_map host_priv mach_host mach_vm clock; do
             "$GITHUB_WORKSPACE/ci/verify-mig-abi.sh" \
               "/usr/src/sys/compat/mach/${sub}_server.c" \

--- a/ci/gen-mig-servers.sh
+++ b/ci/gen-mig-servers.sh
@@ -105,7 +105,9 @@ echo "    migcom: $("$WORK/migcom" -version 2>&1 | head -1)"
 #   <mach_debug/mach_debug_types.defs>             -> this repo
 mkdir -p "$WORK/incl/mach" "$WORK/incl/mach_debug"
 cp "$MACHINC"/mach/*.defs                       "$WORK/incl/mach/"
-cp "$SRCDIR"/sys/mach/mach_port.defs            "$WORK/incl/mach/"
+# Copy every .defs, not just the one being generated: clock.defs includes
+# clock_types.defs, and the other subsystems have similar local dependencies.
+cp "$SRCDIR"/sys/mach/*.defs                     "$WORK/incl/mach/"
 cp "$SRCDIR"/sys/mach_debug/mach_debug_types.defs "$WORK/incl/mach_debug/"
 
 gen_one() {
@@ -206,5 +208,12 @@ gen_one() {
 }
 
 gen_one mach_port
+
+# clock: 3 routines, base 1000, no tombstones -- the smallest subsystem, so it
+# is the first conversion after mach_port. Its .defs was reconstructed in #138
+# and verified ABI-identical to the frozen clock_server.c: routine table
+# identical, all 3 __Request__/__Reply__ struct pairs identical field for
+# field, verify-mig-abi.sh passing against both generated and frozen output.
+gen_one clock
 
 echo "==> MIG generation complete"


### PR DESCRIPTION
First conversion after `mach_port`. Refs #125.

`clock` is the smallest subsystem — 3 routines, base 1000, no tombstones — so it exercises the generation path with the least surface area.

Its `.defs` was reconstructed in #138 and **verified ABI-identical** to the frozen `clock_server.c`: routine table identical including base/end, all 3 `__Request__`/`__Reply__` struct pairs identical field-for-field, and `verify-mig-abi.sh` passing against both the generated and the frozen server.

`gen-mig-servers.sh` now copies **every** `.defs` into the include dir rather than naming `mach_port.defs` specifically — `clock.defs` includes `clock_types.defs`, and the remaining subsystems have similar local dependencies.

The CI ABI gate already checked `clock` at the path `gen_one` writes to, so it now verifies the **generated** server rather than the frozen one.

## Why this is verifiable without the box

Kernel CI builds both arches and runs a boot smoke-test on a self-assembled image, so a bad conversion shows up as a build or boot failure here rather than needing hardware. (The arm64 test box is currently unreachable — see nextbsd-userland#115.)

## Remaining conversions

`mach_host`, `host_priv`, `task`, `vm_map` — all unblocked.
`mach_vm` — blocked on **#136** (`ipc_port_release_send()` asserts `IP_VALID` where modern migcom emits it unguarded, and `_mach_make_memory_entry` legitimately passes `MACH_PORT_NULL`).