### PR TITLE
Revert #160 — the generation kernel does not boot on hardware

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_entry.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_entry.c
@@ -331,7 +331,7 @@ ipc_entry_lookup(ipc_space_t space, mach_port_name_t name)
 	if (curthread->td_proc->p_fd == NULL)
 		return (NULL);
 
-	if (fget(curthread, MACH_PORT_INDEX(name), cap_rights_init(&rights, CAP_KQUEUE_EVENT|CAP_KQUEUE_CHANGE), &fp) != 0) {
+	if (fget(curthread, name, cap_rights_init(&rights, CAP_KQUEUE_EVENT|CAP_KQUEUE_CHANGE), &fp) != 0) {
 		if (mach_debug_enable)
 			log(LOG_DEBUG, "%s:%d entry for port name: %d not found\n", curproc->p_comm, curproc->p_pid, name);
 		return (NULL);
@@ -345,21 +345,6 @@ ipc_entry_lookup(ipc_space_t space, mach_port_name_t name)
 		return (NULL);
 	}
 	entry = fp->f_data;
-	/*
-	 * Generation check. Port names are file descriptors here and the fd
-	 * allocator reissues the lowest free number, so a name freed by one
-	 * RPC is handed back bit-identical to the next. Without this compare
-	 * a caller holding a stale name silently operates on whatever object
-	 * now occupies that fd. Reject the mismatch instead.
-	 */
-	if (MACH_PORT_GEN(name) != IE_BITS_GEN(entry->ie_bits)) {
-		if (mach_debug_enable)
-			log(LOG_DEBUG, "%s:%d stale port name 0x%x (gen 0x%x != 0x%x)\n",
-			    curproc->p_comm, curproc->p_pid, name,
-			    MACH_PORT_GEN(name), IE_BITS_GEN(entry->ie_bits));
-		fdrop(fp, curthread);
-		return (NULL);
-	}
 	fdrop(fp, curthread);
 	return (entry);
 }
