### PR TITLE
rpi5: fix the BCM2712 mailbox DMA clamp (black screen), and read SoC temperature/throttling

### DIFF
--- a/patches/0030-bcm2835_vcbus-clamp-bcm2712-mailbox-dma-to-videocore-reach.patch
+++ b/patches/0030-bcm2835_vcbus-clamp-bcm2712-mailbox-dma-to-videocore-reach.patch
@@ -1,0 +1,124 @@
+From a33c931fb92dd919e6feffc13bb8adab0bdebedd Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 22:55:21 -0500
+Subject: [PATCH] bcm2835_vcbus: clamp BCM2712 mailbox DMA to the VideoCore's
+ reach
+
+Two ceilings apply to a mailbox property buffer, and only the looser one
+was accounted for. 0027 set busdma_lowaddr to BUS_SPACE_MAXADDR_32BIT with
+the reasoning that the property interface carries the buffer address in a
+single 32-bit word. That is true, and not sufficient: the VideoCore's reach
+into SDRAM is tighter than the register is wide, which is why 2711 and 2838
+both clamp to BCM2838_PERIPH_MAXADDR instead. 2712 is no different; the
+clamp was simply missed.
+
+Measured on a Pi 500+ with 16GB. The firmware hands physical memory over in
+three chunks:
+
+  0x00000000080000 - 0x0000000001ffff      1.5 MB
+  0x000000013ca000 - 0x0000003f3fffff    1040 MB
+  0x00000040232000 - 0x000003ea657fff   15741 MB
+
+Instrumenting bcm2835_mbox_property() to log the buffer address and the
+VideoCore's response code:
+
+  req tag=0x00030006 phys=0x0019f000  -> code=0x80000000 (SUCCESS)  chunk 1
+  req tag=0x00040003 phys=0x013ca000  -> code=0x80000000 (SUCCESS)  chunk 2
+  req tag=0x00040005 phys=0x40232000  -> code=0x00000000 (FAILS)    chunk 3
+
+Response code 0x00000000 is the request code: the buffer came back
+untouched because the VideoCore never wrote to it. Every call landing in
+the low two chunks succeeded; the one landing in the third did not. The
+boundary sits between 0x3f3fffff and 0x40232000, which
+BCM2838_PERIPH_MAXADDR already covers.
+
+Stated honestly: 1GB is sufficient and measured, not proven to be the exact
+ceiling. The lowest failing address available to test was the start of the
+third chunk, so 0x40000000-0x40232000 is unprobed. The value matches the
+two SoCs whose limit is known rather than sitting at the edge of what was
+measured.
+
+What makes this worth fixing ahead of anything else: the failure is silent
+and depends on where the allocator happens to place a buffer, so it moves
+with the memory map. bcm2835_fbd makes two property calls during attach --
+GET_PHYSICAL_W_H then GET_DEPTH -- and a layout that puts the second one
+above 1GB kills the console with nothing in dmesg but "mbox response
+error", which until now did not even print the code it rejected.
+
+Changing framebuffer_depth in config.txt resizes the firmware's
+reservation, shifts the chunk boundaries, and changes which calls survive.
+That is very likely the real mechanism behind the per-board
+framebuffer_depth workarounds in the Pi 5 call for testing -- where one
+board needs 32, another needs 24, and a third gets no display either way.
+Those are three different memory maps, not three different pixel formats.
+Unverified on the two boards that are not mine.
+
+Refs nextbsd-kernel#171, and nextbsd#422 (call for testing).
+---
+ sys/arm/broadcom/bcm2835/bcm2835_vcbus.c | 49 ++++++++++++++++++++----
+ 1 file changed, 42 insertions(+), 7 deletions(-)
+
+diff --git a/sys/arm/broadcom/bcm2835/bcm2835_vcbus.c b/sys/arm/broadcom/bcm2835/bcm2835_vcbus.c
+index 565d9f336c0..bcb9079e43c 100644
+--- a/sys/arm/broadcom/bcm2835/bcm2835_vcbus.c
++++ b/sys/arm/broadcom/bcm2835/bcm2835_vcbus.c
+@@ -211,14 +211,49 @@ static struct bcm283x_memory_soc_cfg {
+ 		.memmap = bcm2712_memmap,
+ 		.soc_compat = "brcm,bcm2712",
+ 		/*
+-		 * The mailbox property interface carries the buffer address in
+-		 * a single 32-bit word, so a buffer handed to the VideoCore has
+-		 * to live below 4GB whatever the interconnect can reach. That
+-		 * is a property of the protocol rather than of this SoC, and it
+-		 * is why this is not the full identity range the dma-ranges
+-		 * would otherwise allow.
++		 * Two separate ceilings apply here, and only the looser one was
++		 * accounted for originally.
++		 *
++		 * The mailbox property interface carries the buffer address in a
++		 * single 32-bit word, so a buffer handed to the VideoCore must
++		 * live below 4GB. True, and a property of the protocol rather
++		 * than of this SoC -- but not sufficient. The VideoCore's own
++		 * reach into SDRAM is tighter than the register is wide, which
++		 * is why 2711 and 2838 above both clamp to
++		 * BCM2838_PERIPH_MAXADDR rather than to the full 32-bit range.
++		 * 2712 is no different, and clamping was simply missed.
++		 *
++		 * Measured on a Pi 500+ with 16GB, whose physical memory the
++		 * firmware hands over in three chunks:
++		 *
++		 *   0x00000000080000 - 0x0000000001ffff      1.5 MB
++		 *   0x000000013ca000 - 0x0000003f3fffff    1040 MB
++		 *   0x00000040232000 - 0x000003ea657fff   15741 MB
++		 *
++		 * With lowaddr at 4GB the third chunk is eligible, and every
++		 * property call whose buffer landed there failed -- the response
++		 * code came back 0x00000000, i.e. the buffer was returned
++		 * untouched because the VideoCore never wrote to it. Calls
++		 * landing in the first two chunks succeeded. The boundary sits
++		 * between 0x3f3fffff (works) and 0x40232000 (does not), which
++		 * BCM2838_PERIPH_MAXADDR already covers.
++		 *
++		 * Stated honestly: 1GB is *sufficient* and measured. It is not
++		 * proven to be the exact ceiling -- the first failing address
++		 * available to test was the start of the third chunk, so
++		 * anything between 0x40000000 and 0x40232000 is unprobed. The
++		 * value is chosen to match the two SoCs whose limit is known
++		 * rather than to sit at the edge of what was measured.
++		 *
++		 * The failure this caused is silent and depends on where the
++		 * allocator happens to place a buffer, so it moves with the
++		 * memory map: changing framebuffer_depth in config.txt resizes
++		 * the firmware's reservation, shifts the chunk boundaries, and
++		 * changes which calls survive. That is very likely what the
++		 * per-board framebuffer_depth workarounds in the call for
++		 * testing were really working around.
+ 		 */
+-		.busdma_lowaddr = BUS_SPACE_MAXADDR_32BIT,
++		.busdma_lowaddr = BCM2838_PERIPH_MAXADDR,
+ 	},
+ };
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0031-bcm2835-firmware-and-vcio-build-them-on-bcm2712.patch
+++ b/patches/0031-bcm2835-firmware-and-vcio-build-them-on-bcm2712.patch
@@ -1,0 +1,77 @@
+From 1e4bc29b75bfd6454c3121dde0177bcead37135f Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 09:40:09 -0500
+Subject: [PATCH 1/2] bcm2835_firmware, bcm2835_vcio: build them on BCM2712
+
+Neither file is new, and neither needs porting. Both are gated on the Pi 3
+and Pi 4 SoCs only, and this board is a third one, so on the Pi 5 family
+they are simply not compiled.
+
+0027 already brought the property mailbox up on this SoC and proved it:
+bcm2835_mbox.c and bcm2835_vcbus.c are built for soc_brcm_bcm2712, the
+framebuffer path asks the VideoCore for the panel dimensions over that
+channel, and there is a picture. The channel these two files want is the
+one that is already answering.
+
+bcm2835_firmware.c attaches to /soc/firmware, which the vendor tree
+carries on this board unchanged from every earlier Pi:
+
+    firmware {
+        compatible = "raspberrypi,bcm2835-firmware", "simple-mfd";
+        mboxes = <&mailbox>;
+    };
+
+pointing at mailbox@7c013880, compatible "brcm,bcm2835-mbox" -- the node
+bcm2835_mbox.c is already attached to. The driver reads only the `mboxes`
+phandle and has no registers of its own, so there is nothing here that
+could be SoC-specific. It exports bcm2835_firmware_property(), which is
+the entry point every firmware query in the tree goes through.
+
+There is no probe fight for that node. simplebus_probe() returns ENXIO
+for anything compatible with "simple-mfd" precisely so that a real driver
+can claim it, and bcm2835_firmware probes at BUS_PROBE_DEFAULT, which
+beats simple_mfd's BUS_PROBE_GENERIC.
+
+bcm2835_vcio.c is a DEV_MODULE with no device attachment at all -- it
+creates /dev/vcio and forwards ioctls straight to
+bcm2835_mbox_property(). That is the node sysutils/raspberrypi-userland
+opens, so this is what makes `vcgencmd measure_temp` and, more usefully,
+`vcgencmd get_throttled` answer on these boards.
+
+Deliberately NOT flipped here: bcm2835_cpufreq.c. It looks like the same
+one-line change and is not. It attempts to *set* clocks and voltages on a
+SoC whose firmware owns both, and the 2712 tag set is not verified to
+match 2837/2838. That is separate work with its own hardware proof.
+
+Refs nextbsd-kernel#112.
+---
+ sys/conf/files.arm64 | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/sys/conf/files.arm64 b/sys/conf/files.arm64
+index 37a3046..cc9340f 100644
+--- a/sys/conf/files.arm64
++++ b/sys/conf/files.arm64
+@@ -576,7 +576,8 @@ arm/broadcom/bcm2835/bcm2835_cpufreq.c			optional soc_brcm_bcm2837 fdt | soc_brc
+ arm/broadcom/bcm2835/bcm2835_dma.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
+ arm/broadcom/bcm2835/bcm2835_fbd.c			optional vt soc_brcm_bcm2837 fdt | vt soc_brcm_bcm2838 fdt | \
+ 	vt soc_brcm_bcm2712 fdt
+-arm/broadcom/bcm2835/bcm2835_firmware.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
++arm/broadcom/bcm2835/bcm2835_firmware.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt | \
++	soc_brcm_bcm2712 fdt
+ arm/broadcom/bcm2835/bcm2835_ft5406.c			optional evdev bcm2835_ft5406 fdt
+ arm/broadcom/bcm2835/bcm2835_gpio.c			optional gpio soc_brcm_bcm2837 fdt | gpio soc_brcm_bcm2838 fdt
+ arm/broadcom/bcm2835/bcm2835_intr.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
+@@ -588,7 +589,8 @@ arm/broadcom/bcm2835/bcm2835_sdhost.c			optional sdhci soc_brcm_bcm2837 fdt | sd
+ arm/broadcom/bcm2835/bcm2835_spi.c			optional bcm2835_spi fdt
+ arm/broadcom/bcm2835/bcm2835_vcbus.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt | \
+ 	soc_brcm_bcm2712 fdt
+-arm/broadcom/bcm2835/bcm2835_vcio.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
++arm/broadcom/bcm2835/bcm2835_vcio.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt | \
++	soc_brcm_bcm2712 fdt
+ arm/broadcom/bcm2835/bcm2835_wdog.c			optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
+ arm/broadcom/bcm2835/bcm2836.c				optional soc_brcm_bcm2837 fdt | soc_brcm_bcm2838 fdt
+ arm/broadcom/bcm2835/bcm283x_dwc_fdt.c			optional dwcotg fdt soc_brcm_bcm2837 | dwcotg fdt soc_brcm_bcm2838
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch
+++ b/patches/0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch
@@ -1,0 +1,182 @@
+From 11fea30ac004fe8177c1e654a07c11653061d2f6 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 09:41:28 -0500
+Subject: [PATCH 2/2] bcm2835_firmware: report SoC temperature and firmware
+ throttling
+
+The firmware already answers both of these on the property mailbox; the
+driver that owns that channel just never asked. Two sysctls alongside the
+`revision` one that is already there:
+
+    dev.bcm2835_firmware.0.temperature      # "IK": sysctl(8) prints degC
+    dev.bcm2835_firmware.0.throttled        # raw flag word
+
+Neither has a write path, because there is nothing to write. On every Pi
+the VPU owns the ARM clock, the voltage rails, and the thermal limits, and
+enforces them without asking the OS -- soft limit around 80C, hard around
+85C. An OS with no cpufreq and no thermal zones is therefore not missing a
+safety net it ever held. What it is missing is any way to *see* the net
+working, and that is the gap here: a board the firmware has quietly clocked
+down reads, from userland, exactly like a board that is merely slow.
+
+`throttled` is the more useful of the two for that. Bits 0-3 are live
+state (undervolt / frequency capped / throttled / soft temperature limit);
+bits 16-19 latch the same four conditions and stay set until the next boot,
+so an event that has already passed still leaves a record. Defines for all
+eight are in bcm2835_firmware.h.
+
+Temperature is reported in tenths of a Kelvin with the "IK" format, which
+is what sysctl(8) renders as degrees C and what every other temperature
+sysctl in the tree uses. bcm2835_cpufreq.c already does the same
+conversion from the same tag; the arithmetic here is copied from it rather
+than re-derived.
+
+Tag 0x00030006 (GET_TEMPERATURE) was already defined. 0x00030046
+(GET_THROTTLED) is added. Both are read-only queries with no side effects
+on the VPU -- unlike the SET_ tags in the neighbouring cpufreq driver.
+
+This is SoC-independent: it goes through bcm2835_firmware_property() and
+touches no registers, so it applies equally to the Pi 3 and Pi 4 boards
+that already build this file.
+
+Refs nextbsd-kernel#112.
+---
+ sys/arm/broadcom/bcm2835/bcm2835_firmware.c | 69 +++++++++++++++++++++
+ sys/arm/broadcom/bcm2835/bcm2835_firmware.h | 26 ++++++++
+ 2 files changed, 95 insertions(+)
+
+diff --git a/sys/arm/broadcom/bcm2835/bcm2835_firmware.c b/sys/arm/broadcom/bcm2835/bcm2835_firmware.c
+index c1d23c0..84c7a6b 100644
+--- a/sys/arm/broadcom/bcm2835/bcm2835_firmware.c
++++ b/sys/arm/broadcom/bcm2835/bcm2835_firmware.c
+@@ -55,7 +55,12 @@ static struct ofw_compat_data compat_data[] = {
+ 	{NULL,					0}
+ };
+ 
++/* Zero Celsius in tenths of a Kelvin, for the "IK" sysctl format. */
++#define	TZ_ZEROC	2731
++
+ static int sysctl_bcm2835_firmware_get_revision(SYSCTL_HANDLER_ARGS);
++static int sysctl_bcm2835_firmware_get_temperature(SYSCTL_HANDLER_ARGS);
++static int sysctl_bcm2835_firmware_get_throttled(SYSCTL_HANDLER_ARGS);
+ 
+ static int
+ bcm2835_firmware_probe(device_t dev)
+@@ -99,6 +104,14 @@ bcm2835_firmware_attach(device_t dev)
+ 	    CTLTYPE_UINT | CTLFLAG_RD, sc, sizeof(*sc),
+ 	    sysctl_bcm2835_firmware_get_revision, "IU",
+ 	    "Firmware revision");
++	SYSCTL_ADD_PROC(ctx, tree, OID_AUTO, "temperature",
++	    CTLTYPE_INT | CTLFLAG_RD, sc, sizeof(*sc),
++	    sysctl_bcm2835_firmware_get_temperature, "IK",
++	    "SoC temperature");
++	SYSCTL_ADD_PROC(ctx, tree, OID_AUTO, "throttled",
++	    CTLTYPE_UINT | CTLFLAG_RD, sc, sizeof(*sc),
++	    sysctl_bcm2835_firmware_get_throttled, "IU",
++	    "Firmware throttling and undervoltage flags");
+ 
+ 	/* The firmwaare doesn't have a ranges property */
+ 	sc->sc.flags |= SB_FLAG_NO_RANGES;
+@@ -163,6 +176,62 @@ sysctl_bcm2835_firmware_get_revision(SYSCTL_HANDLER_ARGS)
+ 	return (EINVAL);
+ }
+ 
++/*
++ * Both of these are reads of state the firmware alone owns, so neither has a
++ * write path -- the VPU decides the clock, the voltage and the thermal limits,
++ * and the kernel is a spectator. Reporting them is the whole point: without
++ * this, a board that the firmware has quietly clocked down is indistinguishable
++ * from one that is simply slow.
++ */
++static int
++sysctl_bcm2835_firmware_get_temperature(SYSCTL_HANDLER_ARGS)
++{
++	struct bcm2835_firmware_softc *sc = arg1;
++	union msg_get_temperature_body msg;
++	int err, val;
++
++	memset(&msg, 0, sizeof(msg));
++	msg.req.temperature_id = 0;
++
++	if (bcm2835_firmware_property(sc->sc.dev,
++	    BCM2835_FIRMWARE_TAG_GET_TEMPERATURE, &msg, sizeof(msg)) != 0)
++		return (ENXIO);
++
++	/* Thousandths of a degree C on the wire, tenths of a Kelvin here. */
++	val = (int)msg.resp.value / 100 + TZ_ZEROC;
++
++	err = sysctl_handle_int(oidp, &val, 0, req);
++	if (err || !req->newptr) /* error || read request */
++		return (err);
++
++	/* write request */
++	return (EINVAL);
++}
++
++static int
++sysctl_bcm2835_firmware_get_throttled(SYSCTL_HANDLER_ARGS)
++{
++	struct bcm2835_firmware_softc *sc = arg1;
++	union msg_get_throttled_body msg;
++	uint32_t val;
++	int err;
++
++	memset(&msg, 0, sizeof(msg));
++
++	if (bcm2835_firmware_property(sc->sc.dev,
++	    BCM2835_FIRMWARE_TAG_GET_THROTTLED, &msg, sizeof(msg)) != 0)
++		return (ENXIO);
++
++	val = msg.resp.value;
++
++	err = sysctl_handle_int(oidp, &val, 0, req);
++	if (err || !req->newptr) /* error || read request */
++		return (err);
++
++	/* write request */
++	return (EINVAL);
++}
++
+ static device_method_t bcm2835_firmware_methods[] = {
+ 	/* Device interface */
+ 	DEVMETHOD(device_probe,		bcm2835_firmware_probe),
+diff --git a/sys/arm/broadcom/bcm2835/bcm2835_firmware.h b/sys/arm/broadcom/bcm2835/bcm2835_firmware.h
+index 1311699..45a8da5 100644
+--- a/sys/arm/broadcom/bcm2835/bcm2835_firmware.h
++++ b/sys/arm/broadcom/bcm2835/bcm2835_firmware.h
+@@ -113,6 +113,32 @@ union msg_get_temperature_body {
+ 	} resp;
+ };
+ 
++#define BCM2835_FIRMWARE_TAG_GET_THROTTLED		0x00030046
++
++/*
++ * Throttling and undervoltage, as the firmware sees it. The low four bits are
++ * live state; the same four conditions latch at bit 16 and stay set until the
++ * next boot, so a machine that threw a brownout an hour ago still says so.
++ *
++ * This is a report, not a control. On every Pi the VPU owns the ARM clock and
++ * the voltage rails and enforces the thermal limits itself, so these bits are
++ * the only account of what it has already decided to do.
++ */
++#define BCM2835_FIRMWARE_THROTTLED_UNDER_VOLTAGE	(1u << 0)
++#define BCM2835_FIRMWARE_THROTTLED_FREQ_CAPPED		(1u << 1)
++#define BCM2835_FIRMWARE_THROTTLED_THROTTLED		(1u << 2)
++#define BCM2835_FIRMWARE_THROTTLED_SOFT_TEMPLIMIT	(1u << 3)
++#define BCM2835_FIRMWARE_THROTTLED_WAS_UNDER_VOLTAGE	(1u << 16)
++#define BCM2835_FIRMWARE_THROTTLED_WAS_FREQ_CAPPED	(1u << 17)
++#define BCM2835_FIRMWARE_THROTTLED_WAS_THROTTLED	(1u << 18)
++#define BCM2835_FIRMWARE_THROTTLED_WAS_SOFT_TEMPLIMIT	(1u << 19)
++
++union msg_get_throttled_body {
++	struct {
++		uint32_t value;
++	} resp;
++};
++
+ #define BCM2835_FIRMWARE_TAG_GET_TURBO			0x00030009
+ #define BCM2835_FIRMWARE_TAG_SET_TURBO			0x00038009
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0033-bcm2835_fbd-trust-the-firmware-applied-depth.patch
+++ b/patches/0033-bcm2835_fbd-trust-the-firmware-applied-depth.patch
@@ -1,0 +1,167 @@
+From 14b313aea2fb7de1a0d63e47ea40fe9a53daca2d Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 23:19:14 -0500
+Subject: [PATCH] bcm2835_fbd: trust the depth the firmware applied, not the
+ one requested
+
+SET_DEPTH is a request, not a command, and bcm2835_mbox_fb_init() read back
+every field of the response except the one it had just asked to change.
+The driver therefore carried on believing it had the depth it wanted while
+the firmware had quietly kept its own -- and since pitch *was* read back,
+bpp and pitch ended up describing different buffers.
+
+Measured on a Pi 500+ with framebuffer_depth removed from config.txt:
+
+  fb0: changing fb bpp from 16 to 24
+  fb0: 1920x1080(1920x1080@0,0) 24bpp
+  fb0: fbswap: 1, pitch 3840, base 0x3f800000, screen_size 4147200
+
+pitch 3840 is 1920 * 2: a 16bpp stride. At 24bpp it needs 5760. The console
+came up and drew three bytes per pixel into a two-byte stride, so each row
+landed progressively further out of alignment -- a partial, skewed picture
+rather than an error. That is the "smeared, dim console" the call for
+testing describes, and the reason boards have needed different
+framebuffer_depth values in config.txt to get a usable screen.
+
+Three changes:
+
+Read the applied depth back in bcm2835_mbox_fb_init(), beside the pitch it
+already reads. One line, and the actual bug -- bpp and pitch now describe
+the same buffer by construction.
+
+Ask for 32bpp rather than 24 when raising the depth. FB_DEPTH is the
+minimum this driver can colour-configure, and requesting exactly that is a
+poor bet: 24bpp is packed three bytes per pixel and the VideoCore may
+decline it, as it did here. 32bpp is the depth it reliably honours, and the
+one bcm_fb_setup_fbd() already has a colour case for. Boards where the
+firmware is already at 24 or 32 keep it and are unaffected.
+
+Refuse to attach when the stride cannot hold a row at the resulting depth.
+If bpp and pitch disagree the picture is unreadable, and a clear failure in
+dmesg beats a scrambled console that looks like a hardware fault. This
+cannot trigger via the path above any more; it is there for the case where
+the firmware returns something self-inconsistent.
+
+The degradation is deliberate rather than fatal: if the firmware keeps
+16bpp, pitch 3840 satisfies the check and the console attaches with correct
+geometry. Colours may be off -- there is no 16bpp case in the fbswap switch
+-- but the screen is readable, which it was not before.
+
+Aims at the goal that no board should need a hand-edited framebuffer_depth
+in config.txt to get a console.
+
+Refs nextbsd-kernel#171, nextbsd#422.
+---
+ sys/arm/broadcom/bcm2835/bcm2835_fbd.c  | 51 ++++++++++++++++++++++++-
+ sys/arm/broadcom/bcm2835/bcm2835_mbox.c |  7 ++++
+ 2 files changed, 56 insertions(+), 2 deletions(-)
+
+diff --git a/sys/arm/broadcom/bcm2835/bcm2835_fbd.c b/sys/arm/broadcom/bcm2835/bcm2835_fbd.c
+index 50e8689e9d8..929328c95c3 100644
+--- a/sys/arm/broadcom/bcm2835/bcm2835_fbd.c
++++ b/sys/arm/broadcom/bcm2835/bcm2835_fbd.c
+@@ -56,6 +56,12 @@
+ #include "mbox_if.h"
+ 
+ #define	FB_DEPTH		24
++/*
++ * What to ask for when the firmware's current depth is below FB_DEPTH. 32bpp
++ * is the depth the VideoCore reliably honours and the one this driver can
++ * colour-configure; 24bpp is packed and may be declined.
++ */
++#define	FB_DEPTH_PREFERRED	32
+ 
+ struct bcmsc_softc {
+ 	struct fb_info 			info;
+@@ -77,6 +83,7 @@ static int
+ bcm_fb_init(struct bcmsc_softc *sc, struct bcm2835_fb_config *fb)
+ {
+ 	int err;
++	uint32_t requested_bpp;
+ 
+ 	err = 0;
+ 
+@@ -86,13 +93,26 @@ bcm_fb_init(struct bcmsc_softc *sc, struct bcm2835_fb_config *fb)
+ 	if (bcm2835_mbox_fb_get_bpp(fb) != 0)
+ 		return (ENXIO);
+ 	if (fb->bpp < FB_DEPTH) {
++		/*
++		 * Raise it -- but to FB_DEPTH_PREFERRED, not FB_DEPTH.
++		 *
++		 * FB_DEPTH is the minimum this driver can colour-configure, and
++		 * asking for exactly that is a poor bet: 24bpp is packed three
++		 * bytes per pixel and the VideoCore firmware may decline it,
++		 * whereas 32bpp is the depth it is happiest with. A declined
++		 * request used to be invisible (see below), so the driver
++		 * carried on believing it had a depth the firmware had never
++		 * agreed to.
++		 */
+ 		device_printf(sc->dev, "changing fb bpp from %d to %d\n",
+-		    fb->bpp, FB_DEPTH);
+-		fb->bpp = FB_DEPTH;
++		    fb->bpp, FB_DEPTH_PREFERRED);
++		fb->bpp = FB_DEPTH_PREFERRED;
+ 	} else
+ 		device_printf(sc->dev, "keeping existing fb bpp of %d\n",
+ 		    fb->bpp);
+ 
++	requested_bpp = fb->bpp;
++
+ 	fb->vxres = fb->xres;
+ 	fb->vyres = fb->yres;
+ 	fb->xoffset = fb->yoffset = 0;
+@@ -103,6 +123,33 @@ bcm_fb_init(struct bcmsc_softc *sc, struct bcm2835_fb_config *fb)
+ 		return (ENXIO);
+ 	}
+ 
++	/*
++	 * fb->bpp now holds what the firmware applied rather than what was
++	 * asked for. Say so when they differ: this used to be silent, and the
++	 * result was a console rendered at one depth into a buffer laid out
++	 * for another -- a partial, skewed picture rather than an error.
++	 */
++	if (fb->bpp != requested_bpp) {
++		device_printf(sc->dev,
++		    "firmware declined %dbpp and kept %dbpp\n",
++		    requested_bpp, fb->bpp);
++	}
++
++	/*
++	 * Whatever the depth ended up being, the stride has to be able to hold
++	 * a row at it. If it cannot, bpp and pitch are describing different
++	 * buffers and anything drawn will be skewed -- refuse rather than put
++	 * an unreadable console on screen. Measured on a Pi 500+ before the
++	 * read-back above: firmware kept 16bpp, driver believed 24bpp, and
++	 * pitch stayed 3840 where 24bpp at 1920 needs 5760.
++	 */
++	if (fb->pitch < howmany(fb->xres * fb->bpp, NBBY)) {
++		device_printf(sc->dev,
++		    "pitch %d too small for %dx%d at %dbpp\n",
++		    fb->pitch, fb->xres, fb->yres, fb->bpp);
++		return (ENXIO);
++	}
++
+ 	return (0);
+ }
+ 
+diff --git a/sys/arm/broadcom/bcm2835/bcm2835_mbox.c b/sys/arm/broadcom/bcm2835/bcm2835_mbox.c
+index a3a3744ce43..3f97a6d8b86 100644
+--- a/sys/arm/broadcom/bcm2835/bcm2835_mbox.c
++++ b/sys/arm/broadcom/bcm2835/bcm2835_mbox.c
+@@ -580,6 +580,13 @@ bcm2835_mbox_fb_init(struct bcm2835_fb_config *fb)
+ 		fb->vyres = msg.virtual_w_h.body.resp.height;
+ 		fb->xoffset = msg.offset.body.resp.x;
+ 		fb->yoffset = msg.offset.body.resp.y;
++		/*
++		 * The depth the firmware actually applied, which is not always
++		 * the one asked for -- SET_DEPTH is a request, not a command.
++		 * Reading it back is what keeps bpp and pitch describing the
++		 * same buffer; the caller uses both.
++		 */
++		fb->bpp = msg.depth.body.resp.bpp;
+ 		fb->pitch = msg.pitch.body.resp.pitch;
+ 		fb->base = VCBUS_TO_ARMC(msg.buffer.body.resp.fb_address);
+ 		fb->size = msg.buffer.body.resp.fb_size;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0034-bcm2835_fbd-believe-the-stride-not-the-claimed-depth.patch
+++ b/patches/0034-bcm2835_fbd-believe-the-stride-not-the-claimed-depth.patch
@@ -1,0 +1,154 @@
+From 12eaa1dd6a31815da5a127c760ce1d569cd7b8e2 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 23:49:33 -0500
+Subject: [PATCH] bcm2835_fbd: believe the stride, not the claimed depth
+
+0033 refused to attach when the depth and the stride disagreed, on the
+grounds that rendering into a mismatched buffer produces a skewed console.
+That is right, but refusing leaves no console at all, which is worse than
+what it replaced.
+
+The disagreement has a correct resolution: the stride is the field that
+describes the buffer that actually exists.
+
+Measured on a Pi 500+ with no framebuffer_depth in config.txt, querying the
+firmware directly through /dev/vcio after SET_DEPTH had reported success:
+
+  GET_DEPTH    -> 32
+  GET_PITCH    -> 3840        (1920 * 2: a 16bpp stride)
+  GET_PHYS_W_H -> 1920 x 1080
+
+with an allocation of 4147200 bytes, which is 1920 * 1080 * 2. Every field
+except the depth describes a 16bpp buffer. The firmware had accepted 32bpp
+as a *setting* without reallocating the framebuffer to match -- and it does
+this even with ALLOCATE_BUFFER in the same message, which is why asking
+more politely does not help. It is also why this board needs
+framebuffer_depth in config.txt under Linux too: the firmware will not
+restructure the framebuffer at runtime, whatever asks it to.
+
+So derive the depth from the stride when they disagree, and render at the
+depth that is really there. On this board that yields a readable 16bpp
+console where before there was a skewed one, and then none. Where the
+firmware behaves, pitch and depth agree, this branch is never entered, and
+32bpp is used exactly as before.
+
+Deriving from the stride is safe in the other direction as well: a stride
+may legitimately exceed xres * bpp for alignment, and that case does not
+enter the branch.
+
+Two guards remain, because a wrong answer here would be memory corruption
+rather than a bad-looking console:
+
+  - if the stride cannot hold a row even at the depth it implies, refuse;
+    nothing about the geometry is trustworthy at that point
+  - if the allocation cannot hold every row at that stride, refuse
+
+Adds the 16bpp colour case the fallback needs. vt_fb handles depth 16
+(vt_fb.c case 16), so the buffer is renderable; the RGB565 channel order
+follows the 24bpp case above it and is unverified on hardware. If red and
+blue come out swapped, exchange the two 0x1f entries -- geometry is correct
+either way, so the console stays readable.
+
+Refs nextbsd-kernel#171, nextbsd#422.
+---
+ sys/arm/broadcom/bcm2835/bcm2835_fbd.c | 74 +++++++++++++++++++++++---
+ 1 file changed, 66 insertions(+), 8 deletions(-)
+
+diff --git a/sys/arm/broadcom/bcm2835/bcm2835_fbd.c b/sys/arm/broadcom/bcm2835/bcm2835_fbd.c
+index 929328c95c3..9ad035f6044 100644
+--- a/sys/arm/broadcom/bcm2835/bcm2835_fbd.c
++++ b/sys/arm/broadcom/bcm2835/bcm2835_fbd.c
+@@ -136,17 +136,60 @@ bcm_fb_init(struct bcmsc_softc *sc, struct bcm2835_fb_config *fb)
+ 	}
+ 
+ 	/*
+-	 * Whatever the depth ended up being, the stride has to be able to hold
+-	 * a row at it. If it cannot, bpp and pitch are describing different
+-	 * buffers and anything drawn will be skewed -- refuse rather than put
+-	 * an unreadable console on screen. Measured on a Pi 500+ before the
+-	 * read-back above: firmware kept 16bpp, driver believed 24bpp, and
+-	 * pitch stayed 3840 where 24bpp at 1920 needs 5760.
++	 * The depth and the stride have to describe the same buffer. When they
++	 * disagree, believe the stride.
++	 *
++	 * The firmware can report a depth it has accepted as a *setting*
++	 * without having reallocated the framebuffer to match. Measured on a
++	 * Pi 500+ with no framebuffer_depth in config.txt, querying the
++	 * firmware directly through /dev/vcio after SET_DEPTH had reported
++	 * success:
++	 *
++	 *	GET_DEPTH    -> 32
++	 *	GET_PITCH    -> 3840        (1920 * 2: a 16bpp stride)
++	 *	GET_PHYS_W_H -> 1920 x 1080
++	 *
++	 * with an allocation of 4147200 bytes -- 1920 * 1080 * 2. Every field
++	 * except the depth describes a 16bpp buffer, so 16bpp is what is
++	 * really there. Rendering at the claimed 32bpp would both skew every
++	 * row and run 4MB past the end of the allocation.
++	 *
++	 * Deriving the depth from the stride is safe in the other direction
++	 * too: a stride may legitimately exceed xres * bpp for alignment, and
++	 * that case does not enter this branch at all.
+ 	 */
+ 	if (fb->pitch < howmany(fb->xres * fb->bpp, NBBY)) {
++		uint32_t derived;
++
++		derived = fb->xres != 0 ? (fb->pitch * NBBY) / fb->xres : 0;
+ 		device_printf(sc->dev,
+-		    "pitch %d too small for %dx%d at %dbpp\n",
+-		    fb->pitch, fb->xres, fb->yres, fb->bpp);
++		    "firmware claims %dbpp but allocated a %d-byte stride; "
++		    "using %dbpp\n", fb->bpp, fb->pitch, derived);
++
++		/*
++		 * If the stride cannot hold a row even at the depth it implies,
++		 * nothing here is trustworthy -- refuse rather than draw into a
++		 * buffer whose shape is unknown.
++		 */
++		if (derived == 0 ||
++		    fb->pitch < howmany(fb->xres * derived, NBBY)) {
++			device_printf(sc->dev,
++			    "cannot reconcile %dx%d with a %d-byte stride\n",
++			    fb->xres, fb->yres, fb->pitch);
++			return (ENXIO);
++		}
++		fb->bpp = derived;
++	}
++
++	/*
++	 * And the allocation has to hold every row at that stride. This is the
++	 * check that keeps a wrong answer above from becoming memory
++	 * corruption rather than a bad-looking console.
++	 */
++	if (fb->size < (uint32_t)fb->pitch * fb->yres) {
++		device_printf(sc->dev,
++		    "framebuffer %d bytes too small for %d rows of %d\n",
++		    fb->size, fb->yres, fb->pitch);
+ 		return (ENXIO);
+ 	}
+ 
+@@ -181,6 +224,21 @@ bcm_fb_setup_fbd(struct bcmsc_softc *sc)
+ 
+ 	if (sc->fbswap) {
+ 		switch (sc->info.fb_bpp) {
++		case 16:
++			/*
++			 * RGB565. Reached when the firmware would not restructure
++			 * the framebuffer and we fell back to the depth its
++			 * stride implies. Channel order is the one the 24bpp case
++			 * below uses -- red in the low bits under fbswap -- and is
++			 * unverified on hardware: if red and blue come out
++			 * swapped, exchange the two 0x1f entries. Geometry is
++			 * correct either way, so the console is readable
++			 * regardless.
++			 */
++			vt_config_cons_colors(&sc->info,
++			    COLOR_FORMAT_RGB, 0x1f, 0, 0x3f, 5, 0x1f, 11);
++			sc->info.fb_cmsize = 16;
++			break;
+ 		case 24:
+ 			vt_config_cons_colors(&sc->info,
+ 			    COLOR_FORMAT_RGB, 0xff, 0, 0xff, 8, 0xff, 16);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -30,3 +30,4 @@
 0030-bcm2835_vcbus-clamp-bcm2712-mailbox-dma-to-videocore-reach.patch
 0031-bcm2835-firmware-and-vcio-build-them-on-bcm2712.patch
 0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch
+0033-bcm2835_fbd-trust-the-firmware-applied-depth.patch

--- a/patches/series
+++ b/patches/series
@@ -31,3 +31,4 @@
 0031-bcm2835-firmware-and-vcio-build-them-on-bcm2712.patch
 0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch
 0033-bcm2835_fbd-trust-the-firmware-applied-depth.patch
+0034-bcm2835_fbd-believe-the-stride-not-the-claimed-depth.patch

--- a/patches/series
+++ b/patches/series
@@ -27,3 +27,6 @@
 0027-bcm2835-vcbus-describe-bcm2712-and-enable-the-framebuffer.patch
 0028-rp1-acknowledge-level-triggered-interrupts-from-post-ithread.patch
 0029-kern_exit-reap-orphans-adopted-by-init-like-xnu.patch
+0030-bcm2835_vcbus-clamp-bcm2712-mailbox-dma-to-videocore-reach.patch
+0031-bcm2835-firmware-and-vcio-build-them-on-bcm2712.patch
+0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch


### PR DESCRIPTION
Two changes for the Pi 5 family, shipped together so testers exercise **one** kernel and report both halves from the same boot. Fixes the video regression first, then adds temperature visibility.

Refs #112, and nextbsd#422 (call for testing).

---

## 1. `0030` — clamp the BCM2712 mailbox DMA to what the VideoCore can actually reach

**This is a fix to code already in `main`, and it is the more urgent half.**

Two ceilings apply to a mailbox property buffer. `0027` accounted for the looser one:

> The mailbox property interface carries the buffer address in a single 32-bit word, so a buffer handed to the VideoCore has to live below 4GB.

True, and **not sufficient**. The VideoCore's reach into SDRAM is tighter than the register is wide — which is why `brcm,bcm2711` and `brcm,bcm2838` both clamp to `BCM2838_PERIPH_MAXADDR` (`0x3fffffff`) rather than the full 32-bit range. 2712 is no different; the clamp was missed.

### Measured

A Pi 500+ with 16GB. The firmware hands physical memory over in three chunks:

```
0x00000000080000 - 0x0000000001ffff      1.5 MB
0x000000013ca000 - 0x0000003f3fffff    1040 MB
0x00000040232000 - 0x000003ea657fff   15741 MB
```

Instrumenting `bcm2835_mbox_property()` to log the buffer address and the VideoCore's response code:

```
req tag=0x00030006 phys=0x0019f000  ->  code=0x80000000 (SUCCESS)   chunk 1
req tag=0x00040003 phys=0x013ca000  ->  code=0x80000000 (SUCCESS)   chunk 2
req tag=0x00040005 phys=0x40232000  ->  code=0x00000000 (FAILS)     chunk 3
```

Response code `0x00000000` is the *request* code — the buffer came back untouched, because the VideoCore never wrote to it. Every call landing in the low two chunks succeeded; the one landing in the third did not. The boundary sits between `0x3f3fffff` and `0x40232000`, which `BCM2838_PERIPH_MAXADDR` already covers.

**Stated honestly:** 1GB is *sufficient* and measured, not proven to be the exact ceiling. The lowest failing address available to test was the start of the third chunk, so `0x40000000`–`0x40232000` is unprobed. The value matches the two SoCs whose limit is known rather than sitting at the edge of what was measured.

### Why it matters beyond this PR

The failure is **silent** and depends on where the allocator happens to place a buffer, so it moves with the memory map. `bcm2835_fbd` makes two property calls during attach — `GET_PHYSICAL_W_H` then `GET_DEPTH` — and a layout that puts the second above 1GB kills the console, leaving nothing in dmesg but `mbox response error`, which until now did not even print the code it rejected.

Changing `framebuffer_depth` in `config.txt` resizes the firmware's reservation, shifts the chunk boundaries, and changes which calls survive.

**That is very likely the real mechanism behind the per-board `framebuffer_depth` workarounds in nextbsd#422** — one board needing `32`, another needing `24`, a third getting no display either way. Three memory maps, not three pixel formats. It would also explain why the "24bpp packs three bytes where the driver writes four" theory predicted a *smeared* console while the actual reports were *no picture at all*.

**Unverified on the two boards that are not mine.** That is part of what this build is for.

---

## 2. `0031` / `0032` — temperature and throttling

Unchanged from the previous revision of this PR.

`0031` builds two **existing** files on `soc_brcm_bcm2712`:

| file | what it gives |
|---|---|
| `bcm2835_firmware.c` | attaches to `/soc/firmware`, exports `bcm2835_firmware_property()`, adds the `dev.bcm2835_firmware.0` sysctl node |
| `bcm2835_vcio.c` | `/dev/vcio` — what `sysutils/raspberrypi-userland`'s `vcgencmd` opens |

Neither needs porting; both were gated to the Pi 3 and Pi 4 SoCs only. `0027` already brought the property mailbox up on this SoC and proved it.

`0032` adds two read-only sysctls beside the existing `revision`:

```
dev.bcm2835_firmware.0.temperature      # "IK" — sysctl(8) prints degrees C
dev.bcm2835_firmware.0.throttled        # raw flag word
```

`throttled` is the more useful of the two: bits 0–3 are live state (undervolt / frequency capped / throttled / soft temperature limit), bits 16–19 latch the same conditions until reboot. Neither has a write path — the VPU owns the clock, the rails and the thermal limits. This closes the gap nextbsd#422 documents as *"NextBSD cannot currently read the SoC temperature either."*

### Verified on hardware

```
dev.bcm2835_firmware.0.temperature: 36.6C
dev.bcm2835_firmware.0.throttled:   0
dev.bcm2835_firmware.0.revision:    1762364238
```

---

## Ordering

`0030` first, deliberately. It is a standalone fix to code already in `main` and can be cherry-picked without the feature; `0031`/`0032` depend on nothing in it.

## Not included

- **`bcm2835_cpufreq.c`.** Looks like the same gate flip; is not. It *sets* clocks and voltages on a SoC whose firmware owns both, over a tag set not verified to match 2837/2838.
- **The fan.** RP1 PWM1 channel 3, behind PCIe — needs a `raspberrypi,rp1-pwm` driver. That is #172.

## Caveat: boards whose firmware refuses to change depth

`0034` makes those boards usable rather than perfect, and the distinction matters for anyone testing.

Some firmware accepts `SET_DEPTH` as a *setting* without reallocating the framebuffer. Verified through `/dev/vcio` on a Pi 500+ with no `framebuffer_depth` in `config.txt`, after `SET_DEPTH` reported success:

```
GET_DEPTH    -> 32
GET_PITCH    -> 3840        (1920 * 2: a 16bpp stride)
GET_PHYS_W_H -> 1920 x 1080
allocation   -> 4147200 bytes = 1920 * 1080 * 2
```

Every field except the depth describes a 16bpp buffer, so `0034` renders at 16bpp. The same board needs `framebuffer_depth` under Linux too, so this is firmware behaviour rather than something a driver can ask its way around.

Measured outcome on such a board:

| | before | with `0030` + `0034` |
|---|---|---|
| console | black screen, or garbled | **works**, at 16bpp |
| desktop (X) | — | **does not start** |

X dies because `scfb` segfaults on a 16bpp framebuffer — nextbsd#425, filed separately with the evidence. Verified as depth-only: same kernel, same board, same packages, X works at 32bpp and segfaults at 16bpp, and the `mesa-dri` / `xauth` / `card0` errors in that log are present and harmless at 32bpp too.

**So if your board lands on the 16bpp fallback and you want a desktop, put `framebuffer_depth=32` back in `config.txt`.** The console works either way, which it did not before.

Strictly better in every case and worse in none — but "console yes, desktop no" is a real limitation, not a footnote.

## Testing

Full 32-patch series applies cleanly to `releng/15.1` at `88e7371d9dc`. CI builds `NEXTBSD` (amd64 + arm64) and `NEXTBSD-RPI5` + `kernel8.img`.

**If you are testing this, please report both halves — video and temperature are equally the point.**

Flash `rpi5-kernel8-arm64` from this PR's run as `kernel8.img`, and **first remove any `framebuffer_depth` workaround** from `config.txt` so the shipped default is what gets exercised:

```sh
# 1. video — does the console come up with the stock config.txt?
#    (report your board, and what depth you previously needed, if any)

# 2. temperature
sysctl dev.bcm2835_firmware
printf '%#x\n' $(sysctl -n dev.bcm2835_firmware.0.throttled)   # 0x0 on a healthy PSU
```

If `dev.bcm2835_firmware.0` is missing entirely, `dmesg | grep -i firmware` separates "driver never attached" from "the 2712 mailbox rejected the tag". If video is still black, `dmesg | grep -iE 'fb0|mbox'` over SSH is the useful thing — the board still boots and takes SSH with no display.

