### PR TITLE
mach/ipc: resolve EVFILT_MACHPORT through ipc_space, not the fd table (#147)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_pset.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_pset.c
@@ -564,7 +564,21 @@ static int      filt_machportattach(struct knote *kn);
 static void     filt_machportdetach(struct knote *kn);
 static int      filt_machport(struct knote *kn, long hint);
 struct filterops machport_filtops = {
-	.f_isfd = 1,
+	/*
+	 * NOT an fd filter. The kevent ident is a Mach port-set NAME, resolved
+	 * through the calling task's ipc_space (see filt_machportattach). With
+	 * f_isfd = 1 the kqueue core called fget(kev.ident) before attach and
+	 * held an fp reference for the knote's whole life -- which worked only
+	 * because port names happen to be file descriptors in this port. XNU
+	 * resolves EVFILT_MACHPORT idents through ipc_space and its names are
+	 * never fds; this is that shape.
+	 *
+	 * Consequences of the flip, all handled below: the knote is stored in
+	 * kq_knhash rather than kq_knlist[fd], knote_fdclose() no longer reaps
+	 * it, and nothing else holds the port set alive -- so the knote takes
+	 * its own reference in attach and drops it in detach.
+	 */
+	.f_isfd = 0,
 	.f_attach = filt_machportattach,
 	.f_detach = filt_machportdetach,
 	.f_event = filt_machport,
@@ -652,9 +666,21 @@ filt_machportattach(struct knote *kn)
 		return (ENOENT);
 	}
 
-	kn->kn_fp = entry->ie_fp;
+	/*
+	 * Hand the reference taken above to the knote rather than dropping it.
+	 *
+	 * Before f_isfd = 0 this reference only had to cover knlist_add(): the
+	 * fp reference kqueue held on our behalf kept the port set alive
+	 * afterwards. Nothing holds it now, so releasing here would leave the
+	 * knote pointing at a set that any concurrent teardown may free --
+	 * reintroducing the #250 use-after-free, but across the knote's entire
+	 * lifetime rather than one narrow window, and presenting as the same
+	 * "page fault write 0x70".
+	 *
+	 * filt_machportdetach() drops it, on every path.
+	 */
+	kn->kn_hook = pset;
 	knlist_add(note, kn, 0);
-	ips_release(pset);
 	return (0);
 }
 
@@ -664,27 +690,40 @@ static void
 filt_machportdetach(struct knote *kn)
 {
 	ipc_pset_t	pset;
-	ipc_entry_t	entry;
 
 	/*
-	 * If ipc_pset_destroy already cleared this knote from the set's
-	 * knlist (kn_knlist == NULL), the pset — and the fp/entry backing it
-	 * — may already be freed; removing again would touch freed memory.
-	 * This is the normal teardown order once a native EVFILT_MACHPORT
-	 * knote can outlive a destroyed port set, so it is not an error.
-	 * Guard every dereference so any teardown order is UAF-safe.
+	 * A native EVFILT_MACHPORT knote can outlive the port set it was
+	 * registered on: ipc_pset_destroy() clears the knlist and stamps
+	 * EV_EOF, but the knote itself is not reaped until the kq is scanned
+	 * or closed. That is the normal teardown order, not an error.
+	 *
+	 * Our reference (taken in attach) is what keeps the set's memory alive
+	 * for exactly that window, so nothing here can touch freed memory --
+	 * and it is why the release below must happen on every path.
 	 */
-	if (kn->kn_knlist == NULL)
-		return;
-	if (kn->kn_fp == NULL || kn->kn_fp->f_type != DTYPE_MACH_IPC)
-		return;
-	entry = kn->kn_fp->f_data;
-	if (entry == NULL || (entry->ie_bits & MACH_PORT_TYPE_PORT_SET) == 0)
-		return;
-	pset = (ipc_pset_t)entry->ie_object;
+	pset = (ipc_pset_t)kn->kn_hook;
 	if (pset == NULL)
 		return;
-	knlist_remove(&pset->ips_note, kn, 0);
+
+	/*
+	 * Use the cached pointer, never a fresh lookup by name.
+	 *
+	 * f_detach can run on a thread whose current_space() is NOT the
+	 * registering task's: kqueue_drain() runs in whichever process performs
+	 * the last fdrop of the kq fd, which for a kq passed over SCM_RIGHTS is
+	 * a different process entirely. Re-resolving the ident there would
+	 * remove the knote from the wrong task's port set.
+	 *
+	 * If ipc_pset_destroy() already cleared us from the knlist
+	 * (kn_knlist == NULL) the set is torn down but not freed -- our
+	 * reference is what is still holding the memory -- so skip the remove
+	 * and go straight to the release.
+	 */
+	if (kn->kn_knlist != NULL)
+		knlist_remove(&pset->ips_note, kn, 0);
+
+	kn->kn_hook = NULL;
+	ips_release(pset);
 }
 
 
@@ -693,8 +732,18 @@ filt_machport(struct knote *kn, long hint)
 {
 
 	mach_port_name_t        name = (mach_port_name_t)kn->kn_kevent.ident;
-	ipc_entry_t				entry = kn->kn_fp->f_data;
-	ipc_pset_t              pset = (ipc_pset_t) entry->ie_object;
+	/*
+	 * cached is the port set this knote was attached to, and the value
+	 * ipc_object_translate() is seeded with below. That seeding is
+	 * load-bearing, not cosmetic: translate only takes io_lock when the
+	 * caller did NOT pre-seed *objectp ("caller already holds locked
+	 * reference"). io_lock is a non-recursive MTX_DEF, so seeding NULL here
+	 * would take the lock in translate, skip the conditional unlock below,
+	 * and then recurse on it further down -- "panic: recursed on
+	 * non-recursive mutex".
+	 */
+	ipc_pset_t              cached = (ipc_pset_t)kn->kn_hook;
+	ipc_pset_t              pset = cached;
 	thread_t				self = current_thread();
 	kern_return_t           kr;
 	mach_msg_option_t	option;
@@ -737,7 +786,7 @@ filt_machport(struct knote *kn, long hint)
 
 		ips_reference(pset);
 
-		if (pset != (ipc_pset_t)entry->ie_object)
+		if (pset != cached)
 			ips_unlock(pset);
 
 	} else

