### PR TITLE
kern_exit + procdesc: fix the three remaining zombie defects after #174 (#177, #179, #180)

### DIFF
--- a/patches/0035-kern_exit-sweep-zombies-adopted-after-death.patch
+++ b/patches/0035-kern_exit-sweep-zombies-adopted-after-death.patch
@@ -1,0 +1,104 @@
+From b30650be562b656ecc8c9d991114b38a5a803abe Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Thu, 3 Sep 2026 07:55:12 -0500
+Subject: [PATCH] kern_exit: sweep zombies that init adopts after they are
+ already dead
+
+The reap-at-exit path added in #174 misses the case where the child is
+already a zombie when its parent exits.
+
+exit1() flags such children as it reparents them, but the sweep is only ever
+enqueued from a process's own exit1(), gated on p_pptr == initproc. A child
+that had already exited ran that code long before -- with its real parent as
+p_pptr, and before it carried the flag -- so nothing enqueued a sweep for
+it, and nothing ever will on its behalf. It is adopted by init, flagged, and
+then simply waits.
+
+It is collected eventually only by luck: the sweep scans all of init's
+flagged zombie children, so any other orphan exiting later clears the
+backlog too. On a quiet machine nothing triggers that.
+
+Reported by probonopd running the fixed kernel for several hours: greatly
+improved, but a residue of ~20 that accumulates and then sits, not growing
+by the minute. The names are the tell -- md5, strings and tail, used with
+pipes on the command line. Shell pipeline members that became zombies while
+the shell was alive, orphaned when it exited. Exactly this case, not the
+NSTask helpers #173 was about.
+
+Fix: notice the case where it is already visible. The PRS_ZOMBIE branch in
+the reparent loop already exists and already knows the situation, so set a
+flag there and widen the existing enqueue condition. One flag, one
+condition; it reuses the sweep, which already looks for precisely these --
+flagged zombie children of init -- so there is no new machinery.
+
+The enqueue stays where #174 put it, after the parent-notification block and
+before the PROC_SLOCK section, since taskqueue_enqueue_timeout() takes a
+sleepable mutex and must not run under a spin lock. Setting a flag inside
+the loop and acting on it there is also why this is not enqueued from inside
+the loop itself, where PROC_LOCK(q) and proctree_lock are both held.
+
+Gated on q->p_reaper == initproc to match the sweep's scope, so a userland
+reaper established with procctl(PROC_REAP_ACQUIRE) still collects its own
+children.
+
+Still not covered, and not coverable: a zombie whose parent is alive and
+never calls wait(). No PID 1 fix reaches that; on this system the example is
+gpbs under LoginWindow.
+
+Refs nextbsd-kernel#177, #173, #174.
+---
+ sys/kern/kern_exit.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/sys/kern/kern_exit.c b/sys/kern/kern_exit.c
+index fad3c2c752f..c8ec42a21bd 100644
+--- a/sys/kern/kern_exit.c
++++ b/sys/kern/kern_exit.c
+@@ -313,6 +313,7 @@ exit1(struct thread *td, int rval, int signo)
+ 	ksiginfo_t *ksi, *ksi1;
+ 	int signal_parent;
+ 	bool autoreap;
++	bool adopted_zombie;
+ 
+ 	mtx_assert(&Giant, MA_NOTOWNED);
+ 	KASSERT(rval == 0 || signo == 0, ("exit1 rv %d sig %d", rval, signo));
+@@ -578,6 +579,7 @@ exit1(struct thread *td, int rval, int signo)
+ 	 * - traced ones to the original parent (or init if we are that parent)
+ 	 * - the rest to init
+ 	 */
++	adopted_zombie = false;
+ 	q = LIST_FIRST(&p->p_children);
+ 	if (q != NULL)		/* only need this if any child is S_ZOMB */
+ 		wakeup(q->p_reaper);
+@@ -600,6 +602,19 @@ exit1(struct thread *td, int rval, int signo)
+ 			q->p_flag2 |= P2_ORPHAN_AUTOREAP;
+ 			proc_reparent(q, q->p_reaper, true);
+ 			if (q->p_state == PRS_ZOMBIE) {
++				/*
++				 * nextbsd#177: this child is a zombie
++				 * ALREADY, so its own exit1() has long
++				 * since run -- with us as its parent,
++				 * not init, and before it carried the
++				 * flag just set above. Nothing has
++				 * therefore scheduled a sweep for it,
++				 * and nothing ever will on its behalf.
++				 * Note it and enqueue once below.
++				 */
++				if (q->p_reaper == initproc)
++					adopted_zombie = true;
++
+ 				/*
+ 				 * Inform reaper about the reparented
+ 				 * zombie, since wait(2) has something
+@@ -805,7 +820,7 @@ exit1(struct thread *td, int rval, int signo)
+ 	 * section below, because taskqueue_enqueue_timeout() takes a sleepable
+ 	 * mutex and must not run under a spin lock.
+ 	 */
+-	if (autoreap)
++	if (autoreap || adopted_zombie)
+ 		taskqueue_enqueue_timeout(taskqueue_thread,
+ 		    &nextbsd_autoreap_task, 1);
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0036-kern_exit-stop-autoreap-sweep-re-arming-every-tick.patch
+++ b/patches/0036-kern_exit-stop-autoreap-sweep-re-arming-every-tick.patch
@@ -1,0 +1,89 @@
+From 6acb6eadc45ead82cb9c464b81f53b08e03e91e7 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Thu, 3 Sep 2026 10:08:50 -0500
+Subject: [PATCH 1/2] kern_exit: stop the autoreap sweep re-arming every tick
+ forever
+
+The sweep added in #174 notes any flagged process that is not yet a zombie
+so it can come back for it rather than depending on the timing. Its comment
+assumed "flagged but still running" means "mid-exit, will be a zombie in a
+moment". It does not.
+
+P2_ORPHAN_AUTOREAP means "was orphaned onto init", and plenty of processes
+are orphaned onto init and then go on living for the rest of the boot --
+every double-forking daemon on the system. Measured on a Pi 500+: gdnc (129)
+and gpbs (148), both alive, both children of PID 1, neither a launchd job.
+So `again` was set on every pass and the task re-armed itself every tick for
+the life of the machine.
+
+	thread taskq CPU:  0:21.86 -> 0:22.04 over 60s
+	                   = 0.18s/60s = 0.3% of a core, idle
+	uptime 9h38m, 21.9s accumulated: same rate since boot
+
+0.3% of a core forever is bad on a Pi. Taking proctree_lock exclusive hz
+times a second systemwide is worse -- that lock serialises fork, exit, wait
+and reparenting, and each pass holds it for a full walk of init's children.
+
+Gate the re-arm on P2_WEXIT, which is the state the comment meant.
+proc_set_p2_wexit() runs at the top of exit1(), long before the flag site
+and the enqueue, so anything that scheduled a sweep is already carrying it
+and the window is microseconds wide. A living orphan has it clear and no
+longer arms anything.
+
+Missing a re-arm would be harmless regardless: every flagged process
+enqueues a sweep from its own exit1() as it dies, so the re-arm only covers
+the case where the task fires before PRS_ZOMBIE is set. It is not the
+mechanism anything depends on.
+
+Note the ordering with nextbsd-kernel#177: the endless sweep was collecting
+flagged zombies within a tick, which masked the missing enqueue for children
+already dead when they were adopted. That fix has to precede this one, and
+does.
+
+Refs nextbsd-kernel#180, #174, #177.
+---
+ sys/kern/kern_exit.c | 27 +++++++++++++++++++++++----
+ 1 file changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/sys/kern/kern_exit.c b/sys/kern/kern_exit.c
+index c8ec42a21bd..c803e584910 100644
+--- a/sys/kern/kern_exit.c
++++ b/sys/kern/kern_exit.c
+@@ -269,11 +269,30 @@ nextbsd_autoreap(void *arg __unused, int pending __unused)
+ 			if (p->p_state == PRS_ZOMBIE)
+ 				break;
+ 			/*
+-			 * Flagged but still running: it is somewhere between
+-			 * the enqueue in exit1() and PRS_ZOMBIE. Come back for
+-			 * it rather than depending on the timing.
++			 * Flagged, not a zombie yet. Only come back for it if
++			 * it is genuinely mid-exit -- P2_WEXIT is set at the
++			 * top of exit1(), long before the flag site and the
++			 * enqueue, so anything that scheduled us is already
++			 * carrying it and the window is microseconds wide.
++			 *
++			 * nextbsd#180: testing "flagged and not a zombie" here
++			 * instead re-armed forever. The flag means "was
++			 * orphaned onto init", not "is dying", and a system
++			 * with any double-forking daemon has flagged
++			 * processes that stay alive for the whole boot --
++			 * measured, gdnc and gpbs. That re-armed the task
++			 * every tick for the life of the machine: 0.3% of a
++			 * core on an idle Pi, and proctree_lock taken
++			 * exclusive hz times a second systemwide.
++			 *
++			 * Missing a re-arm is harmless in any case. Every
++			 * flagged process enqueues a sweep from its own
++			 * exit1() as it dies, so this is belt-and-braces for
++			 * the case where the task fires before PRS_ZOMBIE is
++			 * set, not the mechanism anything depends on.
+ 			 */
+-			again = true;
++			if ((p->p_flag2 & P2_WEXIT) != 0)
++				again = true;
+ 		}
+ 		if (p == NULL) {
+ 			sx_xunlock(&proctree_lock);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0037-procdesc-flag-processes-orphaned-onto-the-reaper.patch
+++ b/patches/0037-procdesc-flag-processes-orphaned-onto-the-reaper.patch
@@ -1,0 +1,91 @@
+From e3b99a70e1ad40de91ab1fb2008a83a492e809b1 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Thu, 3 Sep 2026 10:09:13 -0500
+Subject: [PATCH 2/2] procdesc: flag processes this path orphans onto the
+ reaper
+
+procdesc_close() has two branches for a process whose last descriptor is
+going away. If it is already a zombie it is proc_reap()ed on the spot, which
+is fine. If it is still alive it is detached from the descriptor, reparented
+onto its reaper -- usually init -- and then SIGKILLed.
+
+That second branch is a second orphan-onto-the-reaper site, and #174 only
+flagged the one in exit1(). So the process reaches init without
+P2_ORPHAN_AUTOREAP, and when the SIGKILL lands its exit1() finds
+p_pptr == initproc but no flag: autoreap stays false, signal_parent is set,
+launchd gets a SIGCHLD it does not wait on, and the zombie is permanent --
+and invisible to the sweep, which only looks at flagged processes.
+
+This is what was still leaking after #174, and it is why the names in the
+report were what they were. Every Capsicum-sandboxed tool in base gets its
+file access through libcasper, which pdfork()s helpers that end their lives
+exactly here. ktrace of one strings(1):
+
+	848 strings  CALL  pdfork(...,0)
+	849 strings  RET   pdfork 0            <- casper helper
+	849 strings  CALL  fork
+	850 strings  CALL  pdfork(...,0)       <- casper service
+	850 strings  CALL  _exit(0)
+	848 strings  CALL  cap_enter
+
+so strings, md5, head and tail each leaked one zombie per invocation.
+Reduced to a 12-line pdfork(2) reproducer with no shell involved, which
+leaks identically.
+
+How this was distinguished from the exit1() gap in #177: with eleven of them
+standing, orphaning a live child onto init -- #174's covered case -- got that
+child collected, proving a sweep ran, and left all eleven untouched. The
+sweep scans every flagged zombie child of init, so surviving it means they
+were never flagged.
+
+Set the flag here too. Nothing else is needed, because the process is still
+alive at this point and its own exit1() then enqueues the sweep the same way
+any other orphan does. The traced branch is left alone, matching exit1(),
+which does not flag traced children either.
+
+p_flag2 is written under PROC_LOCK(p), held across this block.
+
+Refs nextbsd-kernel#179, #173, #174, #177.
+---
+ sys/kern/sys_procdesc.c | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/sys/kern/sys_procdesc.c b/sys/kern/sys_procdesc.c
+index 9360ec147f8..2687fd3a514 100644
+--- a/sys/kern/sys_procdesc.c
++++ b/sys/kern/sys_procdesc.c
+@@ -404,6 +404,31 @@ procdesc_close(struct file *fp, struct thread *td)
+ 			 */
+ 			p->p_sigparent = SIGCHLD;
+ 			if ((p->p_flag & P_TRACED) == 0) {
++				/*
++				 * nextbsd#179: the other orphan-onto-the-reaper
++				 * site, and the reason libcasper tools leaked.
++				 * exit1() flags its own reparented children so
++				 * the kernel can reap them if the reaper turns
++				 * out to be init, which does not wait(2) on
++				 * NextBSD; this path reparents too, and without
++				 * the flag the process we are about to SIGKILL
++				 * exits with p_pptr == initproc, takes no
++				 * autoreap branch, and is left a zombie that
++				 * the sweep cannot even see.
++				 *
++				 * Measured: every Capsicum-sandboxed tool in
++				 * base -- strings, md5, head, tail -- pdforks
++				 * libcasper helpers that end here, so each run
++				 * leaked exactly one.
++				 *
++				 * Nothing further is needed: the process is
++				 * still alive at this point, so its own exit1()
++				 * enqueues the sweep the same way any other
++				 * orphan does. The PRS_ZOMBIE branch above is
++				 * already correct -- it proc_reap()s on the
++				 * spot.
++				 */
++				p->p_flag2 |= P2_ORPHAN_AUTOREAP;
+ 				proc_reparent(p, p->p_reaper, true);
+ 			} else {
+ 				proc_clear_orphan(p);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -32,3 +32,6 @@
 0032-bcm2835-firmware-report-soc-temperature-and-throttling.patch
 0033-bcm2835_fbd-trust-the-firmware-applied-depth.patch
 0034-bcm2835_fbd-believe-the-stride-not-the-claimed-depth.patch
+0035-kern_exit-sweep-zombies-adopted-after-death.patch
+0036-kern_exit-stop-autoreap-sweep-re-arming-every-tick.patch
+0037-procdesc-flag-processes-orphaned-onto-the-reaper.patch


### PR DESCRIPTION
Closes #177, #179, #180. One kernel so testers exercise all three at once.

#174 fixed the case it was built for — an orphan that is still alive when init adopts it — and hardware measurement after it landed turned up three more things. Two are defects in that patch; one is a second code path it never knew about, and that one is what people were still seeing.

| patch | issue | what |
|---|---|---|
| 0030 | #177 | a child **already a zombie** when init adopts it never gets a sweep scheduled |
| 0031 | #180 | the sweep **re-arms every tick forever** — 0.3% of a core idle, `proctree_lock` taken `hz` times a second |
| 0032 | #179 | `procdesc_close()` is a **second orphan-onto-the-reaper site** #174 never flagged — the actual cause of the reported residue |

The order is load-bearing, see below.

## 0032 (#179) — the one that fixes the symptom

@probonopd, hours into running the merged kernel: still ~20 zombies, not growing by the minute, and `md5`, `strings`, `tail`.

Those names are the whole diagnosis. Every Capsicum-sandboxed tool in base gets its file access through **libcasper**, which `pdfork()`s helpers. `ktrace` of one `strings /boot/kernel/kernel`:

```
848 strings  CALL  pdfork(...,0)
849 strings  RET   pdfork 0            <- casper helper
849 strings  CALL  fork
850 strings  CALL  pdfork(...,0)       <- casper service
850 strings  CALL  _exit(0)
848 strings  CALL  cap_enter
```

Those helpers end their lives in `procdesc_close()`, which has two branches — and only the first was ever safe (`sys/kern/sys_procdesc.c`):

```c
		if (p->p_state == PRS_ZOMBIE) {
			proc_reap(curthread, p, NULL, 0);      /* fine */
		} else {
			...
			p->p_sigparent = SIGCHLD;
			if ((p->p_flag & P_TRACED) == 0)
				proc_reparent(p, p->p_reaper, true);   /* -> init, unflagged */
			...
			if ((pd->pd_flags & PDF_DAEMON) == 0)
				kern_psignal(p, SIGKILL);
		}
```

So the process is handed to init and then killed, and its `exit1()` finds `p_pptr == initproc` with no `P2_ORPHAN_AUTOREAP`. No autoreap branch, `signal_parent = 1`, launchd gets a SIGCHLD it does not wait on — a permanent zombie that the sweep **cannot even see**, since the sweep only considers flagged processes.

Fix: set the flag there too. Nothing else, because the process is still alive at that point, so its own `exit1()` enqueues the sweep like any other orphan.

**Reproduced** — 12 lines, no shell, no pipeline:

```c
#include <sys/procdesc.h>
#include <unistd.h>
#include <stdio.h>
int main(void) {
	int fd; pid_t p;
	p = pdfork(&fd, 0);            /* exactly what libcasper does */
	if (p == 0) { for (;;) pause(); }
	printf("%d\n", (int)p);
	return (0);                    /* exit closes fd -> procdesc_close() */
}
```

```
$ C=$(./pdt); sleep 5; ps -o pid,ppid,state,ucomm -p $C
  887    1 Z    pdt          <- permanent
```

**How it was distinguished from #177**, which is a different mechanism with the same symptom: with eleven of these standing, orphaning a *live* child onto init — #174's covered case — got that child collected, proving a sweep ran, and left all eleven untouched. The sweep scans every flagged zombie child of init, so surviving it means they were never flagged.

## 0031 (#180) — the sweep never stopped running

```c
			if (p->p_state == PRS_ZOMBIE)
				break;
			/* Flagged but still running: ... come back for it */
			again = true;
```

That comment assumed "flagged and not a zombie" means "mid-exit". It means "was orphaned onto init", which is a permanent property of every double-forking daemon on the box:

```
$ ps -axo pid,ppid,state,ucomm | awk '$2==1 && $3 !~ /^Z/'
129    1 Is   gdnc
148    1 Is   gpbs
$ launchctl list | awk 'NR>1 && $1 != "-" {print $1}'
23 24 25 26 27 28 49 30 31 22 32 242 34 35 36 38 43      <- 129 and 148 absent
```

So `again` was true on every pass and the task re-armed itself every tick for the life of the machine. Otherwise-idle Pi 500+, `kern.hz=1000`, load average 0.08:

```
thread taskq CPU:  0:21.86 -> 0:22.04 over 60s = 0.18s/60s = 0.3% of a core
uptime 9h38m, 21.9s accumulated                = same rate since boot
```

0.3% of a core forever is bad on a Pi. `proctree_lock` exclusive `hz` times a second, systemwide, is worse — it serialises fork, exit, wait and reparenting, and each pass holds it for a full walk of init's children.

Fix: gate the re-arm on `P2_WEXIT`, which is the state the comment meant. `proc_set_p2_wexit()` runs at the top of `exit1()`, long before the flag site and the enqueue, so anything that scheduled a sweep already carries it and the window is microseconds wide. A living orphan has it clear and arms nothing.

Missing a re-arm is harmless anyway: every flagged process enqueues a sweep from its own `exit1()`, so the re-arm only covers a task firing before `PRS_ZOMBIE` is set.

## 0030 (#177) — and why the order matters

`exit1()` flags children as it reparents them, but the enqueue is gated on a process's **own** `exit1()` running with `p_pptr == initproc`. A child that was already a zombie ran that code long before, under its real parent and without the flag — so nothing enqueued a sweep for it, and nothing ever will on its behalf.

The existing `PRS_ZOMBIE` branch already knows the situation, so note it there and widen the enqueue:

```c
if (q->p_state == PRS_ZOMBIE) {
        if (q->p_reaper == initproc)
                adopted_zombie = true;
        ...
}
...
if (autoreap || adopted_zombie)
        taskqueue_enqueue_timeout(taskqueue_thread, &nextbsd_autoreap_task, 1);
```

**This has to precede 0031.** Today the endless sweep collects such a zombie within a tick (measured: ~60ms), which masks the missing enqueue entirely — that is why this ticket originally looked like the answer to probono's 20 and was not. Fixing the spin without this in place would turn a masked defect into a visible one.

Gated on `q->p_reaper == initproc` to match the sweep's scope, so a userland reaper from `procctl(PROC_REAP_ACQUIRE)` still collects its own children. The flag is set inside the loop and acted on after it, because `taskqueue_enqueue_timeout()` takes a sleepable mutex and cannot run under `PROC_LOCK(q)` + `proctree_lock`, nor under the `PROC_SLOCK` section further down.

## XNU, for the record

#174's argument was "do what XNU does". `bsd/kern/kern_exit.c`, the same reparent loop:

```c
if (q->p_stat == SZOMB) {
        ...
        reap_child_locked(p, q, REAP_DEAD_PARENT | REAP_LOCKED | reparent_flags);
```

It reaps in the kernel, right there, with no signal to launchd — 0030's case. Measured on macOS 26.6.2 to match: an already-zombie child stays a zombie exactly as long as its parent is alive (correct — nobody waited), then is gone at the first 20ms sample after the parent exits.

Ours differs in two deliberate ways: it defers to a taskqueue, because FreeBSD's `proc_reap()` cannot run under the locks held in that loop, costing one tick (~1ms at `kern.hz=1000`); and it gates on `p_reaper == initproc`, because FreeBSD has `procctl(PROC_REAP_ACQUIRE)` and XNU has no equivalent.

## Not covered, and not coverable

A zombie whose parent is **alive** and never calls `wait()`. No PID 1 fix reaches that — here it is `gpbs` under LoginWindow, #173. `ps ax | grep defunct` cannot tell it apart, since the args column is cleared on exit, but `ucomm` and the parent survive:

```sh
ps -axo pid,ppid,state,ucomm | awk '$3 ~ /^Z/'
```

- **PPID 1** → one of the three fixed here
- **PPID a live process** → that process is not reaping; different bug

## Testing

The 32-patch series applies cleanly to `releng/15.1` at `88e7371d9dc`. Not yet on hardware — that is what this PR is for.

Grab `kernel8.img` from this PR's `kernel (arm64, aarch64)` run artifact, back up the existing one and swap it in on the FAT partition:

```sh
mkdir -p /mnt/boot && mount_msdosfs /dev/nda0s1 /mnt/boot
cp /mnt/boot/kernel8.img /mnt/boot/kernel8.prev
cp /path/to/kernel8.img /mnt/boot/kernel8.img
umount /mnt/boot && reboot
```

### 1. #179 — the reported symptom

```sh
ps -axo state= | grep -c Z          # `ps ax | grep defunct | wc -l` counts the grep too
strings /boot/kernel/kernel | grep BSD >/dev/null
md5 /boot/kernel/kernel >/dev/null
sleep 2
ps -axo pid,ppid,state,ucomm | awk '$3 ~ /^Z/'
```

**Pass:** no new PPID-1 zombie. Before this PR each of those two commands leaves one behind, permanently.

### 2. #180 — the sweep is quiet again

```sh
ps -axHo tid,time,comm | grep 'thread taskq'
sleep 60
ps -axHo tid,time,comm | grep 'thread taskq'
```

**Pass:** essentially no change over 60s. Before, it accrues ~0.18s per minute forever.

### 3. #177 — both orphan cases

```sh
sh -c '/bin/sleep 2 & exit 0'        # orphan alive at adoption   (#174)
sh -c '/usr/bin/true & /bin/sleep 2' # orphan already dead        (#177)
sleep 4; ps -axo pid,ppid,state,ucomm | awk '$3 ~ /^Z/'
```

**Pass:** neither leaves a PPID-1 zombie. This one is a regression check on 0030 against 0031 — before this PR the second case passes only because of the spin 0031 removes.

### 4. Nothing regressed in launchd's own bookkeeping

```sh
launchctl list
```

**Pass:** jobs still show live PIDs, and `LastExitStatus` still populates for jobs that have exited. The whole point of flagging rather than blanket-reaping is that launchd keeps getting its own children's exit status; if a job's status came back empty, that would be this PR's fault.

Pre-existing zombies from before the reboot are gone after it, so any that appear are new.
