### PR TITLE
rpi5: drive the Pi 5 B Active Cooler — rp1_clk, RP1 pinctrl, rp1_pwm

### DIFF
--- a/patches/0035-rp1_clk-peripheral-clock-gates-for-rp1.patch
+++ b/patches/0035-rp1_clk-peripheral-clock-gates-for-rp1.patch
@@ -1,0 +1,416 @@
+From 22ec8d0650fdc43fb8b689d34e8734f479fd7a26 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 12:13:27 -0500
+Subject: [PATCH 1/3] rp1_clk: peripheral clock gates for RP1
+
+Every leaf clock in RP1 is off at reset, and the vendor driver that turns
+them on is 2500 lines of PLL, mux and divider tree. This is the small part
+of that: the clocks that take a fractional divider straight off the 50MHz
+crystal, which is already running -- everything on RP1 that works today
+works because it is.
+
+So the interface is one operation, "run clock N at F Hz", for the clocks
+in the table, and ENOENT for everything else. That refusal is the point.
+A clock whose parent is a PLL cannot be added to the table without also
+bringing that PLL up, and a divider programmed off a dead PLL does not
+fail -- it produces a peripheral that reads and writes normally and never
+ticks.
+
+Two clocks to begin with, PWM0 and PWM1, because the Pi 5 B's Active
+Cooler is on pwm1 (nextbsd-kernel#112). The ids are the vendor binding's
+(include/dt-bindings/clock/rp1.h) because they arrive as the second cell
+of a `clocks = <&rp1_clocks N>` phandle out of the device tree we are
+handed; they are ABI, not ours to number.
+
+Parent selection is the one part worth spelling out. For these clocks the
+CTRL register's SRC field is unused -- the vendor's table gives them
+clk_src_mask = 0, so its set_parent writes nothing there -- and selection
+is entirely by the AUXSRC field, indexing that clock's own auxiliary
+parent list. xosc is at index 2 in both PWM lists. The divider is 16.16
+fixed point across two registers, and the arithmetic here is
+rp1_clock_choose_div() from the vendor driver rather than re-derived.
+
+Register offsets are from clk-rp1.c.
+
+The driver attaches at BUS_PASS_BUS, ahead of rp1_gpio (BUS_PASS_INTERRUPT)
+and rp1_pwm (BUS_PASS_DEFAULT), so consumers find it without anyone having
+to encode an explicit dependency.
+
+UNPROVEN ON HARDWARE: written against the vendor driver and the device
+tree, not against a board. The only Pi 5-family machine available is a
+Pi 500+, whose DTB leaves both PWM blocks disabled.
+
+Refs nextbsd-kernel#112.
+---
+ sys/arm/broadcom/bcm2835/rp1_clk.c | 288 +++++++++++++++++++++++++++++
+ sys/arm/broadcom/bcm2835/rp1_clk.h |  50 +++++
+ sys/conf/files.arm64               |   1 +
+ 3 files changed, 339 insertions(+)
+ create mode 100644 sys/arm/broadcom/bcm2835/rp1_clk.c
+ create mode 100644 sys/arm/broadcom/bcm2835/rp1_clk.h
+
+diff --git a/sys/arm/broadcom/bcm2835/rp1_clk.c b/sys/arm/broadcom/bcm2835/rp1_clk.c
+new file mode 100644
+index 00000000000..1c052b693c4
+--- /dev/null
++++ b/sys/arm/broadcom/bcm2835/rp1_clk.c
+@@ -0,0 +1,288 @@
++/*-
++ * SPDX-License-Identifier: BSD-2-Clause
++ *
++ * Copyright (c) 2026 The NextBSD Project
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
++ */
++
++/*
++ * Peripheral clock gates for RP1, the southbridge on Raspberry Pi 5-family
++ * boards.
++ *
++ * Deliberately not a clock tree, and the scope is the whole design decision
++ * here. RP1's clockman drives three PLLs, a dozen derived sources and around
++ * forty leaf clocks; the vendor driver for it is 2500 lines. None of that is
++ * needed to make one peripheral tick. The leaf clocks in the table below take
++ * a fractional divider straight off the 50MHz crystal, and that crystal is
++ * already running -- everything on RP1 that works today works because it is.
++ *
++ * So this exposes one operation, "run clock N at F Hz", for the clocks it
++ * names, and returns ENOENT for everything else rather than guessing. A clock
++ * whose parent is a PLL is not in the table and must not be added to it
++ * without also bringing that PLL up, which is exactly the part this file does
++ * not do. Silently divide-by-zeroing off a dead PLL would look like working
++ * code and produce a dead peripheral.
++ *
++ * Register offsets and the divider arithmetic are from the vendor clk-rp1.c.
++ * Parent selection is the one part worth spelling out: for these clocks the
++ * CTRL register's SRC field is unused -- the vendor's table gives them
++ * clk_src_mask = 0, so its set_parent writes nothing there -- and selection is
++ * entirely by AUXSRC, which indexes that clock's own auxiliary parent list.
++ * xosc sits at index 2 in both PWM lists.
++ *
++ * UNPROVEN ON HARDWARE. Written against the vendor driver and the device tree,
++ * not against a board: the only Pi 5-family machine available has no fan, and
++ * its DTB leaves both PWM blocks disabled. Read the attach output before
++ * trusting it.
++ */
++
++#include <sys/param.h>
++#include <sys/systm.h>
++#include <sys/bus.h>
++#include <sys/kernel.h>
++#include <sys/lock.h>
++#include <sys/module.h>
++#include <sys/mutex.h>
++#include <sys/rman.h>
++
++#include <machine/bus.h>
++
++#include <dev/ofw/ofw_bus.h>
++#include <dev/ofw/ofw_bus_subr.h>
++
++#include <arm/broadcom/bcm2835/rp1_clk.h>
++
++/* CTRL, common to every leaf clock. */
++#define	RP1_CLK_CTRL_ENABLE		(1u << 11)
++#define	RP1_CLK_CTRL_AUXSRC_MASK	0x000003e0u
++#define	RP1_CLK_CTRL_AUXSRC_SHIFT	5
++
++/* The divider is 16.16 fixed point, split across two registers. */
++#define	RP1_CLK_DIV_FRAC_BITS		16
++#define	RP1_CLK_DIV_ONE			(1ULL << RP1_CLK_DIV_FRAC_BITS)
++#define	RP1_CLK_DIV_INT_MAX		0xffffULL
++
++/*
++ * The crystal, and the root of everything this file touches. rp1.dtsi gives it
++ * as a fixed-clock: clock-frequency = <50000000>.
++ */
++#define	RP1_XOSC_FREQ			50000000ULL
++
++struct rp1_clk_leaf {
++	u_int		id;
++	const char	*name;
++	bus_size_t	ctrl;
++	bus_size_t	div_int;
++	bus_size_t	div_frac;
++	u_int		auxsrc;		/* index of xosc in this clock's aux list */
++};
++
++static const struct rp1_clk_leaf rp1_clk_leaves[] = {
++	{ RP1_CLK_PWM0, "pwm0", 0x00074, 0x00078, 0x0007c, 2 },
++	{ RP1_CLK_PWM1, "pwm1", 0x00084, 0x00088, 0x0008c, 2 },
++};
++
++struct rp1_clk_softc {
++	device_t	dev;
++	struct resource	*res;
++	struct mtx	mtx;
++};
++
++static struct ofw_compat_data compat_data[] = {
++	{ "raspberrypi,rp1-clocks",	1 },
++	{ NULL,				0 }
++};
++
++static const struct rp1_clk_leaf *
++rp1_clk_find(u_int id)
++{
++	u_int i;
++
++	for (i = 0; i < nitems(rp1_clk_leaves); i++)
++		if (rp1_clk_leaves[i].id == id)
++			return (&rp1_clk_leaves[i]);
++	return (NULL);
++}
++
++/*
++ * Divider for a target rate, 16.16 fixed point, rounded to nearest and clamped
++ * to at least a divide of one. This is rp1_clock_choose_div() from the vendor
++ * driver, for the fractional-divider case that every clock here has.
++ */
++static uint64_t
++rp1_clk_choose_div(uint64_t freq)
++{
++	uint64_t div;
++
++	div = (RP1_XOSC_FREQ << RP1_CLK_DIV_FRAC_BITS) + freq / 2;
++	div /= freq;
++
++	if (div < RP1_CLK_DIV_ONE)
++		div = RP1_CLK_DIV_ONE;
++	if (div > (RP1_CLK_DIV_INT_MAX << RP1_CLK_DIV_FRAC_BITS))
++		div = RP1_CLK_DIV_INT_MAX << RP1_CLK_DIV_FRAC_BITS;
++
++	return (div);
++}
++
++int
++rp1_clk_enable(device_t dev, u_int id, uint64_t freq)
++{
++	struct rp1_clk_softc *sc = device_get_softc(dev);
++	const struct rp1_clk_leaf *leaf;
++	uint64_t div;
++	uint32_t ctrl;
++
++	leaf = rp1_clk_find(id);
++	if (leaf == NULL)
++		return (ENOENT);
++
++	/*
++	 * Nothing here can multiply, so a request above the crystal is a
++	 * caller bug rather than something to silently clamp: clamping would
++	 * hand back a peripheral running at the wrong speed.
++	 */
++	if (freq == 0 || freq > RP1_XOSC_FREQ)
++		return (EINVAL);
++
++	div = rp1_clk_choose_div(freq);
++
++	mtx_lock(&sc->mtx);
++
++	/*
++	 * Divider before enable. The other order briefly runs the peripheral
++	 * at whatever the previous divider was, which for a PWM output means
++	 * a burst at the wrong frequency into whatever it drives.
++	 */
++	bus_write_4(sc->res, leaf->div_int,
++	    (uint32_t)(div >> RP1_CLK_DIV_FRAC_BITS));
++	bus_write_4(sc->res, leaf->div_frac,
++	    (uint32_t)div << RP1_CLK_DIV_FRAC_BITS);
++
++	ctrl = bus_read_4(sc->res, leaf->ctrl);
++	ctrl &= ~RP1_CLK_CTRL_AUXSRC_MASK;
++	ctrl |= (leaf->auxsrc << RP1_CLK_CTRL_AUXSRC_SHIFT) &
++	    RP1_CLK_CTRL_AUXSRC_MASK;
++	ctrl |= RP1_CLK_CTRL_ENABLE;
++	bus_write_4(sc->res, leaf->ctrl, ctrl);
++
++	mtx_unlock(&sc->mtx);
++
++	return (0);
++}
++
++int
++rp1_clk_disable(device_t dev, u_int id)
++{
++	struct rp1_clk_softc *sc = device_get_softc(dev);
++	const struct rp1_clk_leaf *leaf;
++	uint32_t ctrl;
++
++	leaf = rp1_clk_find(id);
++	if (leaf == NULL)
++		return (ENOENT);
++
++	mtx_lock(&sc->mtx);
++	ctrl = bus_read_4(sc->res, leaf->ctrl);
++	ctrl &= ~RP1_CLK_CTRL_ENABLE;
++	bus_write_4(sc->res, leaf->ctrl, ctrl);
++	mtx_unlock(&sc->mtx);
++
++	return (0);
++}
++
++uint64_t
++rp1_clk_get_freq(device_t dev, u_int id)
++{
++	struct rp1_clk_softc *sc = device_get_softc(dev);
++	const struct rp1_clk_leaf *leaf;
++	uint64_t div;
++
++	leaf = rp1_clk_find(id);
++	if (leaf == NULL)
++		return (0);
++
++	mtx_lock(&sc->mtx);
++	div = (uint64_t)bus_read_4(sc->res, leaf->div_int) <<
++	    RP1_CLK_DIV_FRAC_BITS;
++	div |= bus_read_4(sc->res, leaf->div_frac) >> RP1_CLK_DIV_FRAC_BITS;
++	mtx_unlock(&sc->mtx);
++
++	if (div == 0)
++		return (0);
++
++	return ((((RP1_XOSC_FREQ << RP1_CLK_DIV_FRAC_BITS) + div / 2) / div));
++}
++
++static int
++rp1_clk_probe(device_t dev)
++{
++
++	if (!ofw_bus_status_okay(dev))
++		return (ENXIO);
++	if (ofw_bus_search_compatible(dev, compat_data)->ocd_data == 0)
++		return (ENXIO);
++
++	device_set_desc(dev, "RP1 peripheral clocks");
++	return (BUS_PROBE_DEFAULT);
++}
++
++static int
++rp1_clk_attach(device_t dev)
++{
++	struct rp1_clk_softc *sc = device_get_softc(dev);
++	phandle_t node;
++	int rid;
++
++	sc->dev = dev;
++	mtx_init(&sc->mtx, device_get_nameunit(dev), NULL, MTX_DEF);
++
++	rid = 0;
++	sc->res = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &rid, RF_ACTIVE);
++	if (sc->res == NULL) {
++		device_printf(dev, "could not map clockman registers\n");
++		mtx_destroy(&sc->mtx);
++		return (ENXIO);
++	}
++
++	/*
++	 * Consumers reach this driver through their own `clocks` phandle, so
++	 * the xref registration is the whole interface.
++	 */
++	node = ofw_bus_get_node(dev);
++	OF_device_register_xref(OF_xref_from_node(node), dev);
++
++	return (0);
++}
++
++static device_method_t rp1_clk_methods[] = {
++	DEVMETHOD(device_probe,		rp1_clk_probe),
++	DEVMETHOD(device_attach,	rp1_clk_attach),
++
++	DEVMETHOD_END
++};
++
++static driver_t rp1_clk_driver = {
++	"rp1_clk",
++	rp1_clk_methods,
++	sizeof(struct rp1_clk_softc),
++};
++
++/*
++ * Before every consumer. rp1_gpio comes up at BUS_PASS_INTERRUPT and rp1_pwm
++ * at BUS_PASS_DEFAULT, so BUS_PASS_BUS puts the clocks first without anyone
++ * having to encode a dependency.
++ */
++EARLY_DRIVER_MODULE(rp1_clk, simplebus, rp1_clk_driver, 0, 0,
++    BUS_PASS_BUS + BUS_PASS_ORDER_MIDDLE);
+diff --git a/sys/arm/broadcom/bcm2835/rp1_clk.h b/sys/arm/broadcom/bcm2835/rp1_clk.h
+new file mode 100644
+index 00000000000..f501fdb3106
+--- /dev/null
++++ b/sys/arm/broadcom/bcm2835/rp1_clk.h
+@@ -0,0 +1,50 @@
++/*-
++ * SPDX-License-Identifier: BSD-2-Clause
++ *
++ * Copyright (c) 2026 The NextBSD Project
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
++ */
++
++#ifndef	_ARM_BROADCOM_BCM2835_RP1_CLK_H_
++#define	_ARM_BROADCOM_BCM2835_RP1_CLK_H_
++
++/*
++ * Clock identifiers, straight from the vendor binding
++ * (include/dt-bindings/clock/rp1.h). These are ABI: they are the second cell
++ * of a `clocks = <&rp1_clocks N>` reference in the device tree we are handed,
++ * so they must never be renumbered to suit us. Only the ids rp1_clk(4)
++ * actually handles are listed -- see the comment at the top of rp1_clk.c for
++ * why that is a short list on purpose.
++ */
++#define	RP1_CLK_PWM0		17
++#define	RP1_CLK_PWM1		18
++
++/*
++ * Set a leaf clock's rate and start it. Returns ENOENT for a clock this
++ * driver does not know, which is the common case and not an error worth
++ * a device_printf on its own.
++ */
++int	rp1_clk_enable(device_t dev, u_int id, uint64_t freq);
++
++/* Stop a leaf clock. The divider is left as it was. */
++int	rp1_clk_disable(device_t dev, u_int id);
++
++/*
++ * Read a leaf clock's rate back out of its divider rather than returning what
++ * was last asked for. A consumer computing register values from this needs
++ * the rate the hardware actually landed on.
++ */
++uint64_t rp1_clk_get_freq(device_t dev, u_int id);
++
++#endif /* _ARM_BROADCOM_BCM2835_RP1_CLK_H_ */
+diff --git a/sys/conf/files.arm64 b/sys/conf/files.arm64
+index cc9340fe8c4..a6d08d6964d 100644
+--- a/sys/conf/files.arm64
++++ b/sys/conf/files.arm64
+@@ -598,6 +598,7 @@ arm/broadcom/bcm2835/bcm2838_pci.c			optional soc_brcm_bcm2838 fdt pci | \
+ 	soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/bcm2712_mip.c			optional soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/rp1.c				optional soc_brcm_bcm2712 fdt pci
++arm/broadcom/bcm2835/rp1_clk.c				optional soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/rp1_gpio.c				optional soc_brcm_bcm2712 gpio fdt pci
+ arm/broadcom/bcm2835/bcm2838_xhci.c			optional soc_brcm_bcm2838 fdt pci xhci
+ arm/broadcom/bcm2835/raspberrypi_gpio.c			optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0036-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch
+++ b/patches/0036-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch
@@ -1,0 +1,385 @@
+From cae037be74030753da2d7a34f67e5be17720cce6 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 12:13:58 -0500
+Subject: [PATCH 2/3] rp1_gpio: implement fdt_pinctrl for the RP1 pin mux
+
+This driver was written with multiplexing deliberately left out, on the
+grounds that the firmware has already assigned every pin its function
+before handing the board over. That held for everything reached so far --
+phy-reset-gpios on the Ethernet PHY, and gpioled -- and it stops holding
+at the Pi 5 B's fan.
+
+The Active Cooler is on pwm1 channel 3, and the vendor device tree asks
+for GPIO45 to be muxed to it:
+
+    &rp1_pwm1 { pinctrl-0 = <&rp1_pwm1_gpio45>; };
+
+    rp1_pwm1_gpio45 { function = "pwm1"; pins = "gpio45";
+                      bias-pull-down; };
+
+Under Linux the pinctrl driver applies that at probe. Nothing in the
+firmware does it, so without this the fan pin keeps whatever function it
+came up with and rp1_pwm(4) drives a pin that is not connected to it.
+
+The generic pinmux/pinconf binding, so: `pins` is a string list of pin
+names, `function` is one name and is optional (a node may set bias alone),
+and bias-pull-up / bias-pull-down / bias-disable map onto the pad bits
+this file already drives for GPIO_PIN_PULLUP and friends.
+
+Two things that are easy to get wrong and silent when wrong:
+
+Muxing releases the overrides, not just FUNCSEL. Output, output-enable and
+input can each be forced independently of the selected function, and a pin
+left with OEOVER forced from an earlier GPIO configuration keeps that
+direction whatever FUNCSEL says -- the peripheral then drives nothing. All
+three go back to "the function decides", which is what the vendor's
+rp1_set_fsel() does.
+
+The pad is handed over before the function is selected: input buffer on,
+output driver enabled, then FUNCSEL. The other order briefly points the
+new function at a disabled output stage.
+
+The per-pin function table is transcribed mechanically from the vendor
+pinctrl-rp1.c and must stay identical to it -- the index into a row IS the
+FUNCSEL value and none of it is derivable from anything else. The 5 that
+appears throughout at "gpio" is the RP1_CTRL_FUNCSEL_RIO this file already
+writes for plain GPIO, which is a useful check that the transcription is
+aligned.
+
+At bootverbose each mux logs the FUNCSEL it found before overwriting it.
+That is deliberate: whether the Pi 5 B firmware has already muxed GPIO45
+is a question about hardware nobody here can answer, and the first tester's
+dmesg settles it either way.
+
+No pin is muxed at attach. Consumers ask, via
+fdt_pinctrl_configure_by_name().
+
+Refs nextbsd-kernel#112.
+---
+ sys/arm/broadcom/bcm2835/rp1_gpio.c | 267 +++++++++++++++++++++++++++-
+ 1 file changed, 259 insertions(+), 8 deletions(-)
+
+diff --git a/sys/arm/broadcom/bcm2835/rp1_gpio.c b/sys/arm/broadcom/bcm2835/rp1_gpio.c
+index 63d499a54c2..daeb8be9b67 100644
+--- a/sys/arm/broadcom/bcm2835/rp1_gpio.c
++++ b/sys/arm/broadcom/bcm2835/rp1_gpio.c
+@@ -19,15 +19,21 @@
+ /*
+  * GPIO for RP1, the southbridge on Raspberry Pi 5-family boards.
+  *
+- * Deliberately narrow: this drives pins, and does nothing else. There is no
+- * pin multiplexing, no pull configuration beyond what a consumer asks for, and
+- * no interrupt support. The firmware has already assigned every pin its
+- * function before handing the board over -- the board boots Linux with these
+- * settings and we inherit them -- so what is missing is not the ability to
+- * choose a function but the ability to toggle a line that is already a GPIO.
++ * Narrow, but no longer only GPIO: this drives pins and multiplexes them, and
++ * does nothing else. There is still no interrupt support.
+  *
+- * That is enough for phy-reset-gpios, which is what the Ethernet PHY sits
+- * behind, and for gpioled. Multiplexing can come later if something needs it.
++ * Multiplexing was left out to begin with on the grounds that the firmware has
++ * already assigned every pin its function before handing the board over, which
++ * holds for everything reached so far -- phy-reset-gpios on the Ethernet PHY,
++ * and gpioled. It stops holding at the Pi 5 B's fan: the Active Cooler is on
++ * pwm1 channel 3, and the device tree asks for GPIO45 to be muxed to it
++ *
++ *	&rp1_pwm1 { pinctrl-0 = <&rp1_pwm1_gpio45>; };
++ *
++ * with that node giving function = "pwm1". Under Linux the pinctrl driver
++ * applies it at probe; nothing in the firmware does. So this file now also
++ * implements fdt_pinctrl(9), which is what rp1_pwm(4) calls to get its pin
++ * (nextbsd-kernel#112).
+  *
+  * Register layout is from the RP1 Peripherals datasheet, cross-checked
+  * against the running silicon rather than taken on trust. Three blocks, each
+@@ -61,6 +67,13 @@
+ #include <dev/ofw/ofw_bus.h>
+ #include <dev/ofw/ofw_bus_subr.h>
+ 
++/*
++ * After the ofw headers, not in alphabetical order with them:
++ * fdt_pinctrl_if.h uses phandle_t without declaring it, so this only compiles
++ * once openfirm.h has been pulled in above.
++ */
++#include <dev/fdt/fdt_pinctrl.h>
++
+ #include "gpio_if.h"
+ 
+ #define	RP1_GPIO_NPINS		54
+@@ -78,6 +91,18 @@
+ #define	 RP1_CTRL_FUNCSEL_MASK	0x1f
+ #define	 RP1_CTRL_FUNCSEL_RIO	5
+ #define	 RP1_CTRL_FUNCSEL_NULL	31
++/*
++ * Output, output-enable and input can each be forced independently of the
++ * selected function. Muxing a pin to a peripheral means handing all three back
++ * to it: a pin left with OEOVER forced from an earlier GPIO configuration
++ * keeps that direction no matter what FUNCSEL says, and the peripheral drives
++ * nothing.
++ */
++#define	 RP1_CTRL_OUTOVER_MASK	0x00003000
++#define	 RP1_CTRL_OUTOVER_SHIFT	12
++#define	 RP1_CTRL_OEOVER_MASK	0x0000c000
++#define	 RP1_CTRL_OEOVER_SHIFT	14
++#define	  RP1_OVER_PERI		0	/* the selected function drives it */
+ 
+ /* SYS_RIO, one bit per pin. */
+ #define	RP1_RIO_OUT		0x00
+@@ -105,6 +130,77 @@ static const struct {
+ 	{ 34, 20 },
+ };
+ 
++/*
++ * Which function each FUNCSEL value selects, per pin. Transcribed from the
++ * vendor pinctrl-rp1.c, whose table this must stay identical to -- the numbers
++ * are the hardware's and are not derivable from anything else. The index into
++ * a row IS the FUNCSEL value, so GPIO45's "pwm1" at index 0 means FUNCSEL 0,
++ * and the 5 that appears throughout at "gpio" is the RP1_CTRL_FUNCSEL_RIO this
++ * file already writes for plain GPIO.
++ *
++ * NULL is a value the pin does not implement.
++ */
++#define	RP1_FSEL_COUNT		9
++
++#define	_	NULL
++static const char * const rp1_pin_funcs[RP1_GPIO_NPINS][RP1_FSEL_COUNT] = {
++	[0] = { "spi0", "dpi", "uart1", "i2c0", _, "gpio", "proc_rio", "pio", "spi2" },
++	[1] = { "spi0", "dpi", "uart1", "i2c0", _, "gpio", "proc_rio", "pio", "spi2" },
++	[2] = { "spi0", "dpi", "uart1", "i2c1", "ir", "gpio", "proc_rio", "pio", "spi2" },
++	[3] = { "spi0", "dpi", "uart1", "i2c1", "ir", "gpio", "proc_rio", "pio", "spi2" },
++	[4] = { "gpclk0", "dpi", "uart2", "i2c2", "ri0", "gpio", "proc_rio", "pio", "spi3" },
++	[5] = { "gpclk1", "dpi", "uart2", "i2c2", "dtr0", "gpio", "proc_rio", "pio", "spi3" },
++	[6] = { "gpclk2", "dpi", "uart2", "i2c3", "dcd0", "gpio", "proc_rio", "pio", "spi3" },
++	[7] = { "spi0", "dpi", "uart2", "i2c3", "dsr0", "gpio", "proc_rio", "pio", "spi3" },
++	[8] = { "spi0", "dpi", "uart3", "i2c0", _, "gpio", "proc_rio", "pio", "spi4" },
++	[9] = { "spi0", "dpi", "uart3", "i2c0", _, "gpio", "proc_rio", "pio", "spi4" },
++	[10] = { "spi0", "dpi", "uart3", "i2c1", _, "gpio", "proc_rio", "pio", "spi4" },
++	[11] = { "spi0", "dpi", "uart3", "i2c1", _, "gpio", "proc_rio", "pio", "spi4" },
++	[12] = { "pwm0", "dpi", "uart4", "i2c2", "aaud", "gpio", "proc_rio", "pio", "spi5" },
++	[13] = { "pwm0", "dpi", "uart4", "i2c2", "aaud", "gpio", "proc_rio", "pio", "spi5" },
++	[14] = { "pwm0", "dpi", "uart4", "i2c3", "uart0", "gpio", "proc_rio", "pio", "spi5" },
++	[15] = { "pwm0", "dpi", "uart4", "i2c3", "uart0", "gpio", "proc_rio", "pio", "spi5" },
++	[16] = { "spi1", "dpi", "dsi0_te_ext", _, "uart0", "gpio", "proc_rio", "pio", _ },
++	[17] = { "spi1", "dpi", "dsi1_te_ext", _, "uart0", "gpio", "proc_rio", "pio", _ },
++	[18] = { "spi1", "dpi", "i2s0", "pwm0", "i2s1", "gpio", "proc_rio", "pio", "gpclk1" },
++	[19] = { "spi1", "dpi", "i2s0", "pwm0", "i2s1", "gpio", "proc_rio", "pio", _ },
++	[20] = { "spi1", "dpi", "i2s0", "gpclk0", "i2s1", "gpio", "proc_rio", "pio", _ },
++	[21] = { "spi1", "dpi", "i2s0", "gpclk1", "i2s1", "gpio", "proc_rio", "pio", _ },
++	[22] = { "sd0", "dpi", "i2s0", "i2c3", "i2s1", "gpio", "proc_rio", "pio", _ },
++	[23] = { "sd0", "dpi", "i2s0", "i2c3", "i2s1", "gpio", "proc_rio", "pio", _ },
++	[24] = { "sd0", "dpi", "i2s0", _, "i2s1", "gpio", "proc_rio", "pio", "spi2" },
++	[25] = { "sd0", "dpi", "i2s0", "mic", "i2s1", "gpio", "proc_rio", "pio", "spi3" },
++	[26] = { "sd0", "dpi", "i2s0", "mic", "i2s1", "gpio", "proc_rio", "pio", "spi5" },
++	[27] = { "sd0", "dpi", "i2s0", "mic", "i2s1", "gpio", "proc_rio", "pio", "spi1" },
++	[28] = { "sd1", "i2c4", "i2s2", "spi6", "vbus0", "gpio", "proc_rio", _, _ },
++	[29] = { "sd1", "i2c4", "i2s2", "spi6", "vbus0", "gpio", "proc_rio", _, _ },
++	[30] = { "sd1", "i2c5", "i2s2", "spi6", "uart5", "gpio", "proc_rio", _, _ },
++	[31] = { "sd1", "i2c5", "i2s2", "spi6", "uart5", "gpio", "proc_rio", _, _ },
++	[32] = { "sd1", "gpclk3", "i2s2", "spi6", "uart5", "gpio", "proc_rio", _, _ },
++	[33] = { "sd1", "gpclk4", "i2s2", "spi6", "uart5", "gpio", "proc_rio", _, _ },
++	[34] = { "pwm1", "gpclk3", "vbus0", "i2c4", "mic", "gpio", "proc_rio", _, _ },
++	[35] = { "spi8", "pwm1", "vbus0", "i2c4", "mic", "gpio", "proc_rio", _, _ },
++	[36] = { "spi8", "uart5", "pcie_clkreq_n", "i2c5", "mic", "gpio", "proc_rio", _, _ },
++	[37] = { "spi8", "uart5", "mic", "i2c5", "pcie_clkreq_n", "gpio", "proc_rio", _, _ },
++	[38] = { "spi8", "uart5", "mic", "i2c6", "aaud", "gpio", "proc_rio", "dsi0_te_ext", _ },
++	[39] = { "spi8", "uart5", "mic", "i2c6", "aaud", "gpio", "proc_rio", "dsi1_te_ext", _ },
++	[40] = { "pwm1", "uart5", "i2c4", "spi6", "aaud", "gpio", "proc_rio", _, _ },
++	[41] = { "pwm1", "uart5", "i2c4", "spi6", "aaud", "gpio", "proc_rio", _, _ },
++	[42] = { "gpclk5", "uart5", "vbus1", "spi6", "i2s2", "gpio", "proc_rio", _, _ },
++	[43] = { "gpclk4", "uart5", "vbus1", "spi6", "i2s2", "gpio", "proc_rio", _, _ },
++	[44] = { "gpclk5", "i2c5", "pwm1", "spi6", "i2s2", "gpio", "proc_rio", _, _ },
++	[45] = { "pwm1", "i2c5", "spi7", "spi6", "i2s2", "gpio", "proc_rio", _, _ },
++	[46] = { "gpclk3", "i2c4", "spi7", "mic", "i2s2", "gpio", "proc_rio", "dsi0_te_ext", _ },
++	[47] = { "gpclk5", "i2c4", "spi7", "mic", "i2s2", "gpio", "proc_rio", "dsi1_te_ext", _ },
++	[48] = { "pwm1", "pcie_clkreq_n", "spi7", "mic", "uart5", "gpio", "proc_rio", _, _ },
++	[49] = { "spi8", "spi7", "i2c5", "aaud", "uart5", "gpio", "proc_rio", _, _ },
++	[50] = { "spi8", "spi7", "i2c5", "aaud", "vbus2", "gpio", "proc_rio", _, _ },
++	[51] = { "spi8", "spi7", "i2c6", "aaud", "vbus2", "gpio", "proc_rio", _, _ },
++	[52] = { "spi8", _, "i2c6", "aaud", "vbus3", "gpio", "proc_rio", _, _ },
++	[53] = { "spi8", "spi7", _, "pcie_clkreq_n", "vbus3", "gpio", "proc_rio", _, _ },
++};
++#undef	_
++
+ struct rp1_gpio_softc {
+ 	device_t	dev;
+ 	device_t	busdev;
+@@ -358,6 +454,152 @@ rp1_gpio_map_gpios(device_t bus, phandle_t dev, phandle_t gparent, int gcells,
+ 	return (0);
+ }
+ 
++/*
++ * Parse a "gpioNN" pin name. The binding names pins rather than numbering
++ * them, and this is the only form RP1 uses.
++ */
++static int
++rp1_gpio_parse_pin(const char *name, int *pinp)
++{
++	int pin;
++
++	if (strncmp(name, "gpio", 4) != 0 || name[4] == '\0')
++		return (EINVAL);
++
++	pin = 0;
++	for (name += 4; *name != '\0'; name++) {
++		if (*name < '0' || *name > '9')
++			return (EINVAL);
++		pin = pin * 10 + (*name - '0');
++		if (pin >= RP1_GPIO_NPINS)
++			return (EINVAL);
++	}
++
++	*pinp = pin;
++	return (0);
++}
++
++/*
++ * fdt_pinctrl(9): apply one pin configuration node.
++ *
++ * RP1 uses the generic pinmux/pinconf binding:
++ *
++ *	rp1_pwm1_gpio45 {
++ *		function = "pwm1";
++ *		pins = "gpio45";
++ *		bias-pull-down;
++ *	};
++ *
++ * `function` is optional -- a node may configure bias alone -- but `pins` is
++ * not, and a node naming a function the pin does not implement is a device
++ * tree bug worth failing on rather than muxing to something arbitrary.
++ */
++static int
++rp1_gpio_configure(device_t dev, phandle_t cfgxref)
++{
++	struct rp1_gpio_softc *sc = device_get_softc(dev);
++	char *function, *pins, *p;
++	phandle_t node;
++	uint32_t ctrl, oldctrl, pad;
++	ssize_t len;
++	int bank, bit, error, fsel, i, pin;
++
++	node = OF_node_from_xref(cfgxref);
++	error = 0;
++
++	function = NULL;
++	(void)OF_getprop_alloc(node, "function", (void **)&function);
++
++	len = OF_getprop_alloc(node, "pins", (void **)&pins);
++	if (len <= 0) {
++		OF_prop_free(function);
++		return (ENOENT);
++	}
++
++	/* A string list: NUL-separated names packed into one property. */
++	for (p = pins; p < pins + len && *p != '\0'; p += strlen(p) + 1) {
++		if (rp1_gpio_parse_pin(p, &pin) != 0 ||
++		    rp1_gpio_decode(pin, &bank, &bit) != 0) {
++			device_printf(dev, "unknown pin \"%s\"\n", p);
++			error = EINVAL;
++			break;
++		}
++
++		fsel = -1;
++		if (function != NULL) {
++			for (i = 0; i < RP1_FSEL_COUNT; i++) {
++				if (rp1_pin_funcs[pin][i] != NULL &&
++				    strcmp(rp1_pin_funcs[pin][i],
++				    function) == 0) {
++					fsel = i;
++					break;
++				}
++			}
++			if (fsel < 0) {
++				device_printf(dev,
++				    "gpio%d has no \"%s\" function\n", pin,
++				    function);
++				error = EINVAL;
++				break;
++			}
++		}
++
++		RP1_LOCK(sc);
++
++		pad = rp1_rd(sc->pads, bank, RP1_PADS(bit));
++		if (OF_hasprop(node, "bias-pull-up")) {
++			pad &= ~RP1_PADS_PDE;
++			pad |= RP1_PADS_PUE;
++		} else if (OF_hasprop(node, "bias-pull-down")) {
++			pad &= ~RP1_PADS_PUE;
++			pad |= RP1_PADS_PDE;
++		} else if (OF_hasprop(node, "bias-disable")) {
++			pad &= ~(RP1_PADS_PUE | RP1_PADS_PDE);
++		}
++
++		oldctrl = rp1_rd(sc->iob, bank, RP1_IOB_CTRL(bit));
++		if (fsel >= 0) {
++			/*
++			 * Hand the pad to the peripheral before selecting it:
++			 * input buffer on, output driver enabled, and all
++			 * three overrides released. Pad first so the function
++			 * never drives through a disabled output stage.
++			 */
++			pad |= RP1_PADS_IE;
++			pad &= ~RP1_PADS_OD;
++			rp1_wr(sc->pads, bank, RP1_PADS(bit), pad);
++
++			ctrl = oldctrl;
++			ctrl &= ~(RP1_CTRL_FUNCSEL_MASK |
++			    RP1_CTRL_OUTOVER_MASK | RP1_CTRL_OEOVER_MASK);
++			ctrl |= RP1_OVER_PERI << RP1_CTRL_OUTOVER_SHIFT;
++			ctrl |= RP1_OVER_PERI << RP1_CTRL_OEOVER_SHIFT;
++			ctrl |= fsel;
++			rp1_wr(sc->iob, bank, RP1_IOB_CTRL(bit), ctrl);
++		} else {
++			rp1_wr(sc->pads, bank, RP1_PADS(bit), pad);
++		}
++
++		RP1_UNLOCK(sc);
++
++		/*
++		 * Worth logging what was there before: on a board whose
++		 * firmware has already assigned the function this is a no-op,
++		 * and that is a question about the hardware nobody has been
++		 * able to answer yet.
++		 */
++		if (bootverbose && fsel >= 0)
++			device_printf(dev,
++			    "gpio%d funcsel %u -> %d (%s)\n", pin,
++			    oldctrl & RP1_CTRL_FUNCSEL_MASK, fsel, function);
++	}
++
++	OF_prop_free(pins);
++	OF_prop_free(function);
++
++	return (error);
++}
++
+ static int
+ rp1_gpio_probe(device_t dev)
+ {
+@@ -401,6 +643,13 @@ rp1_gpio_attach(device_t dev)
+ 		goto fail;
+ 	}
+ 
++	/*
++	 * "pins" is the property naming the pins inside a configuration node.
++	 * Consumers reach this through fdt_pinctrl_configure_by_name(); no
++	 * pin is muxed here at attach time.
++	 */
++	fdt_pinctrl_register(dev, "pins");
++
+ 	bus_attach_children(dev);
+ 	return (0);
+ 
+@@ -433,6 +682,8 @@ static device_method_t rp1_gpio_methods[] = {
+ 
+ 	DEVMETHOD(ofw_bus_get_node,	rp1_gpio_get_node),
+ 
++	DEVMETHOD(fdt_pinctrl_configure, rp1_gpio_configure),
++
+ 	DEVMETHOD_END
+ };
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0037-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
+++ b/patches/0037-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
@@ -1,0 +1,555 @@
+From 6b1cca95c08fcbbcce2d415e42fd26cce055a110 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 2 Sep 2026 12:13:58 -0500
+Subject: [PATCH 3/3] rp1_pwm: driver for the RP1 PWM blocks
+
+Four channels per block, two blocks. What makes it worth having is the
+Pi 5 B's Active Cooler:
+
+    fan: cooling_fan {
+        compatible = "pwm-fan";
+        pwms = <&rp1_pwm1 3 41566 PWM_POLARITY_INVERTED>;
+        cooling-levels = <0 75 125 175 250>;
+    };
+
+pwm1 channel 3 -- behind PCIe on the southbridge, which is why this lives
+here rather than in one of the bcm2835 PWM drivers. With nothing driving
+it the fan never spins and the board throttles under load through a
+heatsink sized on the assumption that it does (nextbsd-kernel#112).
+
+A pwmbus(4) provider, so pwm(8) reaches it with no new userland:
+
+    pwm -f /dev/pwmc0 -c 3 -p 41566 -d 50 -E
+
+The block is a free-running counter per channel compared against RANGE for
+the period and DUTY for the on-time, both in clock ticks. Two things are
+less obvious than that.
+
+Writes do not take effect when made. Every register is shadowed and
+latched together when SET_UPDATE is written to GLOBAL_CTRL, so each
+configuration change ends in one commit -- which is also what stops a
+channel emitting a half-updated period.
+
+The clock is not ours. RP1's clockman owns it and it is off at reset, so
+without rp1_clk(4) every register here reads and writes normally and the
+pin never moves. Attach therefore fails loudly if the clock will not
+start, rather than leaving a driver that looks attached and does nothing.
+
+Nanoseconds are converted to ticks in one step rather than the vendor
+driver's two. pwm-rp1.c computes a whole number of nanoseconds per tick
+first and then divides by it, which at 50MHz is exactly 20ns and agrees;
+at a rate that does not divide 1e9 evenly its first rounding is silently
+lost. Same answer where it matters, better where it does not.
+
+Pins are muxed through fdt_pinctrl_configure_by_name(), and a missing
+pinctrl-0 is not an error: the 40-pin header blocks have none, and on a
+board whose firmware has already assigned the function it is a no-op.
+
+Register layout is from the vendor pwm-rp1.c.
+
+UNPROVEN ON HARDWARE. This cannot be tested on the one Pi 5-family board
+available: a Pi 500+ has no fan header, and its DTB leaves both
+`cooling_fan` and `rp1_pwm1` status = "disabled", so the driver does not
+attach there at all. It needs a Pi 5 B with an Active Cooler fitted.
+
+Refs nextbsd-kernel#112.
+---
+ sys/arm/broadcom/bcm2835/rp1_pwm.c | 473 +++++++++++++++++++++++++++++
+ sys/conf/files.arm64               |   1 +
+ 2 files changed, 474 insertions(+)
+ create mode 100644 sys/arm/broadcom/bcm2835/rp1_pwm.c
+
+diff --git a/sys/arm/broadcom/bcm2835/rp1_pwm.c b/sys/arm/broadcom/bcm2835/rp1_pwm.c
+new file mode 100644
+index 00000000000..88669b41aff
+--- /dev/null
++++ b/sys/arm/broadcom/bcm2835/rp1_pwm.c
+@@ -0,0 +1,473 @@
++/*-
++ * SPDX-License-Identifier: BSD-2-Clause
++ *
++ * Copyright (c) 2026 The NextBSD Project
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
++ */
++
++/*
++ * PWM for RP1, the southbridge on Raspberry Pi 5-family boards.
++ *
++ * Four channels per block, two blocks. What makes this worth having is the
++ * Pi 5 B's Active Cooler, which hangs off pwm1 channel 3:
++ *
++ *	fan: cooling_fan {
++ *		compatible = "pwm-fan";
++ *		pwms = <&rp1_pwm1 3 41566 PWM_POLARITY_INVERTED>;
++ *		cooling-levels = <0 75 125 175 250>;
++ *	};
++ *
++ * so on a Pi 5 B with no driver here the fan never spins, and the board
++ * throttles under load through a heatsink sized on the assumption that it
++ * does. See nextbsd-kernel#112.
++ *
++ * The block itself is simple: a free-running counter per channel compared
++ * against RANGE for the period and DUTY for the on-time, both in clock ticks.
++ * Two things are less obvious.
++ *
++ * Writes do not take effect when made. Every register in the block is shadowed
++ * and latched together when SET_UPDATE is written to GLOBAL_CTRL, so a
++ * configuration change is a sequence of writes followed by one commit -- which
++ * is also what stops a channel from emitting a half-updated period.
++ *
++ * The clock is not ours. RP1's clockman owns it and it is off at reset, so
++ * without rp1_clk(4) every register here reads and writes normally and the pin
++ * never moves. That failure mode is silent, which is why attach fails loudly
++ * rather than continuing without it.
++ *
++ * Register layout is from the vendor pwm-rp1.c.
++ *
++ * UNPROVEN ON HARDWARE. The only Pi 5-family board available is a Pi 500+,
++ * which has no fan header and whose DTB leaves both `cooling_fan` and
++ * `rp1_pwm1` status = "disabled", so this driver cannot attach there at all.
++ * It needs a Pi 5 B with an Active Cooler fitted.
++ */
++
++#include <sys/param.h>
++#include <sys/systm.h>
++#include <sys/bus.h>
++#include <sys/kernel.h>
++#include <sys/lock.h>
++#include <sys/module.h>
++#include <sys/mutex.h>
++#include <sys/rman.h>
++
++#include <machine/bus.h>
++
++#include <dev/ofw/ofw_bus.h>
++#include <dev/ofw/ofw_bus_subr.h>
++
++#include <dev/fdt/fdt_pinctrl.h>
++
++#include <dev/pwm/pwmc.h>
++
++#include <arm/broadcom/bcm2835/rp1_clk.h>
++
++#include "pwmbus_if.h"
++
++#define	RP1_PWM_NCHANNELS		4
++
++#define	RP1_PWM_GLOBAL_CTRL		0x000
++#define	 RP1_PWM_GLOBAL_SET_UPDATE	(1u << 31)
++#define	 RP1_PWM_GLOBAL_CHAN_EN(c)	(1u << (c))
++
++/*
++ * Three registers per channel on a 16-byte stride, but not contiguously: CTRL
++ * at +0, RANGE at +4, then a FIFO at +8 and DUTY at +12. The offsets are given
++ * the way the vendor driver gives them so the two can be compared by eye.
++ */
++#define	RP1_PWM_CHAN_CTRL(c)		(0x014 + (c) * 16)
++#define	 RP1_PWM_CHAN_MODE_MASK		0x3u
++#define	 RP1_PWM_CHAN_MODE_TRAILING	0x1u	/* trailing-edge M/S */
++#define	 RP1_PWM_CHAN_POLARITY		(1u << 3)
++#define	 RP1_PWM_CHAN_FIFO_POP_MASK	(1u << 8)
++#define	RP1_PWM_CHAN_RANGE(c)		(0x018 + (c) * 16)
++#define	RP1_PWM_CHAN_DUTY(c)		(0x020 + (c) * 16)
++
++#define	NS_PER_SEC			1000000000ULL
++
++struct rp1_pwm_softc {
++	device_t	dev;
++	device_t	busdev;
++	struct resource	*res;
++	struct mtx	mtx;
++
++	device_t	clkdev;
++	u_int		clkid;
++	uint64_t	clk_freq;
++
++	u_int		period[RP1_PWM_NCHANNELS];
++	u_int		duty[RP1_PWM_NCHANNELS];
++};
++
++#define	RP1_PWM_LOCK(sc)	mtx_lock(&(sc)->mtx)
++#define	RP1_PWM_UNLOCK(sc)	mtx_unlock(&(sc)->mtx)
++
++static struct ofw_compat_data compat_data[] = {
++	{ "raspberrypi,rp1-pwm",	1 },
++	{ NULL,				0 }
++};
++
++/*
++ * The rate the DT asks for. rp1.dtsi carries
++ * assigned-clock-rates = <50000000> on both PWM blocks, which is also the
++ * crystal rate, so the divider comes out at exactly one and a tick is 20ns.
++ */
++#define	RP1_PWM_DEFAULT_CLK_FREQ	50000000ULL
++
++/*
++ * Ticks for a duration in nanoseconds, rounded to nearest.
++ *
++ * Done in one step rather than the vendor driver's two (which computes a
++ * whole number of nanoseconds per tick first, then divides by it). At 50MHz a
++ * tick is exactly 20ns and the two agree; at a rate that does not divide
++ * 1e9 evenly the vendor's first rounding is silently lost, so this keeps the
++ * full precision instead of reproducing that.
++ */
++static uint32_t
++rp1_pwm_ns_to_ticks(struct rp1_pwm_softc *sc, u_int ns)
++{
++	uint64_t ticks;
++
++	ticks = ((uint64_t)ns * sc->clk_freq + NS_PER_SEC / 2) / NS_PER_SEC;
++	if (ticks > 0xffffffffULL)
++		ticks = 0xffffffffULL;
++	return ((uint32_t)ticks);
++}
++
++static int
++rp1_pwm_channel_count(device_t dev, u_int *nchannel)
++{
++
++	*nchannel = RP1_PWM_NCHANNELS;
++	return (0);
++}
++
++static int
++rp1_pwm_channel_config(device_t dev, u_int channel, u_int period, u_int duty)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	uint32_t ctrl, range, dutyticks;
++
++	if (channel >= RP1_PWM_NCHANNELS)
++		return (EINVAL);
++	if (duty > period)
++		return (EINVAL);
++
++	range = rp1_pwm_ns_to_ticks(sc, period);
++	dutyticks = rp1_pwm_ns_to_ticks(sc, duty);
++
++	/*
++	 * A period that rounds to zero ticks would leave the comparator with
++	 * nothing to count to. Refuse rather than program it.
++	 */
++	if (range == 0)
++		return (EINVAL);
++
++	RP1_PWM_LOCK(sc);
++
++	bus_write_4(sc->res, RP1_PWM_CHAN_DUTY(channel), dutyticks);
++	bus_write_4(sc->res, RP1_PWM_CHAN_RANGE(channel), range);
++
++	/*
++	 * Put the channel in the mode the vendor driver selects on first use:
++	 * trailing-edge mark/space, with the FIFO pop masked off since nothing
++	 * here feeds it. Polarity lives in the same register and belongs to
++	 * channel_set_flags, so it is preserved.
++	 */
++	ctrl = bus_read_4(sc->res, RP1_PWM_CHAN_CTRL(channel));
++	ctrl &= ~RP1_PWM_CHAN_MODE_MASK;
++	ctrl |= RP1_PWM_CHAN_MODE_TRAILING | RP1_PWM_CHAN_FIFO_POP_MASK;
++	bus_write_4(sc->res, RP1_PWM_CHAN_CTRL(channel), ctrl);
++
++	/* Latch all of the above at once. */
++	bus_write_4(sc->res, RP1_PWM_GLOBAL_CTRL,
++	    bus_read_4(sc->res, RP1_PWM_GLOBAL_CTRL) |
++	    RP1_PWM_GLOBAL_SET_UPDATE);
++
++	sc->period[channel] = period;
++	sc->duty[channel] = duty;
++
++	RP1_PWM_UNLOCK(sc);
++
++	return (0);
++}
++
++static int
++rp1_pwm_channel_get_config(device_t dev, u_int channel, u_int *period,
++    u_int *duty)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++
++	if (channel >= RP1_PWM_NCHANNELS)
++		return (EINVAL);
++
++	RP1_PWM_LOCK(sc);
++	*period = sc->period[channel];
++	*duty = sc->duty[channel];
++	RP1_PWM_UNLOCK(sc);
++
++	return (0);
++}
++
++static int
++rp1_pwm_channel_set_flags(device_t dev, u_int channel, uint32_t flags)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	uint32_t ctrl;
++
++	if (channel >= RP1_PWM_NCHANNELS)
++		return (EINVAL);
++
++	RP1_PWM_LOCK(sc);
++	ctrl = bus_read_4(sc->res, RP1_PWM_CHAN_CTRL(channel));
++	if ((flags & PWM_POLARITY_INVERTED) != 0)
++		ctrl |= RP1_PWM_CHAN_POLARITY;
++	else
++		ctrl &= ~RP1_PWM_CHAN_POLARITY;
++	bus_write_4(sc->res, RP1_PWM_CHAN_CTRL(channel), ctrl);
++	bus_write_4(sc->res, RP1_PWM_GLOBAL_CTRL,
++	    bus_read_4(sc->res, RP1_PWM_GLOBAL_CTRL) |
++	    RP1_PWM_GLOBAL_SET_UPDATE);
++	RP1_PWM_UNLOCK(sc);
++
++	return (0);
++}
++
++static int
++rp1_pwm_channel_get_flags(device_t dev, u_int channel, uint32_t *flags)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	uint32_t ctrl;
++
++	if (channel >= RP1_PWM_NCHANNELS)
++		return (EINVAL);
++
++	RP1_PWM_LOCK(sc);
++	ctrl = bus_read_4(sc->res, RP1_PWM_CHAN_CTRL(channel));
++	RP1_PWM_UNLOCK(sc);
++
++	*flags = (ctrl & RP1_PWM_CHAN_POLARITY) != 0 ?
++	    PWM_POLARITY_INVERTED : 0;
++	return (0);
++}
++
++static int
++rp1_pwm_channel_enable(device_t dev, u_int channel, bool enable)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	uint32_t global;
++
++	if (channel >= RP1_PWM_NCHANNELS)
++		return (EINVAL);
++
++	RP1_PWM_LOCK(sc);
++	global = bus_read_4(sc->res, RP1_PWM_GLOBAL_CTRL);
++	if (enable)
++		global |= RP1_PWM_GLOBAL_CHAN_EN(channel);
++	else
++		global &= ~RP1_PWM_GLOBAL_CHAN_EN(channel);
++	bus_write_4(sc->res, RP1_PWM_GLOBAL_CTRL,
++	    global | RP1_PWM_GLOBAL_SET_UPDATE);
++	RP1_PWM_UNLOCK(sc);
++
++	return (0);
++}
++
++static int
++rp1_pwm_channel_is_enabled(device_t dev, u_int channel, bool *enabled)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	uint32_t global;
++
++	if (channel >= RP1_PWM_NCHANNELS)
++		return (EINVAL);
++
++	RP1_PWM_LOCK(sc);
++	global = bus_read_4(sc->res, RP1_PWM_GLOBAL_CTRL);
++	RP1_PWM_UNLOCK(sc);
++
++	*enabled = (global & RP1_PWM_GLOBAL_CHAN_EN(channel)) != 0;
++	return (0);
++}
++
++/*
++ * Resolve `clocks = <&rp1_clocks RP1_CLK_PWMn>` to the clock driver and the id
++ * within it. #clock-cells is 1 on rp1_clocks, so the property is exactly two
++ * cells; anything else is a device tree we do not understand and is worth
++ * failing on rather than indexing into.
++ */
++static int
++rp1_pwm_find_clock(device_t dev, device_t *clkdev, u_int *clkid)
++{
++	phandle_t node;
++	pcell_t cells[2];
++
++	node = ofw_bus_get_node(dev);
++	if (OF_getencprop(node, "clocks", cells, sizeof(cells)) !=
++	    (ssize_t)sizeof(cells))
++		return (ENXIO);
++
++	*clkdev = OF_device_from_xref(cells[0]);
++	if (*clkdev == NULL)
++		return (ENXIO);
++	*clkid = cells[1];
++
++	return (0);
++}
++
++static int
++rp1_pwm_probe(device_t dev)
++{
++
++	if (!ofw_bus_status_okay(dev))
++		return (ENXIO);
++	if (ofw_bus_search_compatible(dev, compat_data)->ocd_data == 0)
++		return (ENXIO);
++
++	device_set_desc(dev, "RP1 PWM");
++	return (BUS_PROBE_DEFAULT);
++}
++
++static int
++rp1_pwm_attach(device_t dev)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	phandle_t node;
++	int error, rid;
++
++	sc->dev = dev;
++	mtx_init(&sc->mtx, device_get_nameunit(dev), NULL, MTX_DEF);
++
++	rid = 0;
++	sc->res = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &rid, RF_ACTIVE);
++	if (sc->res == NULL) {
++		device_printf(dev, "could not map registers\n");
++		error = ENXIO;
++		goto fail;
++	}
++
++	error = rp1_pwm_find_clock(dev, &sc->clkdev, &sc->clkid);
++	if (error != 0) {
++		device_printf(dev, "could not resolve the clocks property\n");
++		goto fail;
++	}
++
++	/*
++	 * Not optional. The block is clocked from RP1's clockman and that gate
++	 * is closed at reset; without it every register below reads and writes
++	 * normally and the pin stays put, which is the worst kind of failure
++	 * to ship.
++	 */
++	error = rp1_clk_enable(sc->clkdev, sc->clkid,
++	    RP1_PWM_DEFAULT_CLK_FREQ);
++	if (error != 0) {
++		device_printf(dev, "could not start the PWM clock: %d\n",
++		    error);
++		goto fail;
++	}
++
++	sc->clk_freq = rp1_clk_get_freq(sc->clkdev, sc->clkid);
++	if (sc->clk_freq == 0) {
++		device_printf(dev, "PWM clock reads back as stopped\n");
++		error = ENXIO;
++		goto fail;
++	}
++	if (bootverbose)
++		device_printf(dev, "clock %ju Hz\n", (uintmax_t)sc->clk_freq);
++
++	/*
++	 * Mux the pins this block drives. Advisory: a node with no pinctrl-0
++	 * is not an error (the 40-pin header blocks have none), and on a board
++	 * whose firmware has already assigned the function this is a no-op.
++	 */
++	error = fdt_pinctrl_configure_by_name(dev, "default");
++	if (error != 0 && error != ENOENT && bootverbose)
++		device_printf(dev, "pinctrl \"default\" not applied: %d\n",
++		    error);
++
++	node = ofw_bus_get_node(dev);
++	OF_device_register_xref(OF_xref_from_node(node), dev);
++
++	sc->busdev = device_add_child(dev, "pwmbus", DEVICE_UNIT_ANY);
++	if (sc->busdev == NULL) {
++		device_printf(dev, "could not add pwmbus\n");
++		error = ENXIO;
++		goto fail;
++	}
++
++	bus_attach_children(dev);
++	return (0);
++
++fail:
++	if (sc->res != NULL)
++		bus_release_resource(dev, SYS_RES_MEMORY, 0, sc->res);
++	mtx_destroy(&sc->mtx);
++	return (error);
++}
++
++static int
++rp1_pwm_detach(device_t dev)
++{
++	struct rp1_pwm_softc *sc = device_get_softc(dev);
++	int error;
++
++	error = bus_generic_detach(dev);
++	if (error != 0)
++		return (error);
++
++	rp1_clk_disable(sc->clkdev, sc->clkid);
++	bus_release_resource(dev, SYS_RES_MEMORY, 0, sc->res);
++	mtx_destroy(&sc->mtx);
++
++	return (0);
++}
++
++static phandle_t
++rp1_pwm_get_node(device_t bus, device_t dev)
++{
++
++	return (ofw_bus_get_node(bus));
++}
++
++static device_method_t rp1_pwm_methods[] = {
++	/* Device interface */
++	DEVMETHOD(device_probe,		rp1_pwm_probe),
++	DEVMETHOD(device_attach,	rp1_pwm_attach),
++	DEVMETHOD(device_detach,	rp1_pwm_detach),
++
++	/* ofw_bus interface */
++	DEVMETHOD(ofw_bus_get_node,	rp1_pwm_get_node),
++
++	/* pwmbus interface */
++	DEVMETHOD(pwmbus_channel_count,		rp1_pwm_channel_count),
++	DEVMETHOD(pwmbus_channel_config,	rp1_pwm_channel_config),
++	DEVMETHOD(pwmbus_channel_get_config,	rp1_pwm_channel_get_config),
++	DEVMETHOD(pwmbus_channel_set_flags,	rp1_pwm_channel_set_flags),
++	DEVMETHOD(pwmbus_channel_get_flags,	rp1_pwm_channel_get_flags),
++	DEVMETHOD(pwmbus_channel_enable,	rp1_pwm_channel_enable),
++	DEVMETHOD(pwmbus_channel_is_enabled,	rp1_pwm_channel_is_enabled),
++
++	DEVMETHOD_END
++};
++
++static driver_t rp1_pwm_driver = {
++	"pwm",
++	rp1_pwm_methods,
++	sizeof(struct rp1_pwm_softc),
++};
++
++DRIVER_MODULE(rp1_pwm, simplebus, rp1_pwm_driver, 0, 0);
++MODULE_DEPEND(rp1_pwm, pwmbus, 1, 1, 1);
++SIMPLEBUS_PNP_INFO(compat_data);
+diff --git a/sys/conf/files.arm64 b/sys/conf/files.arm64
+index a6d08d6964d..b6c5da59217 100644
+--- a/sys/conf/files.arm64
++++ b/sys/conf/files.arm64
+@@ -600,6 +600,7 @@ arm/broadcom/bcm2835/bcm2712_mip.c			optional soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/rp1.c				optional soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/rp1_clk.c				optional soc_brcm_bcm2712 fdt pci
+ arm/broadcom/bcm2835/rp1_gpio.c				optional soc_brcm_bcm2712 gpio fdt pci
++arm/broadcom/bcm2835/rp1_pwm.c				optional soc_brcm_bcm2712 pwm fdt pci
+ arm/broadcom/bcm2835/bcm2838_xhci.c			optional soc_brcm_bcm2838 fdt pci xhci
+ arm/broadcom/bcm2835/raspberrypi_gpio.c			optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt
+ arm/broadcom/bcm2835/raspberrypi_virtgpio.c		optional soc_brcm_bcm2837 gpio fdt | soc_brcm_bcm2838 gpio fdt
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -32,3 +32,6 @@
 0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch
 0033-bcm2835_fbd-trust-the-firmware-applied-depth.patch
 0034-bcm2835_fbd-believe-the-stride-not-the-claimed-depth.patch
