### PR TITLE
mach/ipc: fix two panics introduced by this session's merged changes

### DIFF
--- a/src-overlay/sys/compat/mach/ipc/ipc_pset.c
+++ b/src-overlay/sys/compat/mach/ipc/ipc_pset.c
@@ -779,6 +779,26 @@ filt_machport(struct knote *kn, long hint)
 				kdb_backtrace();
 				printf("%s: filt_machport kr=%d ips_active=%d name=%d\n", curproc->p_comm, kr, !!ips_active(pset), name);
 			}
+			/*
+			 * ipc_object_translate() takes io_lock ONLY when
+			 * *objectp != object on entry, and it does not check
+			 * io_active -- it returns KERN_SUCCESS for an inactive
+			 * object. So when translate resolves a pset different
+			 * from the cached one AND that pset is inactive, this
+			 * arm is reached holding ips_lock, and returning here
+			 * carried a non-recursive MTX_DEF mutex all the way back
+			 * to userland.
+			 *
+			 * The path was effectively dead before #147: the seed
+			 * used to be entry->ie_object, the same value translate
+			 * was about to read, so *objectp != object was never
+			 * true. #147 changed the seed to kn->kn_hook, a snapshot
+			 * taken at attach time, which genuinely diverges -- a kq
+			 * scanned in a different process than the registering
+			 * task, or a recycled port-set fd.
+			 */
+			if (pset != cached)
+				ips_unlock(pset);
 			kn->kn_data = 0;
 			kn->kn_flags |= (EV_EOF | EV_ONESHOT);
 			return (1);

--- a/src-overlay/sys/compat/mach/mach_module.c
+++ b/src-overlay/sys/compat/mach/mach_module.c
@@ -188,49 +188,26 @@ mach_port_backlog_sysctl(SYSCTL_HANDLER_ARGS)
 			    owner != NULL ? owner->p_pid : -1);
 
 			/*
-			 * Knote state for the set this stranded port belongs
-			 * to. This is the measurement that separates kernel
-			 * from userland:
+			 * The knote-state dump that used to live here has been
+			 * removed: it walked port->ip_pset->ips_note.kl_list with no
+			 * port lock, and that is not merely a stale read.
+			 * ipc_pset_destroy() sets port->ip_pset = NULL under the port
+			 * lock, so a concurrent teardown between the NULL test and
+			 * the dereference starts the walk at a small constant address
+			 * and faults. ips_release() -> io_free() also uma_zfree()s the
+			 * pset, so the knote reads had unbounded lifetime.
 			 *
-			 *   ACTIVE or QUEUED set -- the kernel told userland a
-			 *     message was waiting and userland did not drain
-			 *     it. Nothing further to find on this side.
-			 *   neither set -- userland was never told, and the
-			 *     activation was lost despite every counter on the
-			 *     delivery path reading clean.
+			 * The original comment defended this by noting the iteration
+			 * was bounded. Bounding prevents a spin; it does nothing about
+			 * a fault. A diagnostic must not be able to panic the box it
+			 * is diagnosing.
 			 *
-			 * Read WITHOUT ips_note_lock: that is an sx, this runs
-			 * under PROC_LOCK (a mutex), and sleeping there would
-			 * panic. Same trade-off already taken for the port
-			 * fields above, and sound for the same reason -- a
-			 * wedge persists for minutes. The iteration is bounded
-			 * so a torn or corrupt list cannot spin the sysctl.
+			 * It served its purpose -- it established that a knote IS
+			 * registered on the stranded set and that it is EV_CLEAR,
+			 * which is what identified nextbsd-userland#135. Anything
+			 * needing it again should take ip_lock(port) first, which
+			 * this handler cannot do while holding PROC_LOCK.
 			 */
-			if (port->ip_pset != NULL) {
-				struct knote *kn;
-				int kncount = 0;
-
-				SLIST_FOREACH(kn,
-				    &port->ip_pset->ips_note.kl_list,
-				    kn_selnext) {
-					if (++kncount > 8) {
-						sbuf_printf(&sb,
-						    "         knote: ...more\n");
-						break;
-					}
-					sbuf_printf(&sb,
-					    "         knote kq=%p status=0x%x%s%s%s "
-					    "influx=%d flags=0x%x\n",
-					    kn->kn_kq, kn->kn_status,
-					    (kn->kn_status & KN_ACTIVE) ? " ACTIVE" : "",
-					    (kn->kn_status & KN_QUEUED) ? " QUEUED" : "",
-					    (kn->kn_status & KN_DISABLED) ? " DISABLED" : "",
-					    kn->kn_influx, kn->kn_flags);
-				}
-				if (kncount == 0)
-					sbuf_printf(&sb,
-					    "         knote: NONE registered on this pset\n");
-			}
 		}
 		PROC_UNLOCK(p);
 	}


### PR DESCRIPTION
Both found by auditing what landed today.

**1. `filt_machport()` returned to userland holding `ips_lock`** — a non-recursive `MTX_DEF`. `ipc_object_translate()` takes `io_lock` only when `*objectp != object`, and does not check `io_active`, so an inactive pset resolved differently from the cached one hit the early return with the lock held. The path was effectively dead before #147 changed the seed from `entry->ie_object` to `kn->kn_hook`.

**2. `mach.port_backlog`'s knote dump could fault the box it was diagnosing** — it walked `port->ip_pset->ips_note.kl_list` unlocked, and `ipc_pset_destroy()` NULLs that field under the port lock. My comment defended it as bounded; bounding prevents a spin, not a fault. Removed rather than locked, since the handler holds `PROC_LOCK` and cannot take `ip_lock`. It had already served its purpose.

Port rows are unchanged.