### PR TITLE
mach/ipc: give the reverse (object->entry) hash its own array (#148, C0)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_entry.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_entry.c
@@ -175,14 +175,16 @@ ipc_entry_hash_delete(
 	if ((entry->ie_bits & (MACH_PORT_TYPE_DEAD_NAME | MACH_PORT_TYPE_SEND)) !=
 		MACH_PORT_TYPE_SEND)
 		return;
-	if (idx >= space->is_table_size)
+	if (space->is_reverse_hash == NULL || space->is_reverse_size == 0)
+		return;
+	if (idx >= space->is_reverse_size)
 		return;
 
-	entryp = space->is_table[idx];
+	entryp = space->is_reverse_hash[idx];
 	assert(entryp);
 
 	if (entryp == entry) {
-		space->is_table[idx] = entry->ie_link;
+		space->is_reverse_hash[idx] = entry->ie_link;
 		entry->ie_link = NULL;
 		entry->ie_index = UINT_MAX;
 	} else {

--- a/src-overlay/sys/compat/mach/ipc/ipc_hash.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_hash.c
@@ -254,8 +254,15 @@ ipc_hash_local_lookup(
 	assert(space != IS_NULL);
 	assert(obj != IO_NULL);
 
-	table = space->is_table;
-	size = space->is_table_size;
+	table = space->is_reverse_hash;
+	size = space->is_reverse_size;
+	/*
+	 * Special spaces (ipc_space_create_special) never allocate a table and
+	 * are is_active == FALSE, so nothing should reach here with size 0 --
+	 * but IH_LOCAL_HASH divides by it, so do not rely on that.
+	 */
+	if (table == NULL || size == 0)
+		return (FALSE);
 	hindex = IH_LOCAL_HASH(obj, size);
 
 	entry = table[hindex];
@@ -294,8 +301,15 @@ ipc_hash_local_insert(
 	assert(space != IS_NULL);
 	assert(obj != IO_NULL);
 
-	table = space->is_table;
-	size = space->is_table_size;
+	table = space->is_reverse_hash;
+	size = space->is_reverse_size;
+	/*
+	 * Special spaces (ipc_space_create_special) never allocate a table and
+	 * are is_active == FALSE, so nothing should reach here with size 0 --
+	 * but IH_LOCAL_HASH divides by it, so do not rely on that.
+	 */
+	if (table == NULL || size == 0)
+		return;
 	hindex = IH_LOCAL_HASH(obj, size);
 
 	assert(entry->ie_object == obj);
@@ -330,8 +344,15 @@ ipc_hash_local_delete(
 	assert(space != IS_NULL);
 	assert(obj != IO_NULL);
 
-	table = space->is_table;
-	size = space->is_table_size;
+	table = space->is_reverse_hash;
+	size = space->is_reverse_size;
+	/*
+	 * Special spaces (ipc_space_create_special) never allocate a table and
+	 * are is_active == FALSE, so nothing should reach here with size 0 --
+	 * but IH_LOCAL_HASH divides by it, so do not rely on that.
+	 */
+	if (table == NULL || size == 0)
+		return;
 	hindex = IH_LOCAL_HASH(obj, size);
 
 	assert(entry->ie_object == obj);

--- a/src-overlay/sys/compat/mach/ipc/ipc_space.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_space.c
@@ -173,6 +173,7 @@ ipc_space_create(
 {
 	ipc_space_t space;
 	ipc_entry_t *table;
+	ipc_entry_t *reverse;
 	ipc_entry_num_t new_size;
 
 	space = is_alloc();
@@ -188,6 +189,19 @@ ipc_space_create(
 	new_size = initial->its_size;
 	memset((void *) table, 0, new_size * sizeof(struct ipc_entry *));
 
+	/*
+	 * The reverse (object -> entry) hash gets its own array, same size and
+	 * allocator as is_table for now. Sizing it independently belongs with
+	 * the change that actually makes is_table a name-indexed table.
+	 */
+	reverse = it_entries_alloc(initial);
+	if (reverse == NULL) {
+		it_entries_free(initial, table);
+		is_free(space);
+		return KERN_RESOURCE_SHORTAGE;
+	}
+	memset((void *) reverse, 0, new_size * sizeof(struct ipc_entry *));
+
 
 	is_ref_lock_init(space);
 	space->is_references = 2;
@@ -198,6 +212,8 @@ ipc_space_create(
 	space->is_table = table;
 	space->is_table_size = new_size;
 	space->is_table_next = initial+1;
+	space->is_reverse_hash = reverse;
+	space->is_reverse_size = new_size;
 	LIST_INIT(&space->is_entry_list);
 
 	space->is_tree_total = 0;
@@ -292,8 +308,13 @@ ipc_space_destroy(
 	 *	Now we can futz with it	without having it locked.
 	 */
 
-	table = space->is_table;
-	size = space->is_table_size;
+	/*
+	 * Walk the reverse hash, which is where these chains live now. Same
+	 * traversal as before -- this array is the one that used to be
+	 * is_table.
+	 */
+	table = space->is_reverse_hash;
+	size = space->is_reverse_size;
 
 	for (index = 0; index < size; index++) {
 		ipc_entry_t entry = table[index];
@@ -309,7 +330,13 @@ ipc_space_destroy(
 		}
 	}
 
-	it_entries_free(space->is_table_next-1, table);
+	/*
+	 * Both arrays were allocated from the same ipc_table_size entry and
+	 * neither grows today, so is_table_next-1 frees both correctly. When
+	 * is_table starts growing, this needs the reverse array's own size.
+	 */
+	it_entries_free(space->is_table_next-1, space->is_table);
+	it_entries_free(space->is_table_next-1, space->is_reverse_hash);
 
 	/*
 	 *	Because the space is now dead,

--- a/src-overlay/sys/sys/mach/ipc/ipc_space.h
+++ b/src-overlay/sys/sys/mach/ipc/ipc_space.h
@@ -121,6 +121,23 @@ struct ipc_space {
 	boolean_t is_growing;		/* is the space growing? */
 	ipc_entry_t *is_table;		/* an array of entries */
 	ipc_entry_num_t is_table_size;	/* current size of table */
+	/*
+	 * Reverse map: object pointer -> (name, entry), chained through
+	 * ie_link and bucketed by IH_LOCAL_HASH.
+	 *
+	 * This used to share is_table. It does not any more, because the two
+	 * are opposite directions and only one of them can own that array:
+	 * is_table is becoming a real name-indexed table (name -> entry),
+	 * while this stays object -> name.
+	 *
+	 * The reverse direction is not optional. ipc_object_copyout() consults
+	 * it via ipc_right_reverse() so that receiving a second send right to a
+	 * port you already hold COALESCES onto the existing name instead of
+	 * minting a new one -- without it mach_task_self() would return a
+	 * different name on every call and leak an entry each time.
+	 */
+	ipc_entry_t *is_reverse_hash;	/* object -> entry buckets */
+	ipc_entry_num_t is_reverse_size;/* number of buckets */
 	struct ipc_table_size *is_table_next; /* info for larger table */
 	task_t is_task;
 	ipc_entry_num_t is_tree_total;	/* number of entries in the tree */


### PR DESCRIPTION
Closes #148. Part of #145.

`is_table` is declared as a name-indexed "array of entries" but every actual user treats it as a chained hash keyed on the **object pointer** (`IH_LOCAL_HASH`), with `ie_index` holding a bucket number rather than a name. Those are opposite directions and only one can own the array — and `is_table` needs to become the real name-indexed table.

The reverse direction is **not optional**: `ipc_object_copyout()` consults it via `ipc_right_reverse()` so a second send right to a port you already hold coalesces onto the existing name. Without it `mach_task_self()` would return a different name every call and leak an entry each time.

## What this does

- `ipc_space` gains `is_reverse_hash` / `is_reverse_size`, allocated alongside `is_table` with the same size and allocator, freed with it
- `ipc_space_destroy`'s cleanup walk follows the chains to the new array
- `ipc_hash_local_{lookup,insert,delete}` and `ipc_entry_hash_delete` retarget

`is_table` is now allocated but unread outside already-disabled code (`mach_debug.c`, `mach_port.c` — both `#if 0`/`#ifdef notyet`). That is what makes #151 possible.

Also guards all four against a zero-sized table: special spaces never allocate one, so nothing *should* reach the hash with size 0, but `IH_LOCAL_HASH` divides by it and relying on an `is_active` check several frames up isn't worth a division fault. Pre-existing; closed while the code was open.

**No semantic change** — same buckets, same size, same traversal.

**Deferred:** resizing the `ipc_table_size` progression for a pointer array belongs with #151, where it actually matters; doing it here would change allocation sizes for no benefit.