### PR TITLE
linuxkpi: add dma_mmap_wc, dma_get_sgtable and vm_flags_mod for the DRM DMA GEM helpers (#176)

### DIFF
--- a/patches/0039-linuxkpi-dma_mmap_wc-get_sgtable-and-vm_flags_mod.patch
+++ b/patches/0039-linuxkpi-dma_mmap_wc-get_sgtable-and-vm_flags_mod.patch
@@ -1,0 +1,152 @@
+From 3d7fca745a50514bbcd8564177cb265a30616b1c Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Thu, 3 Sep 2026 19:30:07 -0500
+Subject: [PATCH] linuxkpi: dma_mmap_wc, dma_mmap_pages, dma_get_sgtable and
+ vm_flags_mod
+
+Second round of what the DRM DMA GEM helpers need. #181 got
+drm_gem_dma_create() and drm_gem_dma_free() building; the compiler then
+reached drm_gem_dma_mmap() and drm_gem_dma_get_sg_table() and stopped on four
+more symbols. None of the five from #181 reappeared.
+
+Measured against the source, same as last time:
+
+	drm_gem_dma_mmap()				line
+	  vm_flags_mod(vma, VM_DONTEXPAND, VM_PFNMAP)	533	LIVE
+	  if (map_noncoherent) dma_mmap_pages		538	dead
+	  else                 dma_mmap_wc		542	LIVE
+	drm_gem_dma_get_sg_table()
+	  dma_get_sgtable				431	compile-only
+
+dma_mmap_wc() is the one that has to work: it is how X maps the front buffer
+it allocated through dumb_create(), so the mmap path is required even though
+vc4_firmware_kms itself never touches it. The memory came from
+dma_alloc_wc(), which allocates contiguously, so a single remap_pfn_range()
+over vtophys() covers it with no scatter to walk. Size is in bytes, matching
+both Linux and lkpi_remap_pfn_range(), which iterates until start + size.
+
+vm_flags_mod() is the pair of vm_flags_set()/vm_flags_clear() sitting
+directly above it. Linux's argument order is (set, clear) and set is applied
+first, so a flag named in both ends up cleared.
+
+dma_mmap_pages() is dead for the same reason dma_alloc_noncoherent() is --
+map_noncoherent is never set by anything here. Unlike the allocator it gets
+no warning: it is one remap_pfn_range() over a page the caller already holds,
+with no unexercised synchronisation behind it, so there is nothing to warn
+about.
+
+dma_get_sgtable() has to exist because drm_gem_dma_default_funcs wires
+.get_sg_table unconditionally, but it is reached only on the PRIME *export*
+path. The DMA GEM driver ops wire up only the import half
+(.gem_prime_import_sg_table), so on a single-GPU machine nothing calls it.
+One scatterlist entry is always enough, again because the allocation is
+contiguous.
+
+Refs nextbsd-kernel#176.
+---
+ .../common/include/linux/dma-mapping.h        | 64 +++++++++++++++++++
+ sys/compat/linuxkpi/common/include/linux/mm.h | 13 ++++
+ 2 files changed, 77 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/dma-mapping.h b/sys/compat/linuxkpi/common/include/linux/dma-mapping.h
+index aeb567411e8..a704220509f 100644
+--- a/sys/compat/linuxkpi/common/include/linux/dma-mapping.h
++++ b/sys/compat/linuxkpi/common/include/linux/dma-mapping.h
+@@ -245,6 +245,70 @@ dma_free_noncoherent(struct device *dev, size_t size, void *cpu_addr,
+ 	dma_free_coherent(dev, size, cpu_addr, dma_addr);
+ }
+ 
++/*
++ * nextbsd-kernel#176: mapping a DMA buffer into userspace, and describing one
++ * as a scatterlist. Both are reached through the DRM DMA GEM helpers.
++ *
++ * dma_mmap_wc() is the live path and the reason this matters: it is how X maps
++ * the front buffer it allocated through dumb_create(). The memory came from
++ * dma_alloc_wc() above, so it is physically contiguous and a single
++ * remap_pfn_range() over vtophys() covers it -- there is no scatter to walk.
++ *
++ * Size is in bytes, matching both Linux and lkpi_remap_pfn_range(), which
++ * iterates until start + size.
++ */
++static inline int
++dma_mmap_wc(struct device *dev __unused, struct vm_area_struct *vma,
++    void *cpu_addr, dma_addr_t dma_addr __unused, size_t size)
++{
++
++	vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
++	return (remap_pfn_range(vma, vma->vm_start,
++	    vtophys(cpu_addr) >> PAGE_SHIFT, size, vma->vm_page_prot));
++}
++
++/*
++ * The non-coherent counterpart, and dead for the same reason
++ * dma_alloc_noncoherent() is: drm_gem_dma_mmap() only reaches it when
++ * map_noncoherent is set, and nothing in this tree sets it. Unlike the
++ * allocator it needs no warning -- it is one remap_pfn_range() over a page the
++ * caller already holds, with no unexercised synchronisation behind it.
++ */
++static inline int
++dma_mmap_pages(struct device *dev __unused, struct vm_area_struct *vma,
++    size_t size, struct page *page)
++{
++
++	return (remap_pfn_range(vma, vma->vm_start, page_to_pfn(page), size,
++	    vma->vm_page_prot));
++}
++
++/*
++ * dma_get_sgtable() has to exist because drm_gem_dma_default_funcs wires
++ * .get_sg_table unconditionally, but it is only ever called on the PRIME
++ * *export* path -- handing a buffer to a second driver. The DMA GEM driver ops
++ * wire up only the import half (.gem_prime_import_sg_table), so on a
++ * single-GPU machine nothing calls this.
++ *
++ * One entry is always enough: the buffer came from dma_alloc_wc(), which
++ * allocates contiguously.
++ */
++static inline int
++dma_get_sgtable(struct device *dev __unused, struct sg_table *sgt,
++    void *cpu_addr, dma_addr_t dma_addr, size_t size)
++{
++	int error;
++
++	error = sg_alloc_table(sgt, 1, GFP_KERNEL);
++	if (error != 0)
++		return (error);
++	sg_set_page(sgt->sgl, virt_to_page(cpu_addr), size,
++	    offset_in_page(cpu_addr));
++	sg_dma_address(sgt->sgl) = dma_addr;
++	sg_dma_len(sgt->sgl) = size;
++	return (0);
++}
++
+ static inline void
+ dmam_free_coherent(struct device *dev, size_t size, void *addr,
+     dma_addr_t dma_handle)
+diff --git a/sys/compat/linuxkpi/common/include/linux/mm.h b/sys/compat/linuxkpi/common/include/linux/mm.h
+index a639c094703..e15f9a087a2 100644
+--- a/sys/compat/linuxkpi/common/include/linux/mm.h
++++ b/sys/compat/linuxkpi/common/include/linux/mm.h
+@@ -395,6 +395,19 @@ vm_flags_clear(struct vm_area_struct *vma, unsigned long flags)
+ 	vma->vm_flags &= ~flags;
+ }
+ 
++/*
++ * nextbsd-kernel#176: set and clear in one call, which is what
++ * drm_gem_dma_mmap() uses to swap VM_PFNMAP for VM_DONTEXPAND. Argument order
++ * is Linux's -- set first, then clear -- and set is applied first, so a flag
++ * named in both ends up cleared.
++ */
++static inline void
++vm_flags_mod(struct vm_area_struct *vma, unsigned long set,
++    unsigned long clear)
++{
++	vma->vm_flags = (vma->vm_flags | set) & ~clear;
++}
++
+ static inline struct page *
+ vmalloc_to_page(const void *addr)
+ {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -36,3 +36,4 @@
 0036-kern_exit-stop-autoreap-sweep-re-arming-every-tick.patch
 0037-procdesc-flag-processes-orphaned-onto-the-reaper.patch
 0038-linuxkpi-dma_alloc_wc-noncoherent-and-iosys-map-init-vaddr.patch
+0039-linuxkpi-dma_mmap_wc-get_sgtable-and-vm_flags_mod.patch


### PR DESCRIPTION
Second round of what the DRM DMA GEM helpers need, after #181. Towards #176.

## Where this picks up

#181 got `drm_gem_dma_create()` and `drm_gem_dma_free()` compiling. The measured result on the `drm_dma_helpers` branch: **none of those five symbols reappeared**, and the compiler reached line 431 instead of 147 before stopping on four new ones.

```
=== drm_dma_helpers.ko ===
NOT BUILT -- first errors:
  drm_gem_dma_helper.c:431  dma_get_sgtable
  drm_gem_dma_helper.c:533  vm_flags_mod
  drm_gem_dma_helper.c:538  dma_mmap_pages
  drm_gem_dma_helper.c:542  dma_mmap_wc
```

## Which of them matter

Same measurement as last time, against the source rather than assumed:

```c
drm_gem_dma_mmap()                                  line
  vm_flags_mod(vma, VM_DONTEXPAND, VM_PFNMAP)        533   LIVE
  if (dma_obj->map_noncoherent) dma_mmap_pages       538   dead branch
  else                          dma_mmap_wc          542   LIVE
drm_gem_dma_get_sg_table()
  dma_get_sgtable                                    431   compile-only
```

**`dma_mmap_wc()` is the one that has to work.** `vc4_firmware_kms` never calls it, but X does — it is how the front buffer allocated through `dumb_create()` gets mapped for writing. Same shape as the last round: the driver doesn't want these helpers, the display server does.

The memory came from `dma_alloc_wc()`, which allocates contiguously, so one `remap_pfn_range()` over `vtophys()` covers it — there is no scatter to walk. Size is in bytes, matching both Linux and `lkpi_remap_pfn_range()`, which iterates until `start + size`.

**`vm_flags_mod()`** is the pair of the `vm_flags_set()`/`vm_flags_clear()` already sitting directly above it in `linux/mm.h`. Linux's argument order is `(set, clear)` and set is applied first, so a flag named in both ends up cleared — which matters, because the call site is swapping `VM_PFNMAP` for `VM_DONTEXPAND`.

**`dma_mmap_pages()`** is dead for the same reason `dma_alloc_noncoherent()` was: `map_noncoherent` is never set by `vc4` or `vc4_firmware_kms`. Unlike the allocator it gets **no** warning — it is one `remap_pfn_range()` over a page the caller already holds, with no unexercised synchronisation behind it, so there is nothing to warn about.

**`dma_get_sgtable()`** has to exist because the object funcs wire it unconditionally:

```c
static const struct drm_gem_object_funcs drm_gem_dma_default_funcs = {
	.get_sg_table = drm_gem_dma_object_get_sg_table,
	...
};
```

but it is only reached on the PRIME **export** path, and the driver ops wire up only the import half:

```c
#define DRM_GEM_DMA_DRIVER_OPS_WITH_DUMB_CREATE(dumb_create_func) \
	.dumb_create		   = (dumb_create_func), \
	.gem_prime_import_sg_table = drm_gem_dma_prime_import_sg_table
```

Import, no export. On a single-GPU machine with X talking to one KMS device, nothing calls it. One scatterlist entry is always enough anyway, again because the allocation is contiguous.

## Risk to existing drivers

Lower than #181's. Everything here is **purely additive** — four new inlines, no existing function touched, so no shared code path changes for i915, amdgpu, radeon or nvidia-drm. #181 had one genuinely shared edit (the `linux_dma_alloc_coherent` refactor); this has none.

Checked for redefinition collisions the same way, since that is the failure mode that would break every DRM driver at once:

```
drm-kmod 6.12-lts    dma_mmap_wc, dma_mmap_pages, dma_get_sgtable, vm_flags_mod    0 files
vendored graphics/   same four                                                     0 files
```

## Testing

The 39-patch series applies cleanly to `releng/15.1` at `88e7371d9dc`.

As with #181, this is a prerequisite rather than a result. It gets proven by rebuilding nextbsd-kernel-extensions#42 against the refreshed `continuous` — and note the kernel does **not** cascade to the modules repo on a merge (`Trigger module build` is gated on `repository_dispatch`), so that rebuild has to be kicked off deliberately.
