### PR TITLE
mach/ipc: stamp and validate a generation on port names (#151, partial)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_entry.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_entry.c
@@ -331,7 +331,7 @@ ipc_entry_lookup(ipc_space_t space, mach_port_name_t name)
 	if (curthread->td_proc->p_fd == NULL)
 		return (NULL);
 
-	if (fget(curthread, name, cap_rights_init(&rights, CAP_KQUEUE_EVENT|CAP_KQUEUE_CHANGE), &fp) != 0) {
+	if (fget(curthread, MACH_PORT_INDEX(name), cap_rights_init(&rights, CAP_KQUEUE_EVENT|CAP_KQUEUE_CHANGE), &fp) != 0) {
 		if (mach_debug_enable)
 			log(LOG_DEBUG, "%s:%d entry for port name: %d not found\n", curproc->p_comm, curproc->p_pid, name);
 		return (NULL);
@@ -345,6 +345,21 @@ ipc_entry_lookup(ipc_space_t space, mach_port_name_t name)
 		return (NULL);
 	}
 	entry = fp->f_data;
+	/*
+	 * Generation check. Port names are file descriptors here and the fd
+	 * allocator reissues the lowest free number, so a name freed by one
+	 * RPC is handed back bit-identical to the next. Without this compare
+	 * a caller holding a stale name silently operates on whatever object
+	 * now occupies that fd. Reject the mismatch instead.
+	 */
+	if (MACH_PORT_GEN(name) != IE_BITS_GEN(entry->ie_bits)) {
+		if (mach_debug_enable)
+			log(LOG_DEBUG, "%s:%d stale port name 0x%x (gen 0x%x != 0x%x)\n",
+			    curproc->p_comm, curproc->p_pid, name,
+			    MACH_PORT_GEN(name), IE_BITS_GEN(entry->ie_bits));
+		fdrop(fp, curthread);
+		return (NULL);
+	}
 	fdrop(fp, curthread);
 	return (entry);
 }
@@ -361,7 +376,7 @@ ipc_entry_file_to_port(ipc_space_t space, mach_port_name_t name, ipc_object_t *o
 	if (curthread->td_proc->p_fd == NULL)
 		return (KERN_INVALID_ARGUMENT);
 
-	if (fget(curthread, name, cap_rights_init(&rights, CAP_ALL1), &fp) != 0) {
+	if (fget(curthread, MACH_PORT_INDEX(name), cap_rights_init(&rights, CAP_ALL1), &fp) != 0) {
 		log(LOG_DEBUG, "%s:%d entry for port name: %d not found\n", curproc->p_comm, curproc->p_pid, name);
 		return (KERN_INVALID_ARGUMENT);
 	}
@@ -468,9 +483,16 @@ ipc_entry_get(
 		return (KERN_RESOURCE_SHORTAGE);
 	}
 
-	free_entry->ie_bits = 0;
+	/*
+	 * Advance the space's rolling generation and stamp it into both the
+	 * entry and the name we hand back, so a later reuse of this same fd
+	 * yields a different name and ipc_entry_lookup() can tell them apart.
+	 */
+	space->is_gen_last = IE_BITS_NEW_GEN(space->is_gen_last);
+
+	free_entry->ie_bits = IE_BITS_GEN(space->is_gen_last);
 	free_entry->ie_request = 0;
-	free_entry->ie_name = fd;
+	free_entry->ie_name = MACH_PORT_MAKE(fd, IE_BITS_GEN(space->is_gen_last));
 	free_entry->ie_fp = fp;
 	free_entry->ie_index = UINT_MAX;
 	free_entry->ie_link = NULL;
@@ -481,7 +503,7 @@ ipc_entry_get(
 	finit(fp, 0, DTYPE_MACH_IPC, free_entry, &mach_fileops);
 	fdrop(fp, td);
 	assert(fp->f_count == 1);
-	*namep = fd;
+	*namep = free_entry->ie_name;
 	*entryp = free_entry;
 
 	return KERN_SUCCESS;
@@ -543,6 +565,7 @@ ipc_entry_alloc_name(
 	ipc_entry_t	*entryp)
 {
 	mach_port_name_t newname;
+	mach_port_name_t index;
 	struct file *fp;
 	kern_return_t kr;
 	struct thread *td = curthread;
@@ -551,18 +574,27 @@ ipc_entry_alloc_name(
 		return (KERN_INVALID_TASK);
 	}
 	assert(MACH_PORT_NAME_VALID(name));
+	/* fd half of the requested name; see the comment at kern_fdalloc below */
 	is_write_lock(space);
 	if ((*entryp = ipc_entry_lookup(space, name)) != NULL)
 		return (KERN_SUCCESS);
 
 	is_write_unlock(space);
 
+	/*
+	 * The caller asks for a SPECIFIC name. A name is now
+	 * (generation | fd index), so the fd we must reserve is the index
+	 * half -- passing the whole name to kern_fdalloc() would request a
+	 * minimum fd of a hugely out-of-range number and always fail.
+	 */
+	index = MACH_PORT_INDEX(name);
+
 	/* name could technically be a ridiculously large value */
-	if (kern_fdalloc(td, name, &newname)) {
-		log(LOG_WARNING, "%s:%d failed to allocate %d\n", __FILE__, __LINE__, name);
+	if (kern_fdalloc(td, index, &newname)) {
+		log(LOG_WARNING, "%s:%d failed to allocate %d\n", __FILE__, __LINE__, index);
 		return (KERN_RESOURCE_SHORTAGE);
 	}
-	if (newname != name) {
+	if (newname != index) {
 		kern_fddealloc(td, newname);
 		return (KERN_NAME_EXISTS);
 	}
@@ -570,7 +602,7 @@ ipc_entry_alloc_name(
 		kern_fddealloc(td, newname);
 		return (KERN_RESOURCE_SHORTAGE);
 	}
-	if (kern_finstall(td, fp, &name, FNOFDALLOC, NULL)) {
+	if (kern_finstall(td, fp, &index, FNOFDALLOC, NULL)) {
 		kern_fddealloc(td, newname);
 		fdrop(fp, td);
 		return (KERN_RESOURCE_SHORTAGE);
@@ -595,6 +627,8 @@ ipc_entry_close(
 
 	td = curthread;
 	fdp = td->td_proc->p_fd;
+	/* caller passes a port NAME; the fd is its index half */
+	fd = MACH_PORT_INDEX(fd);
 
 	FILEDESC_XLOCK(fdp);
 	if ((fp = fget_noref(fdp, fd)) == NULL) {

--- a/src-overlay/sys/sys/mach/ipc/ipc_space.h
+++ b/src-overlay/sys/sys/mach/ipc/ipc_space.h
@@ -144,6 +144,13 @@ struct ipc_space {
 	ipc_entry_num_t is_tree_small;	/* # of small entries in the tree */
 	ipc_entry_num_t is_tree_hash;	/* # of hashed entries in the tree */
 	boolean_t is_fast;              /* for is_fast_space() */
+	/*
+	 * Rolling generation stamped into each name handed out by
+	 * ipc_entry_get(). Advanced on every allocation, so a name reissued
+	 * for a recycled fd differs from the stale one a caller may still be
+	 * holding. is_alloc() zeroes the space, so this starts at 0.
+	 */
+	ipc_entry_bits_t is_gen_last;
 };
 
 #define	IS_NULL			((ipc_space_t) 0)

--- a/src-overlay/sys/sys/mach/port.h
+++ b/src-overlay/sys/sys/mach/port.h
@@ -216,20 +216,32 @@ typedef mach_port_t			*mach_port_array_t;
  *
  */
 
-#if 0
+/*
+ * Port name encoding: generation in the HIGH bits, index in the LOW bits.
+ *
+ * This deliberately inverts Apple's layout (index high, generation low).
+ * In this port a port name IS a file descriptor -- ipc_entry_lookup() feeds
+ * it straight to fget() -- so the index must stay a valid fd number and
+ * cannot be shifted. Keeping the generation in the high bits leaves the low
+ * 24 bits usable as an fd while still making a recycled name detectably
+ * stale, which is the whole point of the counter.
+ *
+ * The generation bits line up with IE_BITS_GEN_MASK in ipc_entry.h, so the
+ * value stored in ie_bits and the value carried in the name are the same
+ * bits in the same positions -- no shifting between the two representations.
+ *
+ * Sentinels: MACH_PORT_NULL is 0, which is safe because port fds are
+ * allocated starting at 16, so index 0 is never a live port name.
+ * MACH_PORT_DEAD is ~0; MACH_PORT_NAME_LIVE() below excludes both so a
+ * sentinel is never mistaken for a generationed name.
+ */
+#define	MACH_PORT_INDEX_MASK		0x00ffffffU
+#define	MACH_PORT_INDEX(name)		((name) & MACH_PORT_INDEX_MASK)
+#define	MACH_PORT_GEN(name)		((name) & 0xff000000U)
+#define	MACH_PORT_MAKE(index, gen)	((index) | (gen))
 
-#define	MACH_PORT_INDEX(name)		((name) >> 8)
-#define	MACH_PORT_GEN(name)		(((name) & 0xff) << 24)
-#define	MACH_PORT_MAKE(index, gen)	\
-		(((index) << 8) | (gen) >> 24)
-
-#else	/* NO_PORT_GEN */
-
-#define	MACH_PORT_INDEX(name)		(name)
-#define	MACH_PORT_GEN(name)		(0)
-#define	MACH_PORT_MAKE(index, gen)	(index)
-
-#endif	/* NO_PORT_GEN */
+#define	MACH_PORT_NAME_LIVE(name)	\
+		(((name) != MACH_PORT_NULL) && ((name) != MACH_PORT_DEAD))
 #define MACH_PORT_MAKEB(index, bits)    \
                 MACH_PORT_MAKE(index, IE_BITS_GEN(bits))
 


### PR DESCRIPTION
Part of #145. Requires #147 (merged) and nextbsd-userland#131 (merged).

**This is the candidate fix for the wedge.** Everything before it was prerequisite.

## The defect

A port name is a raw fd from `kern_fdalloc(td, 16, &fd)` — lowest-free-at-or-above-16 — and the generation machinery was compiled out (`MACH_PORT_GEN(name)` was `(0)`). A name released at the end of one RPC is handed straight back to the next, **bit for bit**, and nothing can tell that a cached name now denotes a different object.

`ipc_object_copyin()` then wraps **any** non-Mach fd into a synthetic port with `ip_receiver` set and nobody receiving on it. So a send to a recycled name succeeds, the server never sees the message, and the client blocks forever — the exact observed state.

## Encoding: generation high, index low

Deliberately inverted from Apple (index high, gen low), because a name is *still also an fd* here and the index half must stay a valid fd number. The generation bits line up with `IE_BITS_GEN_MASK`, so `ie_bits` and the name carry the same bits in the same positions. When names stop being fds, both sides move to Apple's layout together.

## Why the two prerequisites were load-bearing

- **#147** — `machport_filtops` had `.f_isfd = 1`, so kqueue called `fget()` on the raw kevent ident. Any generationed name → `EBADF` → EVFILT_MACHPORT registration dead → libdispatch's Mach bridge dead. Verified by writing this patch first and finding it unlandable.
- **userland#131** — launchd sized `mig_cb_table` by the raw port name; a generationed name would ask PID 1 for hundreds of megabytes. **Kernel CI boots against the *published* userland**, so this had to land *and publish* first, or this PR would pass its own smoke-test and still brick the box.

## Known limitation, deliberately not fixed here

The generation is a **per-space rolling counter, not per-slot**, and `IE_BITS_GEN_ONE` gives 64 distinct values. It catches any reuse within 63 intervening allocations — which covers the immediate free-then-reissue pattern the wedge depends on — but a slot reissued exactly 64 allocations later yields a bit-identical name. Per-slot generations need the real name-indexed table and land with it.

## Also still broken, and not made worse

`ipc_entry_alloc_name()` double-allocates: it reserves the requested fd, installs a placeholder `fp` that is never `finit`'d, then calls `ipc_entry_get()` which allocates a *different* fd and overwrites the name. Reachable from `ipc_object_copyout_name()` on the live `mach_msg` path. Pre-existing; this PR masks the index half correctly but does not fix the double-allocation. Flagging because the boot smoke-test exercises that path and is the gate.

## Verification

**Not verified to change the wedge rate.** Baseline is 35/100 on the cold-boot measurement, unchanged by #144 and by Stage 1. I will deploy and post the measured number either way — four predicted fixes in this investigation each addressed a real defect and none moved it.

Regression guard: nextbsd-userland#132 (`test_mach_name_recycle`), which fails today by design and should flip to passing with this.