--- a/src-overlay/sys/compat/mach/ipc/ipc_pset.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_pset.c
@@ -247,6 +247,24 @@ ipc_pset_alloc_name(
 	/* pset is locked */
 
 	pset->ips_local_name = name;
+	/*
+	 * Same initialisation as ipc_pset_alloc(). This path used to set only
+	 * ips_local_name and the thread pool, leaving ips_ports, ips_note and
+	 * ips_note_lock as whatever the zone handed back.
+	 *
+	 * That is latent only for as long as nothing reaches a named port set
+	 * through the knote path: filt_machportattach() calls knlist_add() on
+	 * &pset->ips_note, and ipc_pset_signal() takes sx_slock() on
+	 * &pset->ips_note_lock. Both would operate on uninitialised memory.
+	 * ipc_pset_add() would likewise TAILQ_INSERT_TAIL onto a list head
+	 * whose tqh_last is NULL.
+	 *
+	 * Reachable via mach_port_allocate_full() with a caller-supplied name.
+	 */
+	TAILQ_INIT(&pset->ips_ports);
+	sx_init(&pset->ips_note_lock, "pset knote lock");
+	knlist_init(&pset->ips_note, &pset->ips_note_lock,
+				kn_sx_lock, kn_sx_unlock, kn_sx_assert_lock);
 	thread_pool_init(&pset->ips_thread_pool);
 	*psetp = pset;
 	return KERN_SUCCESS;
@@ -473,6 +491,18 @@ ipc_pset_destroy(
 	knlist_clear(&pset->ips_note, 1 /* islocked */);
 	sx_xunlock(&pset->ips_note_lock);
 	knlist_destroy(&pset->ips_note);
+	/*
+	 * Matching half of the sx_init() in ipc_pset_alloc() /
+	 * ipc_pset_alloc_name(). knlist_destroy() tears down the knote list
+	 * but not the lock backing it; without this the sx is leaked on every
+	 * port-set teardown (and, under WITNESS, its lock object stays
+	 * registered).
+	 *
+	 * Safe only because ipc_pset_alloc_name() now initialises the lock
+	 * too -- before that fix, named port sets reached here with an
+	 * uninitialised sx.
+	 */
+	sx_destroy(&pset->ips_note_lock);
 
 	ips_release(pset);	/* consume the ref our caller gave us */
 }


### PR DESCRIPTION
Closes #147. Part of #145. Builds on #157 (#146).

`machport_filtops` had `.f_isfd = 1`, so kqueue called `fget(kev.ident)` before attach and held an fp reference for the knote's life; the filter reached its object via `kn->kn_fp->f_data`. That works only because port names are fds here. XNU resolves these idents through the task's `ipc_space`.

**Names are still fds after this.** Nothing here changes what a name *is* — it removes the dependency so that changing name representation becomes possible at all. With `f_isfd = 1`, any name carrying generation bits fails `fget()` and EVFILT_MACHPORT registration dies, taking libdispatch's Mach bridge with it. That was verified by writing the generation patch first (preserved on `fix/port-name-generation`, marked do-not-merge).

## Four coupled changes — why one commit

| | |
|---|---|
| `.f_isfd = 0` | flips five kqueue-core behaviours at once |
| attach | caches the pset in `kn->kn_hook` and **transfers the reference to the knote** |
| detach | uses the cached pointer; releases on every path |
| event | seeds `ipc_object_translate()` from the cached pset |

Splitting them crashes: `.f_isfd = 0` without the event fix is a NULL deref on the first event; without the transferred reference it is a UAF on the first pset destroy.

## The two traps

**Reference ownership.** The `ips_reference` previously only had to cover `knlist_add()` — kqueue's fp reference kept the set alive afterwards. Nothing holds it now. Releasing there would reintroduce the #250 UAF across the knote's *entire lifetime* rather than one window, with the same `page fault write 0x70` signature.

**The translate lock dance.** `ipc_object_translate()` only takes `io_lock` when the caller did not pre-seed `*objectp`, and `io_lock` is non-recursive `MTX_DEF`. Seeding NULL — the natural-looking edit — locks in translate, skips the conditional unlock, then recurses: *panic: recursed on non-recursive mutex*. It will not appear in a smoke test; it needs real message delivery.

## Teardown

`knote_fdclose()` only walks `kq_knlist[fd]`, so it can no longer find these knotes. `process_exit` is unaffected (`fdescfree` runs after; `kqueue_drain` reaps both lists). On `process_exec` a non-CLOEXEC kq survives, so a knote can outlive its port set — but `ipc_pset_destroy()` clears the knlist and stamps `EV_EOF`, and the knote's own reference keeps the memory alive until the kq closes. **Bounded leak, not a UAF.** Noted as follow-up rather than fixed here.

## Verification

Gate is the CI boot smoke-test. **Not expected to change the #145 wedge rate** — this is a prerequisite, not the fix. I will post the measured rate anyway.