### PR TITLE
iokit: match device-tree personalities, not just PCI (#185)

### DIFF
--- a/src-overlay/sys/dev/iokit/iokit_catalogue.c
+++ b/src-overlay/sys/dev/iokit/iokit_catalogue.c
@@ -11,6 +11,7 @@
  */
 
 #include "opt_compat_mach.h"
+#include "opt_platform.h"	/* FDT — device-tree personalities (#185) */
 
 #include <sys/param.h>
 #include <sys/systm.h>
@@ -31,6 +32,11 @@
 
 #include <dev/pci/pcivar.h>
 #include <dev/pci/pcireg.h>	/* PCIC_DISPLAY — vgapci look-through (#64) */
+
+#ifdef FDT
+#include <dev/ofw/ofw_bus.h>	/* ofw_bus_get_compat() — #185 */
+#include <dev/ofw/ofw_bus_subr.h>
+#endif
 
 #ifdef COMPAT_MACH
 /* K3b (#216): the kernel->kextd Mach load-request send (compat/mach/iokit_kextd.c).
@@ -65,6 +71,8 @@ iocat_free_record(struct iocat_record *r)
 {
 	if (r->match != NULL)
 		free(r->match, M_IOCAT);
+	if (r->compat != NULL)
+		free(r->compat, M_IOCAT);
 	free(r, M_IOCAT);
 }
 
@@ -159,6 +167,94 @@ iocat_lookup_pci(uint32_t match_word, char *buf, size_t buflen,
 	return (best != NULL ? 0 : ENOENT);
 }
 
+/*
+ * Add a device-tree personality (nextbsd-kernel-extensions#185).
+ *
+ * The PCI twin of this is iocat_add(). Kept separate rather than widening that
+ * one, because struct iocat_add is duplicated into kextd and is an ABI -- see
+ * the comment on struct iocat_add_compat.
+ */
+static int
+iocat_add_compat(struct iocat_add_compat *ua)
+{
+	struct iocat_record *r;
+	char *compat;
+	size_t sz;
+	uint32_t i;
+	int error;
+
+	if (ua->ncompat == 0 || ua->ncompat > IOCAT_MAX_MATCH)
+		return (EINVAL);
+	ua->bundle_id[IOCAT_BUNDLE_ID_MAX - 1] = '\0';
+	if (ua->bundle_id[0] == '\0')
+		return (EINVAL);
+
+	sz = (size_t)ua->ncompat * IOCAT_COMPAT_MAX;
+	compat = malloc(sz, M_IOCAT, M_WAITOK);
+	error = copyin((const void *)(uintptr_t)ua->compat, compat, sz);
+	if (error != 0) {
+		free(compat, M_IOCAT);
+		return (error);
+	}
+	/*
+	 * Terminate every slot. copyin gives us whatever userland had; a string
+	 * without a NUL would run into the next slot on every later strcmp.
+	 */
+	for (i = 0; i < ua->ncompat; i++)
+		compat[(size_t)i * IOCAT_COMPAT_MAX + IOCAT_COMPAT_MAX - 1] = '\0';
+
+	r = malloc(sizeof(*r), M_IOCAT, M_WAITOK | M_ZERO);
+	strlcpy(r->bundle_id, ua->bundle_id, sizeof(r->bundle_id));
+	r->provider_class = IOCAT_PROVIDER_IOPLATFORMDEVICE;
+	r->probe_score = ua->probe_score;
+	r->ncompat = ua->ncompat;
+	r->compat = compat;
+
+	sx_xlock(&iocat_lock);
+	TAILQ_INSERT_TAIL(&iocat_list, r, link);
+	iocat_count++;
+	sx_xunlock(&iocat_lock);
+
+	/* Same push-triggers-match as the PCI path: a device may already have
+	 * gone unmatched before this personality existed. */
+	iocat_rematch_pending();
+	taskqueue_enqueue(taskqueue_thread, &iocat_present_task);
+	return (0);
+}
+
+int
+iocat_lookup_compat(const char *want, char *buf, size_t buflen,
+    int32_t *score_out)
+{
+	struct iocat_record *r, *best;
+	uint32_t i;
+
+	if (want == NULL || *want == '\0')
+		return (ENOENT);
+
+	best = NULL;
+	sx_slock(&iocat_lock);
+	TAILQ_FOREACH(r, &iocat_list, link) {
+		if (r->provider_class != IOCAT_PROVIDER_IOPLATFORMDEVICE)
+			continue;
+		for (i = 0; i < r->ncompat; i++) {
+			if (strcmp(&r->compat[(size_t)i * IOCAT_COMPAT_MAX],
+			    want) != 0)
+				continue;
+			if (best == NULL || r->probe_score > best->probe_score)
+				best = r;
+			break;
+		}
+	}
+	if (best != NULL) {
+		strlcpy(buf, best->bundle_id, buflen);
+		if (score_out != NULL)
+			*score_out = best->probe_score;
+	}
+	sx_sunlock(&iocat_lock);
+	return (best != NULL ? 0 : ENOENT);
+}
+
 /* ---- K3 (#216): device_nomatch -> match -> request a load from userland ----
  *
  * When newbus probes a device no built-in driver claims, it fires the
@@ -173,8 +269,13 @@ iocat_lookup_pci(uint32_t match_word, char *buf, size_t buflen,
  */
 struct iocat_match_work {
 	STAILQ_ENTRY(iocat_match_work) link;
-	uint32_t	match_word;		/* 0x<device><vendor> */
+	uint32_t	match_word;		/* 0x<device><vendor>; 0 if FDT */
 	char		devname[64];
+	/*
+	 * Device-tree devices have no match word, they have a compatible
+	 * string (#185). Empty means "this is a PCI item, use match_word".
+	 */
+	char		compat[IOCAT_COMPAT_MAX];
 };
 static STAILQ_HEAD(, iocat_match_work) iocat_work =
     STAILQ_HEAD_INITIALIZER(iocat_work);
@@ -206,6 +307,21 @@ iocat_request_load(uint32_t match_word, const char *devname,
 		printf("iokit: %s (0x%08x) matches %s (no kextd channel)\n",
 		    devname, match_word, bundle);
 #endif
+}
+
+/*
+ * Look up whichever kind of work item this is (#185): a device-tree item
+ * carries a compatible string, a PCI item a match word. One place to make that
+ * decision, so the two consumers below cannot drift apart.
+ */
+static int
+iocat_lookup_work(const struct iocat_match_work *w, char *buf, size_t buflen,
+    int32_t *score_out)
+{
+
+	if (w->compat[0] != '\0')
+		return (iocat_lookup_compat(w->compat, buf, buflen, score_out));
+	return (iocat_lookup_pci(w->match_word, buf, buflen, score_out));
 }
 
 /* Remember an unmatched device for push-triggers-match. Takes ownership of w
@@ -245,7 +361,7 @@ iocat_rematch_pending(void)
 
 	while ((w = STAILQ_FIRST(&todo)) != NULL) {
 		STAILQ_REMOVE_HEAD(&todo, link);
-		if (iocat_lookup_pci(w->match_word, bundle, sizeof(bundle),
+		if (iocat_lookup_work(w, bundle, sizeof(bundle),
 		    &score) == 0) {
 			iocat_request_load(w->match_word, w->devname, bundle, score);
 			free(w, M_IOCAT);
@@ -256,6 +372,53 @@ iocat_rematch_pending(void)
 		}
 	}
 }
+
+#ifdef FDT
+/*
+ * Recursively walk an OF subtree looking for present-but-unmatched nodes whose
+ * compatible string the catalogue now claims (#185).
+ *
+ * Recursive because the device tree nests -- ofwbus0 -> simplebus0 -> ... --
+ * and the node we care about can be at any depth. Depth is bounded by the
+ * device tree itself (a handful of levels on a Pi), and each frame is small.
+ */
+static void
+iocat_scan_of_subtree(device_t bus, int *checked, int *unmatched, int *requested)
+{
+	device_t *kids;
+	const char *compat;
+	char bundle[IOCAT_BUNDLE_ID_MAX];
+	int32_t score;
+	int nkids, i;
+
+	if (device_get_children(bus, &kids, &nkids) != 0)
+		return;
+	for (i = 0; i < nkids; i++) {
+		/* Recurse first: a bus with a driver still has children. */
+		iocat_scan_of_subtree(kids[i], checked, unmatched, requested);
+
+		compat = ofw_bus_get_compat(kids[i]);
+		if (compat == NULL || *compat == '\0')
+			continue;	/* not an OF node we can match */
+		(*checked)++;
+		if (device_get_driver(kids[i]) != NULL)
+			continue;	/* already has a real owner */
+		(*unmatched)++;
+		if (iocat_lookup_compat(compat, bundle, sizeof(bundle),
+		    &score) != 0)
+			continue;	/* no personality claims it */
+		if (bootverbose)
+			printf("iokit: present-scan: %s (%s) present + "
+			    "unmatched -> request load %s\n",
+			    device_get_nameunit(kids[i]), compat, bundle);
+		/* match_word 0: this is an FDT match, not a PCI one. */
+		iocat_request_load(0, device_get_nameunit(kids[i]), bundle,
+		    score);
+		(*requested)++;
+	}
+	free(kids, M_TEMP);
+}
+#endif /* FDT */
 
 /*
  * Walk every PCI device currently on the bus; for any with no driver attached
@@ -431,6 +594,38 @@ iocat_rematch_present(void)
 		free(kids, M_TEMP);
 	}
 	free(buses, M_TEMP);
+
+#ifdef FDT
+	/*
+	 * The same scan for device-tree devices (#185).
+	 *
+	 * Everything the comment above says about the PCI capture being
+	 * unreliable applies here too, and an OF device cannot be found by the
+	 * PCI walk at all -- it is on ofwbus/simplebus, not under a pci bus. A
+	 * Pi 5 shows the case this exists for:
+	 *
+	 *	ofwbus0: <firmwarekms> irq 12 compat raspberrypi,rpi-firmware-kms-2712 (no driver attached)
+	 *
+	 * present, unmatched, and invisible to the loop above.
+	 *
+	 * Walks every devclass rather than a named bus, because OF devices hang
+	 * off ofwbus, simplebus, and any number of nested simplebuses; asking
+	 * for a compatible string and skipping devices that do not have one is
+	 * both simpler and more complete than enumerating bus names.
+	 */
+	{
+		device_t *devs;
+		int ndevs, i;
+
+		if (devclass_get_devices(devclass_find("ofwbus"), &devs,
+		    &ndevs) == 0) {
+			for (i = 0; i < ndevs; i++)
+				iocat_scan_of_subtree(devs[i], &checked,
+				    &unmatched, &requested);
+			free(devs, M_TEMP);
+		}
+	}
+#endif
 	/* One summary line, under bootverbose, so a verbose boot can confirm the
 	 * scan ran even when every present device is already attached (qemu) and
 	 * no per-device line is printed. Quiet on a normal boot so the autoload
@@ -464,7 +659,7 @@ iocat_match_taskfn(void *ctx __unused, int pending __unused)
 		if (w == NULL)
 			break;
 
-		if (iocat_lookup_pci(w->match_word, bundle, sizeof(bundle),
+		if (iocat_lookup_work(w, bundle, sizeof(bundle),
 		    &score) == 0) {
 			/* Driver known now — ask kextd to load it. */
 			iocat_request_load(w->match_word, w->devname, bundle, score);
@@ -483,17 +678,45 @@ iocat_device_nomatch(void *arg __unused, device_t dev)
 	device_t parent;
 	const char *nu;
 
-	/* Only PCI nubs for now; pci_get_* reads ivars valid on a pci child. */
 	parent = device_get_parent(dev);
-	if (parent == NULL || strcmp(device_get_name(parent), "pci") != 0)
+	if (parent == NULL)
 		return;
 
-	w = malloc(sizeof(*w), M_IOCAT, M_NOWAIT | M_ZERO);
-	if (w == NULL)
+	if (strcmp(device_get_name(parent), "pci") == 0) {
+		/* pci_get_* reads ivars valid on a pci child. */
+		w = malloc(sizeof(*w), M_IOCAT, M_NOWAIT | M_ZERO);
+		if (w == NULL)
+			return;
+		/* IOPCIPrimaryMatch: device in the high 16 bits, vendor low. */
+		w->match_word = ((uint32_t)pci_get_device(dev) << 16) |
+		    pci_get_vendor(dev);
+	} else {
+#ifdef FDT
+		const char *compat;
+
+		/*
+		 * A device-tree node (#185). ofw_bus_get_compat() reads an
+		 * ivar and neither sleeps nor allocates, so it is safe in this
+		 * handler for the same reason the pci_get_* calls above are.
+		 *
+		 * It returns only the FIRST compatible string. A node may list
+		 * several, most specific first, and a personality naming a
+		 * later (more generic) one will not match here. The specific
+		 * string is what a driver personality should name, so this is
+		 * the right default -- but it is a real limit, not an
+		 * oversight.
+		 */
+		compat = ofw_bus_get_compat(dev);
+		if (compat == NULL || *compat == '\0')
+			return;
+		w = malloc(sizeof(*w), M_IOCAT, M_NOWAIT | M_ZERO);
+		if (w == NULL)
+			return;
+		strlcpy(w->compat, compat, sizeof(w->compat));
+#else
 		return;
-	/* IOPCIPrimaryMatch form: device in the high 16 bits, vendor in low 16. */
-	w->match_word = ((uint32_t)pci_get_device(dev) << 16) |
-	    pci_get_vendor(dev);
+#endif
+	}
 	nu = device_get_nameunit(dev);
 	strlcpy(w->devname, nu != NULL ? nu : "?", sizeof(w->devname));
 
@@ -529,6 +752,18 @@ iocat_ioctl(struct cdev *dev __unused, u_long cmd, caddr_t data,
 		lu->bundle_id[0] = '\0';
 		lu->score = 0;
 		return (iocat_lookup_pci(lu->match, lu->bundle_id,
+		    sizeof(lu->bundle_id), &lu->score));
+	}
+	case IOCATIOCADDCOMPAT:		/* device-tree personality (#185) */
+		return (iocat_add_compat((struct iocat_add_compat *)data));
+	case IOCATIOCLOOKUPCOMPAT: {
+		struct iocat_lookup_compat *lu =
+		    (struct iocat_lookup_compat *)data;
+
+		lu->compat[IOCAT_COMPAT_MAX - 1] = '\0';
+		lu->bundle_id[0] = '\0';
+		lu->score = 0;
+		return (iocat_lookup_compat(lu->compat, lu->bundle_id,
 		    sizeof(lu->bundle_id), &lu->score));
 	}
 	case IOCATIOCTESTSEND: {	/* K3b PoC: lookup + kernel->kextd Mach send */

--- a/src-overlay/sys/sys/iocatalogue.h
+++ b/src-overlay/sys/sys/iocatalogue.h
@@ -23,6 +23,15 @@
 /* IOProviderClass — stored opaque by K2; interpreted by the K3 matcher. */
 #define	IOCAT_PROVIDER_UNKNOWN		0
 #define	IOCAT_PROVIDER_IOPCIDEVICE	1
+/*
+ * Device-tree nodes. Apple's name for this provider, and IONameMatch is the
+ * personality key that carries the strings -- so a NextBSD personality reads
+ * the same as a Darwin one rather than inventing a NextBSD-only spelling.
+ */
+#define	IOCAT_PROVIDER_IOPLATFORMDEVICE	2
+
+/* Longest FDT compatible string we will store, including NUL. */
+#define	IOCAT_COMPAT_MAX		128
 
 /*
  * One personality, as pushed from userland. `match` points at an array of
@@ -53,6 +62,42 @@ struct iocat_lookup {
 	char		bundle_id[IOCAT_BUNDLE_ID_MAX];	/* out: winning bundle */
 };
 
+/*
+ * A device-tree personality (nextbsd-kernel-extensions#185).
+ *
+ * PCI personalities match a 32-bit 0x<device><vendor> word; a device-tree node
+ * has no such id, it has a "compatible" string list. So this is a SEPARATE
+ * record type rather than a wider `match` in struct iocat_add -- that struct is
+ * duplicated verbatim into kextd (nextbsd-userland
+ * src/kext_tools/kextd/iocatalogue.h) and is a kernel<->userland ABI. Widening
+ * it would silently break a kextd built against the old header; adding a record
+ * type leaves the old path byte-identical.
+ *
+ * `compat` points at `ncompat` fixed-width IOCAT_COMPAT_MAX strings laid end to
+ * end -- fixed width rather than packed NUL-separated so the kernel can bound
+ * each copyin without walking user memory looking for terminators. A uint64_t
+ * for the same 32/64-bit ABI reason as struct iocat_add::match.
+ */
+struct iocat_add_compat {
+	char		bundle_id[IOCAT_BUNDLE_ID_MAX];
+	int32_t		probe_score;		/* IOProbeScore; higher wins */
+	uint32_t	ncompat;		/* number of strings */
+	uint64_t	compat;			/* user ptr to char[ncompat][IOCAT_COMPAT_MAX] */
+};
+
+/*
+ * Look up the best driver bundle for an FDT compatible string. Userland sets
+ * `compat`; the kernel fills `bundle_id` + `score`, or returns ENOENT.
+ * The userland-visible half of iocat_lookup_compat(), for the same reason
+ * IOCATIOCLOOKUP exists: so the match can be verified deterministically
+ * without waiting for a device to go unmatched.
+ */
+struct iocat_lookup_compat {
+	char		compat[IOCAT_COMPAT_MAX];	/* in */
+	int32_t		score;				/* out */
+	char		bundle_id[IOCAT_BUNDLE_ID_MAX];	/* out */
+};
+
 #define	IOCATIOCADD	_IOW('K', 1, struct iocat_add)		/* add a personality */
 #define	IOCATIOCFLUSH	_IO('K', 2)				/* drop all (re-push) */
 #define	IOCATIOCLOOKUP	_IOWR('K', 3, struct iocat_lookup)	/* match a PCI word */
@@ -64,6 +109,9 @@ struct iocat_lookup {
  * ENXIO (no kextd registered) / ENOSYS (kernel built without COMPAT_MACH).
  */
 #define	IOCATIOCTESTSEND	_IOW('K', 4, uint32_t)
+/* Device-tree personalities (#185). New numbers; 1-4 keep their meaning. */
+#define	IOCATIOCADDCOMPAT	_IOW('K', 5, struct iocat_add_compat)
+#define	IOCATIOCLOOKUPCOMPAT	_IOWR('K', 6, struct iocat_lookup_compat)
 
 #ifdef _KERNEL
 #include <sys/queue.h>
@@ -76,7 +124,13 @@ struct iocat_lookup {
  */
 SYSCTL_DECL(_hw_iokit);
 
-/* In-kernel record (one personality). match[] is malloc'd, nmatch words. */
+/*
+ * In-kernel record (one personality).
+ *
+ * A PCI record uses match[]/nmatch (0x<device><vendor> words); an FDT record
+ * uses compat[]/ncompat (IOCAT_COMPAT_MAX-wide strings). provider_class says
+ * which, and only one of the two is ever non-NULL.
+ */
 struct iocat_record {
 	TAILQ_ENTRY(iocat_record) link;
 	char		bundle_id[IOCAT_BUNDLE_ID_MAX];
@@ -84,6 +138,8 @@ struct iocat_record {
 	int32_t		probe_score;
 	uint32_t	nmatch;
 	uint32_t       *match;
+	uint32_t	ncompat;
+	char	       *compat;		/* ncompat * IOCAT_COMPAT_MAX */
 };
 
 /*
@@ -94,6 +150,14 @@ struct iocat_record {
  * lock; caller holds none.
  */
 int	iocat_lookup_pci(uint32_t match_word, char *buf, size_t buflen,
+	    int32_t *score_out);
+
+/*
+ * The device-tree twin of iocat_lookup_pci(): find the best IOFDTDevice
+ * personality listing `compat` among its compatible strings. Same contract --
+ * takes its own lock, caller holds none, returns 0 on a hit or ENOENT.
+ */
+int	iocat_lookup_compat(const char *compat, char *buf, size_t buflen,
 	    int32_t *score_out);
 #endif /* _KERNEL */
 


### PR DESCRIPTION
The in-kernel IOCatalogue only understood PCI. This adds the device-tree half, so an OF driver can autoload. Part 1 of 3 for #185.

## The problem

A Pi 5 boots with the node present, `VideoCoreKMS.kext` installed and loadable, and nothing ever asks for it:

```
ofwbus0: <firmwarekms> irq 12 compat raspberrypi,rpi-firmware-kms-2712 (no driver attached)
```

Three separate things made that unavoidable:

- match records were `0x<device><vendor>` words, and a device-tree node has no such id
- the `device_nomatch` handler returned early for anything whose parent was not `"pci"`
- the present-scan walked the PCI tree, where an OF device does not appear at all

So no Info.plist could have fixed it. The kernel had no way to express the match.

## What this adds

- **`IOCAT_PROVIDER_IOPLATFORMDEVICE`** and records carrying compatible strings beside the existing PCI words. Exactly one of the two is set.
- **`IOCATIOCADDCOMPAT` / `IOCATIOCLOOKUPCOMPAT`** as *new* ioctls with their own struct.
- **`iocat_lookup_compat()`**, the twin of `iocat_lookup_pci()`.
- **an FDT branch in the nomatch handler.** `ofw_bus_get_compat()` reads an ivar and neither sleeps nor allocates, so it is safe there for the same reason the `pci_get_*` calls above it are.
- **a recursive OF subtree scan** in the present-scan task.

Both consumers go through one `iocat_lookup_work()` helper, so the PCI and FDT paths cannot drift apart.

## Why new ioctls rather than widening `struct iocat_add`

That struct is duplicated **verbatim** into kextd (`nextbsd-userland src/kext_tools/kextd/iocatalogue.h`) and is a kernel↔userland ABI. Widening it would break a kextd and kernel built against different versions of the header. Adding a record type leaves the PCI path byte-identical.

## Why the OF scan, and not just the nomatch hook

The existing comment on the PCI scan explains that the boot `device_nomatch` capture is unreliable on real hardware — a T460s comes up with two driver-less devices that were never queued. The same applies here, and an OF device is invisible to the PCI walk regardless. Without the scan this would work only when the boot capture happened to fire.

The walk is recursive because the device tree nests (`ofwbus0` → `simplebus0` → …) and the node can be at any depth.

## Known limit, stated rather than hidden

`ofw_bus_get_compat()` returns only the **first** compatible string. A personality naming a later, more generic one will not match. Naming the specific string is what a personality should do — so this is the right default, but it is a limit, and it is why the companion Info.plist names `raspberrypi,rpi-firmware-kms-2712` rather than the generic form.

## Risk

Everything is behind `#ifdef FDT`, so amd64 builds unchanged. On its own this changes no behaviour: with no device-tree personalities in the catalogue, `iocat_lookup_compat()` never matches and the new scan finds nothing to request. It makes the behaviour *possible*.

Companion changes: nextbsd-userland (kextd parsing `IONameMatch`) and nextbsd-kernel-extensions (the VideoCoreKMS personality). All three are needed before anything autoloads.
