### PR TITLE
mach/ipc: check the port's own thread pool, not just the portset's (#369)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_mqueue.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_mqueue.c
@@ -450,12 +450,40 @@ ipc_mqueue_deliver(
 	mqueue = &port->ip_messages;
 	receiver = NULL;
 
-    /* first we check the the port and portset for waiters */
+	/*
+	 * Check the portset AND the port, not one or the other.
+	 *
+	 * This was `if (pset) ... else if (receiver == NULL) ...`. Since
+	 * receiver was set to NULL immediately above, the second arm was
+	 * simply `else`, so a port that belongs to a set NEVER had its own
+	 * thread pool consulted -- an `if`/`if` pair collapsed into
+	 * `if`/`else`. The comment always said "port and portset".
+	 *
+	 * The two pools are populated from different sides: a receiver
+	 * registers in the pool named by the rcv_name it passed
+	 * (ipc_mqueue_copyin dispatches on MACH_PORT_TYPE_PORT_SET), while
+	 * the sender picks the pool to search from port->ip_pset. They
+	 * disagree exactly when a thread receives on a BARE PORT NAME for a
+	 * port that is also a member of a set -- which is what libdispatch's
+	 * Mach bridge creates: it allocates a port set and
+	 * mach_port_move_member()s service ports into it, while a daemon's
+	 * dedicated server thread still does a plain mach_msg(MACH_RCV_MSG)
+	 * on the port name itself.
+	 *
+	 * In that shape the bare-port sleeper was never found here, the
+	 * message was enqueued, and the only fallback -- ipc_pset_signal()
+	 * -- activates EVFILT_MACHPORT knotes and never wakes pool
+	 * receivers. The thread parked in mach_msg_receive forever with the
+	 * message sitting on the queue, and the client blocked forever
+	 * waiting for a reply that was never generated.
+	 */
 	if (pset != NULL) {
 		ips_lock(pset);
 		receiver = thread_pool_get_act((ipc_object_t)pset, 0);
 		ips_unlock(pset);
-	} else if (receiver == NULL) {
+	}
+	if (receiver == NULL) {
+		/* port lock is held from entry until the ip_unlock below */
 		receiver = thread_pool_get_act((ipc_object_t)port, 0);
 	}
 	LAUNCHD_TRACE("deliver port=%p pset=%p receiver=%p msgcount=%d qlimit=%d msgh_id=%d",
@@ -492,16 +520,23 @@ ipc_mqueue_deliver(
 		ips_lock(pset);
 		receiver = thread_pool_get_act((ipc_object_t)pset, 0);
 		ips_unlock(pset);
-		if (receiver != NULL) {
-			kmsg = ipc_kmsg_queue_first(&mqueue->imq_messages);
-			assert(kmsg != IKM_NULL);
-			ipc_kmsg_rmqueue_first_macro(&mqueue->imq_messages, kmsg);
-			port->ip_msgcount--;
-			LAUNCHD_TRACE("deliver late receiver=%p kmsg=%p msgcount=%d",
-			    receiver, kmsg, port->ip_msgcount);
-			ipc_mqueue_run(receiver, mqueue, kmsg, port);
-			return (MACH_MSG_SUCCESS);
-		}
+	}
+	if (receiver == NULL) {
+		/* Same omission as the first check: a bare-port receiver on a
+		 * port that is a set member must be re-checked here too, or the
+		 * #369 window stays open for exactly the case that motivated
+		 * this block. */
+		receiver = thread_pool_get_act((ipc_object_t)port, 0);
+	}
+	if (receiver != NULL) {
+		kmsg = ipc_kmsg_queue_first(&mqueue->imq_messages);
+		assert(kmsg != IKM_NULL);
+		ipc_kmsg_rmqueue_first_macro(&mqueue->imq_messages, kmsg);
+		port->ip_msgcount--;
+		LAUNCHD_TRACE("deliver late receiver=%p kmsg=%p msgcount=%d",
+		    receiver, kmsg, port->ip_msgcount);
+		ipc_mqueue_run(receiver, mqueue, kmsg, port);
+		return (MACH_MSG_SUCCESS);
 	}
 	/*
 	 * Hold a reference across the unlock (nextbsd-kernel#131).


### PR DESCRIPTION
## The defect

`ipc_mqueue_deliver()` consulted exactly one of the two thread pools:

```c
receiver = NULL;
/* first we check the the port and portset for waiters */
if (pset != NULL) {
        receiver = thread_pool_get_act((ipc_object_t)pset, 0);
} else if (receiver == NULL) {
        receiver = thread_pool_get_act((ipc_object_t)port, 0);
}
```

`receiver` was set to `NULL` immediately above, so the second arm is just `else`. **A port belonging to a set never had its own thread pool checked.** The comment always said "port *and* portset" — this is an `if`/`if` pair collapsed into `if`/`else`. The `#369` re-check block below had the identical omission, gated on `if (pset != NULL)`, so the case was missed twice.

## Why our userland hits it

The two pools are filled from different sides. A receiver registers in the pool named by the `rcv_name` it passed (`ipc_mqueue_copyin` dispatches on `MACH_PORT_TYPE_PORT_SET`); the sender picks which pool to search from `port->ip_pset`. They disagree exactly when a thread receives on a **bare port name** for a port that is **also a set member**.

That is the shape our userland creates:

- `libmach/dispatch_kevent.c:272` allocates a `MACH_PORT_RIGHT_PORT_SET`, and `:279` calls `mach_port_move_member` to put service ports into it.
- syslogd's `database_server` thread simultaneously does a plain `mach_msg(MACH_RCV_MSG)` on the port name itself.

So the client sends, `pset != NULL`, only the pset pool is searched, the bare-port sleeper is missed, the message is enqueued, and the only remaining fallback is `ipc_pset_signal()` — which activates `EVFILT_MACHPORT` knotes and, per its own comment, "since #256 it never wakes pool receivers."

Result: the server thread parks in `mach_msg_receive` forever with the message sitting on the queue, while the client blocks forever awaiting a reply.

## Matching hardware evidence

Measured on arm64 (192.168.1.216):

- Client blocked in `sys_mach_msg_trap → mach_msg_receive → ipc_mqueue_receive`, **90-second** timeout expiring — a permanent wedge, not slowness.
- syslogd healthy, with thread 100146 **simultaneously** parked in `ipc_mqueue_receive`.
- The message is never processed (verified with a search method validated against a *successful* send).

## The fix

Make the port-pool check a separate `if (receiver == NULL)` in both the initial check and the `#369` re-check. The port lock is held from function entry through the `ip_unlock` below, so consulting the port's pool there needs no extra locking — the original `else` arm did the same thing under the same lock.

## What this does NOT yet explain

The observed failure rate **decays with cumulative traffic** (40–60% from a fresh boot → 0 after ~70–80 sends) and **resets when either daemon restarts**. My hypothesis is that delivery succeeds whenever a pset-registered libdispatch worker happens to be available, and libdispatch's worker pool warms with traffic — but that is a hypothesis. **This change is justified on the code defect alone**, which is unconditional and verified by reading.

Verification on hardware to follow; I will post the measured before/after either way.