@@ -376,7 +361,7 @@ ipc_entry_file_to_port(ipc_space_t space, mach_port_name_t name, ipc_object_t *o
 	if (curthread->td_proc->p_fd == NULL)
 		return (KERN_INVALID_ARGUMENT);
 
-	if (fget(curthread, MACH_PORT_INDEX(name), cap_rights_init(&rights, CAP_ALL1), &fp) != 0) {
+	if (fget(curthread, name, cap_rights_init(&rights, CAP_ALL1), &fp) != 0) {
 		log(LOG_DEBUG, "%s:%d entry for port name: %d not found\n", curproc->p_comm, curproc->p_pid, name);
 		return (KERN_INVALID_ARGUMENT);
 	}
@@ -483,16 +468,9 @@ ipc_entry_get(
 		return (KERN_RESOURCE_SHORTAGE);
 	}
 
-	/*
-	 * Advance the space's rolling generation and stamp it into both the
-	 * entry and the name we hand back, so a later reuse of this same fd
-	 * yields a different name and ipc_entry_lookup() can tell them apart.
-	 */
-	space->is_gen_last = IE_BITS_NEW_GEN(space->is_gen_last);
-
-	free_entry->ie_bits = IE_BITS_GEN(space->is_gen_last);
+	free_entry->ie_bits = 0;
 	free_entry->ie_request = 0;
-	free_entry->ie_name = MACH_PORT_MAKE(fd, IE_BITS_GEN(space->is_gen_last));
+	free_entry->ie_name = fd;
 	free_entry->ie_fp = fp;
 	free_entry->ie_index = UINT_MAX;
 	free_entry->ie_link = NULL;
@@ -503,7 +481,7 @@ ipc_entry_get(
 	finit(fp, 0, DTYPE_MACH_IPC, free_entry, &mach_fileops);
 	fdrop(fp, td);
 	assert(fp->f_count == 1);
-	*namep = free_entry->ie_name;
+	*namep = fd;
 	*entryp = free_entry;
 
 	return KERN_SUCCESS;
@@ -565,7 +543,6 @@ ipc_entry_alloc_name(
 	ipc_entry_t	*entryp)
 {
 	mach_port_name_t newname;
-	mach_port_name_t index;
 	struct file *fp;
 	kern_return_t kr;
 	struct thread *td = curthread;
@@ -574,27 +551,18 @@ ipc_entry_alloc_name(
 		return (KERN_INVALID_TASK);
 	}
 	assert(MACH_PORT_NAME_VALID(name));
-	/* fd half of the requested name; see the comment at kern_fdalloc below */
 	is_write_lock(space);
 	if ((*entryp = ipc_entry_lookup(space, name)) != NULL)
 		return (KERN_SUCCESS);
 
 	is_write_unlock(space);
 
-	/*
-	 * The caller asks for a SPECIFIC name. A name is now
-	 * (generation | fd index), so the fd we must reserve is the index
-	 * half -- passing the whole name to kern_fdalloc() would request a
-	 * minimum fd of a hugely out-of-range number and always fail.
-	 */
-	index = MACH_PORT_INDEX(name);
-
 	/* name could technically be a ridiculously large value */
-	if (kern_fdalloc(td, index, &newname)) {
-		log(LOG_WARNING, "%s:%d failed to allocate %d\n", __FILE__, __LINE__, index);
+	if (kern_fdalloc(td, name, &newname)) {
+		log(LOG_WARNING, "%s:%d failed to allocate %d\n", __FILE__, __LINE__, name);
 		return (KERN_RESOURCE_SHORTAGE);
 	}
-	if (newname != index) {
+	if (newname != name) {
 		kern_fddealloc(td, newname);
 		return (KERN_NAME_EXISTS);
 	}
@@ -602,7 +570,7 @@ ipc_entry_alloc_name(
 		kern_fddealloc(td, newname);
 		return (KERN_RESOURCE_SHORTAGE);
 	}
-	if (kern_finstall(td, fp, &index, FNOFDALLOC, NULL)) {
+	if (kern_finstall(td, fp, &name, FNOFDALLOC, NULL)) {
 		kern_fddealloc(td, newname);
 		fdrop(fp, td);
 		return (KERN_RESOURCE_SHORTAGE);
@@ -627,8 +595,6 @@ ipc_entry_close(
 
 	td = curthread;
 	fdp = td->td_proc->p_fd;
-	/* caller passes a port NAME; the fd is its index half */
-	fd = MACH_PORT_INDEX(fd);
 
 	FILEDESC_XLOCK(fdp);
 	if ((fp = fget_noref(fdp, fd)) == NULL) {

--- a/src-overlay/sys/sys/mach/ipc/ipc_space.h
+++ b/src-overlay/sys/sys/mach/ipc/ipc_space.h
@@ -144,13 +144,6 @@ struct ipc_space {
 	ipc_entry_num_t is_tree_small;	/* # of small entries in the tree */
 	ipc_entry_num_t is_tree_hash;	/* # of hashed entries in the tree */
 	boolean_t is_fast;              /* for is_fast_space() */
-	/*
-	 * Rolling generation stamped into each name handed out by
-	 * ipc_entry_get(). Advanced on every allocation, so a name reissued
-	 * for a recycled fd differs from the stale one a caller may still be
-	 * holding. is_alloc() zeroes the space, so this starts at 0.
-	 */
-	ipc_entry_bits_t is_gen_last;
 };
 
 #define	IS_NULL			((ipc_space_t) 0)

--- a/src-overlay/sys/sys/mach/port.h
+++ b/src-overlay/sys/sys/mach/port.h
@@ -216,32 +216,20 @@ typedef mach_port_t			*mach_port_array_t;
  *
  */
 
-/*
- * Port name encoding: generation in the HIGH bits, index in the LOW bits.
- *
- * This deliberately inverts Apple's layout (index high, generation low).
- * In this port a port name IS a file descriptor -- ipc_entry_lookup() feeds
- * it straight to fget() -- so the index must stay a valid fd number and
- * cannot be shifted. Keeping the generation in the high bits leaves the low
- * 24 bits usable as an fd while still making a recycled name detectably
- * stale, which is the whole point of the counter.
- *
- * The generation bits line up with IE_BITS_GEN_MASK in ipc_entry.h, so the
- * value stored in ie_bits and the value carried in the name are the same
- * bits in the same positions -- no shifting between the two representations.
- *
- * Sentinels: MACH_PORT_NULL is 0, which is safe because port fds are
- * allocated starting at 16, so index 0 is never a live port name.
- * MACH_PORT_DEAD is ~0; MACH_PORT_NAME_LIVE() below excludes both so a
- * sentinel is never mistaken for a generationed name.
- */
-#define	MACH_PORT_INDEX_MASK		0x00ffffffU
-#define	MACH_PORT_INDEX(name)		((name) & MACH_PORT_INDEX_MASK)
-#define	MACH_PORT_GEN(name)		((name) & 0xff000000U)
-#define	MACH_PORT_MAKE(index, gen)	((index) | (gen))
+#if 0
 
-#define	MACH_PORT_NAME_LIVE(name)	\
-		(((name) != MACH_PORT_NULL) && ((name) != MACH_PORT_DEAD))
+#define	MACH_PORT_INDEX(name)		((name) >> 8)
+#define	MACH_PORT_GEN(name)		(((name) & 0xff) << 24)
+#define	MACH_PORT_MAKE(index, gen)	\
+		(((index) << 8) | (gen) >> 24)
+
+#else	/* NO_PORT_GEN */
+
+#define	MACH_PORT_INDEX(name)		(name)
+#define	MACH_PORT_GEN(name)		(0)
+#define	MACH_PORT_MAKE(index, gen)	(index)
+
+#endif	/* NO_PORT_GEN */
 #define MACH_PORT_MAKEB(index, bits)    \
                 MACH_PORT_MAKE(index, IE_BITS_GEN(bits))
 


### PR DESCRIPTION
**Urgent: `main` currently contains a kernel that does not boot.**

#160 passed the CI boot smoke-test and then failed to boot on the arm64 box. Deployed as `20260831-025635`; the machine never came back — no ssh, no ping, and a clean stop/start did not help. Recovered via LiveCD by restoring the previous kernel (`20260831-021508`, Stage 1), which boots fine and reports all services healthy.

This is not abandoning the change. The root-cause analysis is unchanged, the branch is preserved at `fix/port-name-generation`, and the broken kernel is kept on the box at `/boot/kernel/kernel.gen-broken` for post-mortem.

## Two lessons that cost a recovery cycle

**The CI smoke-test is not a sufficient boot gate.** It boots a self-assembled image under qemu/TCG. The box is an arm64 UTM VM with a different disk layout, device set and timing. Something in that gap is fatal here and invisible there. I treated smoke-test-green as authorization to deploy; it isn't. Kernel changes of this class need hardware verification *before* merge.

**There is no serial console.** `utmctl attach` is not implemented (it prints a warning and echoes the controlling terminal), so no panic message was recoverable — I cannot distinguish a panic from a hang. Getting a working console is now a prerequisite for this work rather than a nicety; without it every failed boot costs a full LiveCD recovery.

## Prime suspect (unverified)

`ipc_entry_alloc_name()` is reachable from `ipc_object_copyout_name()` on the live `mach_msg` path, and already double-allocates and returns a name that does not match the one requested — I flagged this in #160's description as "pre-existing, not made worse". Under generations the mismatch now *also* carries a generation mismatch, so lookups that previously limped along on the placeholder entry fail outright. That would break early-boot IPC while leaving the narrower qemu path unaffected.

If that is right, the fix is to make `alloc_name` honour the requested name — which is exactly the work in #151, and confirms the plan's judgement that it cannot be fixed independently of the table.