### PR TITLE
linuxkpi: fix to_platform_device() capturing its own parameter name (#176)

### DIFF
--- a/patches/0041-linuxkpi-fix-to_platform_device-parameter-capture.patch
+++ b/patches/0041-linuxkpi-fix-to_platform_device-parameter-capture.patch
@@ -1,0 +1,73 @@
+From c2a501e00c2dd5a403c7babc4bacd81139a830b8 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Fri, 4 Sep 2026 01:07:43 -0500
+Subject: [PATCH] linuxkpi: fix to_platform_device() capturing its own
+ parameter name
+
+The macro added in the previous patch names its parameter `dev`, which is
+also the member name it passes to container_of. The preprocessor substitutes
+both, so
+
+	to_platform_device(drm->dev)
+
+expands to container_of(drm->dev, struct platform_device, drm->dev) and fails
+four ways at once:
+
+	drm_aperture.c:150: expected ')'
+	drm_aperture.c:150: member reference type 'struct device' is not a pointer
+	drm_aperture.c:150: no member named 'dev' in 'struct device'
+	drm_aperture.c:150: assigning to 'struct platform_device *' from 'void'
+
+That broke the whole drm-kmod build, which is every DRM driver, and was
+caught by the CI gate added in nextbsd-kernel-extensions#43 -- before that
+change the job would have gone green over it.
+
+Rename the parameter to _dev.
+
+Also revert dev_is_platform() to false. There is no flag on struct device
+recording that it came from the platform bus, and answering true
+unconditionally makes drm_aperture's "the given device is not a platform
+device" guard pass for a PCI device, which is worse than the conservative
+answer. Nothing in this tree needs it to be true; fkms never calls it.
+
+Refs nextbsd-kernel#176, #183.
+---
+ .../common/include/linux/platform_device.h    | 22 ++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+index 2b56131b7ae..3e64707c8e8 100644
+--- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
++++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+@@ -59,9 +59,25 @@ struct platform_driver {
+  * did nothing. struct platform_device already embeds struct device, so the
+  * cast is the ordinary container_of.
+  */
+-#define	dev_is_platform(dev)	(true)
+-#define	to_platform_device(dev)	\
+-	container_of(dev, struct platform_device, dev)
++/*
++ * dev_is_platform() stays false. There is no flag on struct device saying it
++ * came from the platform bus, and answering true unconditionally would make
++ * drm_aperture's "the given device is not a platform device" guard pass for a
++ * PCI device -- which is worse than the conservative answer. Nothing in this
++ * tree needs it to be true.
++ */
++#define	dev_is_platform(dev)	(false)
++
++/*
++ * The parameter is _dev, not dev: `dev` is also the member name, so a macro
++ * parameter called dev is substituted into the member argument as well.
++ * to_platform_device(drm->dev) then expands to
++ * container_of(drm->dev, struct platform_device, drm->dev), which fails in
++ * four different ways at once. That is exactly how this broke drm_aperture.c
++ * after the first version landed.
++ */
++#define	to_platform_device(_dev)	\
++	container_of(_dev, struct platform_device, dev)
+ 
+ static __inline void *
+ platform_get_drvdata(const struct platform_device *pdev)
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -38,3 +38,4 @@
 0038-linuxkpi-dma_alloc_wc-noncoherent-and-iosys-map-init-vaddr.patch
 0039-linuxkpi-dma_mmap_wc-get_sgtable-and-vm_flags_mod.patch
 0040-linuxkpi-platform-device-of-lookups-and-component.patch
+0041-linuxkpi-fix-to_platform_device-parameter-capture.patch


### PR DESCRIPTION
Regression from #183, which I merged an hour ago. It broke **the entire drm-kmod build** — every DRM driver.

## The bug

```c
#define to_platform_device(dev)	container_of(dev, struct platform_device, dev)
```

The parameter is named `dev`, and so is the member. The preprocessor substitutes both, so

```c
to_platform_device(drm->dev)
```

expands to `container_of(drm->dev, struct platform_device, drm->dev)` and fails four ways at once:

```
drm_aperture.c:150: expected ')'
drm_aperture.c:150: member reference type 'struct device' is not a pointer
drm_aperture.c:150: no member named 'dev' in 'struct device'
drm_aperture.c:150: assigning to 'struct platform_device *' from 'void'
```

Renaming the parameter to `_dev` fixes it. The comment on the macro now says why, because the next person to touch it will reach for `dev` again.

## Also: dev_is_platform() goes back to false

#183 flipped it to `true`, which was wrong for a different reason. Nothing on `struct device` records that it came from the platform bus, so answering `true` unconditionally makes drm_aperture's *"the function also fails if the given device is not a platform device"* guard pass for a **PCI** device. The conservative answer is the correct one, and nothing in this tree needs it otherwise — fkms never calls it.

## Worth noting how this was caught

#183's own CI passed: the **kernel** builds fine, because nothing in the kernel proper calls `to_platform_device`. The break only appears when drm-kmod compiles against it, which is a different repo and a different job.

nextbsd-kernel-extensions#43 is what surfaced it. Before that change the drm-kmod build carried `continue-on-error`, its summarize steps printed gaps without failing, and this would have gone green — a total build failure of every graphics driver, reported as success. Instead the job failed with every gated module red:

```
failure  Build drm-kmod (6.12-lts) against the kernel obj
failure  Summarize helper build gaps
failure  Summarize virtio shim build gaps
failure  Summarize DMA helper build gaps
failure  Summarize shmem helper build gaps
failure  Summarize virtio-gpu build gaps
```

That is the gate doing exactly what it was written for, one day after landing.

## Testing

41-patch series applies cleanly to `releng/15.1` at `88e7371d9dc`. The real check is the drm-kmod build in nextbsd-kernel-extensions going green again, which needs this merged and `continuous` refreshed.