+0035-rp1_clk-peripheral-clock-gates-for-rp1.patch
+0036-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch
+0037-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch


### PR DESCRIPTION
Fan half of #112. Stacked on #171 — both append to `patches/series`, so this
targets that branch and GitHub will retarget it to `main` when #171 merges.

Together these make the Active Cooler reachable from `pwm(8)`. The
temperature-driven policy that should step it automatically is deliberately
**not** here — see "What's still missing".

## The fan needed more than a PWM driver

From `bcm2712-rpi-5-b.dts:396`:

```
pwms = <&rp1_pwm1 3 41566 PWM_POLARITY_INVERTED>;
```

RP1 PWM1 channel 3 — behind PCIe on the southbridge. Two things stand between
that block and a spinning fan, and both are silent when missing.

### `0031` — `rp1_clk`, peripheral clock gates

RP1's leaf clocks are off at reset. The vendor driver that manages them is
2500 lines of PLL, mux and divider tree; this is the small part of it — the
clocks that take a fractional divider straight off the 50MHz crystal, which is
already running (everything on RP1 that works today works because it is).

One operation, *"run clock N at F Hz"*, and `ENOENT` for anything else. **The
refusal is the point.** A clock whose parent is a PLL cannot be added to the
table without also starting that PLL, and a divider programmed off a dead PLL
doesn't fail — it yields a peripheral that reads and writes normally and never
ticks.

