### PR TITLE
mach/ipc: refuse to resolve a generationed name as a file (#152, partial)

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_entry.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_entry.c
@@ -376,6 +376,33 @@ ipc_entry_file_to_port(ipc_space_t space, mach_port_name_t name, ipc_object_t *o
 	if (curthread->td_proc->p_fd == NULL)
 		return (KERN_INVALID_ARGUMENT);
 
+	/*
+	 * Refuse a name that carries a generation.
+	 *
+	 * This function is the implicit-fileport path: ipc_object_copyin()
+	 * calls it BEFORE ipc_right_lookup(), and if the name's index half
+	 * happens to denote an ordinary file descriptor it wraps that fd in a
+	 * synthetic port with ip_receiver set and nobody receiving on it. A
+	 * send to such a port succeeds and the message is never delivered.
+	 *
+	 * Because it runs before the lookup, it also bypasses the generation
+	 * check in ipc_entry_lookup(). So a STALE Mach port name whose index
+	 * has since been recycled to a vnode or socket was still being
+	 * silently converted into a receiverless port -- the generation was
+	 * stamped and validated, but this path never consulted it. That is
+	 * half of the aliasing the generation counter was added to catch, and
+	 * it is the half that produces the observed wedge (#145).
+	 *
+	 * A legitimately-obtained port name always has a non-zero generation:
+	 * ipc_entry_get() stamps IE_BITS_NEW_GEN() on every allocation and
+	 * the first value is IE_BITS_GEN_ONE, never 0. A bare file descriptor
+	 * number passed where a port name is expected has none. So a non-zero
+	 * generation means "this is a Mach port name" -- and a Mach port name
+	 * must never be resolved as a file.
+	 */
+	if (MACH_PORT_GEN(name) != 0)
+		return (KERN_INVALID_NAME);
+
 	if (fget(curthread, MACH_PORT_INDEX(name), cap_rights_init(&rights, CAP_ALL1), &fp) != 0) {
 		log(LOG_DEBUG, "%s:%d entry for port name: %d not found\n", curproc->p_comm, curproc->p_pid, name);
 		return (KERN_INVALID_ARGUMENT);


### PR DESCRIPTION
Part of #145. Follows #160, and closes a gap I found by re-reading my own patch.

## The gap

`ipc_object_copyin()` calls `ipc_entry_file_to_port()` **before** `ipc_right_lookup()`. That function `fget`s the name's index half and, if it denotes an ordinary file descriptor, wraps it in a synthetic port with `ip_receiver` set and **nobody receiving on it** — a send to which succeeds and is never delivered.

Because it runs before the lookup, **it bypasses the generation check added in #160.**

| stale name lands on | today | with #160 | with this |
|---|---|---|---|
| another **Mach** entry | wedge | rejected (lookup + gen check) | rejected |
| an ordinary **fd** | wedge | **still wedges** | rejected |

That second row is specifically the observed failure mode in #145 — client's send succeeds, server never sees the message, client blocks forever. #160 alone would only have closed half of it.

## The guard

A legitimately-obtained port name always carries a **non-zero** generation: `ipc_entry_get()` stamps `IE_BITS_NEW_GEN()` on every allocation and the first value is `IE_BITS_GEN_ONE`, never 0. A bare fd number passed where a port name is expected has none.

So a non-zero generation means "this is a Mach port name" — and a Mach port name must never be resolved as a file.

## Safety

- Callers unaffected: `ipc_object_copyin()` treats any non-`KERN_SUCCESS` as "not a file, continue with the normal port path".
- No legitimate consumer lost: the implicit fileport has no API and no guard, userland's `fileport_*` are `ENOSYS` stubs, and the sweep recorded on #152 found nothing in userland passing an fd where a port name is expected.

Deleting the path entirely is #152 proper; this is the minimal guard that makes it safe under generations, and it is the half that matters for the wedge.