### PR TITLE
linuxkpi: refcount_dec_not_one, pm_runtime_put_sync_suspend, platform_get_irq_byname (#51)

### DIFF
--- a/patches/0045-linuxkpi-refcount-pm-runtime-and-platform-irq-byname.patch
+++ b/patches/0045-linuxkpi-refcount-pm-runtime-and-platform-irq-byname.patch
@@ -1,0 +1,121 @@
+From 9a108a17c7cc0959a9ba76b47a59c859c5309ee6 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 10:49:38 -0500
+Subject: [PATCH] linuxkpi: refcount_dec_not_one, pm_runtime_put_sync_suspend
+ and platform_get_irq_byname
+
+Three small additions the full vc4 KMS display pipeline needs
+(nextbsd-kernel-extensions#51). Firmware KMS cannot program a plane on
+BCM2712 -- the 2712 firmware does not service SET_PLANE, measured against a
+control tag sent down the identical mailbox path -- so the real display
+pipeline is a separate driver, and a compile probe of it enumerated what
+LinuxKPI is missing.
+
+refcount_dec_not_one() returns false when the refcount was already 1, meaning
+the caller now holds the last reference and owns teardown, and true otherwise
+including the saturated case. Callers use it to avoid taking a destroy path
+from inside a loop. Implemented as a cmpxchg loop rather than a plain
+decrement, because the "was it 1" test and the decrement have to be one
+atomic step.
+
+pm_runtime_put_sync_suspend() is a no-op, matching every other entry point in
+that header -- LinuxKPI does not implement runtime PM. Defined separately from
+pm_runtime_put() rather than aliased to it so a real implementation can tell
+the two apart later.
+
+platform_get_irq_byname() answers with the device's single IRQ for any name.
+struct device carries one irq, so that is the honest limit of what it can
+report; a driver needing several named interrupts needs real interrupt-names
+parsing, and this is not a substitute for it. Said so in the comment, so the
+next person does not mistake it for one.
+---
+ .../common/include/linux/platform_device.h    | 20 +++++++++++++++
+ .../common/include/linux/pm_runtime.h         |  6 +++++
+ .../linuxkpi/common/include/linux/refcount.h  | 25 +++++++++++++++++++
+ 3 files changed, 51 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+index 3e64707c8e8..11b92cf4839 100644
+--- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
++++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+@@ -113,6 +113,26 @@ platform_get_irq(struct platform_device *pdev, unsigned int num)
+ 	return ((int)pdev->dev.irq);
+ }
+ 
++/*
++ * Named interrupts are how a device-tree driver asks for one of several IRQs
++ * without hardcoding an index -- the names come from interrupt-names in the
++ * DT node.
++ *
++ * struct device carries a single irq, so this can honestly answer only for a
++ * device with one interrupt. Rather than guess which name that is, return it
++ * for any name and let the caller's own DT contract decide; a driver that
++ * needs several named interrupts needs real interrupt-names parsing here, and
++ * this returning the sole IRQ is not a substitute for that.
++ */
++static __inline int
++platform_get_irq_byname(struct platform_device *pdev, const char *name)
++{
++
++	if (pdev->dev.irq == LINUX_IRQ_INVALID)
++		return (-ENXIO);
++	return ((int)pdev->dev.irq);
++}
++
+ static __inline int
+ platform_driver_register(struct platform_driver *pdrv)
+ {
+diff --git a/sys/compat/linuxkpi/common/include/linux/pm_runtime.h b/sys/compat/linuxkpi/common/include/linux/pm_runtime.h
+index 6114b7b159d..aeb0e3d08e0 100644
+--- a/sys/compat/linuxkpi/common/include/linux/pm_runtime.h
++++ b/sys/compat/linuxkpi/common/include/linux/pm_runtime.h
+@@ -17,6 +17,12 @@
+ #define pm_runtime_forbid(x) (void)(x)
+ #define pm_runtime_get_noresume(x) (void)(x)
+ #define pm_runtime_put(x) (void)(x)
++/*
++ * Same no-op as the rest of this header: LinuxKPI does not implement
++ * runtime PM. Kept distinct from pm_runtime_put() rather than aliased to
++ * it so a real implementation can tell the two apart later.
++ */
++#define pm_runtime_put_sync_suspend(x) (void)(x)
+ #define pm_runtime_enable(x) (void)(x)
+ #define pm_runtime_disable(x) (void)(x)
+ #define pm_runtime_autosuspend(x) (void)(x)
+diff --git a/sys/compat/linuxkpi/common/include/linux/refcount.h b/sys/compat/linuxkpi/common/include/linux/refcount.h
+index 46e501a6539..7b739c2668e 100644
+--- a/sys/compat/linuxkpi/common/include/linux/refcount.h
++++ b/sys/compat/linuxkpi/common/include/linux/refcount.h
+@@ -82,4 +82,29 @@ refcount_dec_and_test(refcount_t *r)
+ 	return (atomic_dec_and_test(r));
+ }
+ 
++/*
++ * Decrement unless the value is already one, reporting whether it did.
++ *
++ * Linux returns false when the refcount was 1 -- meaning the caller now holds
++ * the last reference and is responsible for teardown -- and true in every
++ * other case, including the saturated one. Callers use it to avoid taking a
++ * destroy path from inside a loop.
++ *
++ * A cmpxchg loop rather than a plain decrement, because the "was it 1" test
++ * and the decrement have to be a single atomic step.
++ */
++static inline bool
++refcount_dec_not_one(refcount_t *r)
++{
++	int old;
++
++	for (;;) {
++		old = atomic_read(r);
++		if (old == 1)
++			return (false);
++		if (atomic_cmpxchg(r, old, old - 1) == old)
++			return (true);
++	}
++}
++
+ #endif /* __LINUXKPI_LINUX_REFCOUNT_H__ */
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -42,3 +42,4 @@
 0042-bcm2712-l2-interrupt-controller.patch
 0043-linuxkpi-dma_priv-init-for-non-pci-devices.patch
 0044-linuxkpi-request_irq-for-non-pci-devices.patch
+0045-linuxkpi-refcount-pm-runtime-and-platform-irq-byname.patch


### PR DESCRIPTION
Three small LinuxKPI additions, each measured by a compile probe rather than guessed. Toward nextbsd/nextbsd-kernel-extensions#51.

## Why these three

Firmware KMS (nextbsd/nextbsd-kernel-extensions#44) brings a Pi 5 display up — it attaches, creates `/dev/dri/card0` and delivers vblank — but it cannot program a plane, because the BCM2712 firmware does not service `SET_PLANE`. That was established by experiment, not inference: `GET_FIRMWARE_REVISION` sent down the *identical* mailbox path returns with the firmware's response bit set, and `SET_PLANE` does not (nextbsd/nextbsd-kernel-extensions#48).

So the real display pipeline is a separate driver, and a compile probe of it enumerated what LinuxKPI is missing. These are the three that belong in the kernel; the rest are drm-kmod or further device-model work.

## What each one does

**`refcount_dec_not_one()`** — returns false when the refcount was already 1, meaning the caller now holds the last reference and owns teardown, and true otherwise including the saturated case. Callers use it to avoid taking a destroy path from inside a loop.

Implemented as a cmpxchg loop rather than a plain decrement, because the "was it 1" test and the decrement have to be a single atomic step:

```c
for (;;) {
        old = atomic_read(r);
        if (old == 1)
                return (false);
        if (atomic_cmpxchg(r, old, old - 1) == old)
                return (true);
}
```

**`pm_runtime_put_sync_suspend()`** — a no-op, matching every other entry point in that header, since LinuxKPI does not implement runtime PM. Defined separately rather than aliased to `pm_runtime_put()` so a real implementation can tell the two apart later.

**`platform_get_irq_byname()`** — returns the device's single IRQ for any name.

This one has an honest limit, stated in the comment rather than left to be discovered: `struct device` carries one `irq`, so that is all it can truthfully report. A driver needing several named interrupts needs real `interrupt-names` parsing, and this is **not** a substitute for it — it is enough for a device with one interrupt, which is the case in front of us.

## Testing

Kernel builds green on **arm64 and amd64** (run 33976027919).

Verified the way patches in this series should be: reset to a pristine tree, apply the entire series in order, confirm all 45 apply and the symbols land.

```
ALL 45 PATCHES APPLY CLEANLY IN ORDER
  refcount_dec_not_one present
  pm_runtime_put_sync_suspend present
  platform_get_irq_byname present
```

Worth recording why that check matters here: the first version of this patch was generated against a *pristine* tree, so its context showed `to_platform_device(dev) (NULL)` — the form patches 0040/0041 replace. It failed to apply in CI at exactly that hunk. Patches late in this series must be generated against the tree the earlier ones produce.

## Risk

Additive only. Two header-only inlines and one macro; no existing behaviour changes, and nothing here alters a struct layout — so unlike nextbsd/nextbsd-kernel#183, this carries no KBI implications for already-built modules.

Refs nextbsd/nextbsd-kernel-extensions#51.