Parent selection is the subtle bit: for these clocks the CTRL register's `SRC`
field is unused (the vendor table gives them `clk_src_mask = 0`, so its
`set_parent` writes nothing there) and selection is entirely by `AUXSRC`,
indexing that clock's own auxiliary parent list. `xosc` is at index 2 in both
PWM lists.

### `0032` — `rp1_gpio`, `fdt_pinctrl` provider

`rp1_gpio` was written with muxing left out on the grounds that the firmware
had already assigned every pin used so far — true for `phy-reset-gpios` and
`gpioled`. It stops being true at the fan:

```
&rp1_pwm1 { pinctrl-0 = <&rp1_pwm1_gpio45>; };
rp1_pwm1_gpio45 { function = "pwm1"; pins = "gpio45"; bias-pull-down; };
```

Linux applies that at probe. Nothing in the firmware does.

Two things easy to get wrong, and silent when wrong:

- **Muxing releases the overrides, not just FUNCSEL.** OUT/OE/IN can each be
  forced independently of the selected function. A pin left with `OEOVER`
  forced from an earlier GPIO configuration keeps that direction whatever
  FUNCSEL says, and the peripheral drives nothing.
- **The pad is handed over before the function is selected** — input buffer on,
  output driver enabled, *then* FUNCSEL. The other order briefly points the new
  function at a disabled output stage.

The per-pin function table is transcribed mechanically from the vendor
`pinctrl-rp1.c` (a script, not by hand) and must stay identical to it: the index
into a row **is** the FUNCSEL value and none of it is derivable. The `5` that
appears throughout at `"gpio"` is the `RP1_CTRL_FUNCSEL_RIO` this file already
writes, which is a free check that the transcription is aligned.

### `0033` — `rp1_pwm`

A `pwmbus(4)` provider, so `pwm(8)` reaches it with no new userland. The block
is a counter per channel compared against RANGE (period) and DUTY (on-time).
Two non-obvious properties:

- **Writes don't take effect when made.** Every register is shadowed and
  latched together on `SET_UPDATE` to `GLOBAL_CTRL`, so each change ends in one
  commit — which is also what stops a channel emitting a half-updated period.
- **The clock isn't ours.** Attach fails loudly if `rp1_clk` won't start it,
  rather than leaving a driver that looks attached and does nothing.

ns→ticks is done in one step rather than the vendor's two (it computes whole
nanoseconds-per-tick first, then divides). At 50MHz a tick is exactly 20ns and
they agree; at a rate that doesn't divide 1e9 evenly the vendor's first
rounding is silently lost.

## None of this is proven on hardware

**And it cannot be proven on the board we have.** A Pi 500+ has no fan header,
and its DTB leaves both `cooling_fan` and `rp1_pwm1` `status = "disabled"` —
`rp1_pwm` will not even attach there. Each driver says so in its own header
comment, not just here.

This needs a **Pi 5 B with an Active Cooler fitted**. Driven by hand:

```sh
pwm -f pwmc0.3 -p 41566 -d 50% -E    # ~50% — should be audible
pwm -f pwmc0.3 -p 41566 -d 100% -E   # full
pwm -f pwmc0.3 -D                    # off
pwm -f pwmc0.3 -C                    # show what the driver thinks it is doing
```

`pwmbus` adds one `pwmc(4)` child per channel, so the fan on channel 3 of the
first (and, with `rp1_pwm0` disabled, only) controller is `/dev/pwm/pwmc0.3`.
`pwm -f` takes the name relative to `/dev/pwm/`.

The DT says `PWM_POLARITY_INVERTED`, so if the fan runs *backwards* from the
duty cycle, add `-I`.

### One open question the code is arranged to answer

Whether the Pi 5 B firmware has already muxed GPIO45 before we get there.
Nobody here can find out. `0032` logs the FUNCSEL it found *before* overwriting
it, at `bootverbose`, so the first tester's dmesg settles it:

```
gpio0: gpio45 funcsel 31 -> 0 (pwm1)     # 31 = NULL, firmware left it alone
gpio0: gpio45 funcsel 0 -> 0 (pwm1)      # firmware had already done it
```

## What's still missing

The **policy**. `thermal-zones` / `cooling-maps` / `cooling-levels` are Linux
bindings and nothing here reads them. Once the fan can be made to spin by hand,
the policy is a small consumer that reads
`dev.bcm2835_firmware.0.temperature` (from #171) and steps the duty cycle
through the DT's `cooling-levels = <0 75 125 175 250>` against the trip points
in `cpu-thermal`. That's a follow-up, and it wants a fan that is known to work
underneath it first.

Verified: the full 33-patch series applies cleanly to `releng/15.1` at
`88e7371d9dc`.

Refs #112.

