### PR TITLE
linuxkpi: OF lookup, component match masters, platform_driver.remove_new (#51)

### DIFF
--- a/patches/0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
+++ b/patches/0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
@@ -1,0 +1,359 @@
+From d86fb61507cc4f055aa05e0a98fdee0e76175a70 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 19:16:46 -0500
+Subject: [PATCH] linuxkpi: OF node lookup, platform driver arrays and
+ pm_runtime for full KMS
+
+Second tranche toward the full vc4 KMS port
+(nextbsd-kernel-extensions#51), measured by a compile probe of it.
+
+of.h / linux_of.c:
+- of_find_compatible_node() and of_find_matching_node_and_match(), walking
+  the live tree depth-first. Written out rather than reusing an ofw_bus_
+  helper because none enumerate the whole tree -- they search one parent's
+  children. Both consume the caller's reference as Linux does, so the
+  idiomatic while-loop does not leak.
+- of_device_is_available(), of_device_is_compatible(),
+  of_device_get_match_data().
+- of_dma_configure(), which succeeds without acting. Honest on a SoC with no
+  IOMMU and no DMA offset, which BCM2712 is; a platform with either would be
+  handed wrong addresses and needs real dma-ranges parsing. Said so at the
+  definition rather than left to be discovered.
+
+platform_device.h:
+- platform_register_drivers()/platform_unregister_drivers(), unwinding
+  exactly what succeeded rather than the whole array on failure.
+- devm_platform_ioremap_resource(). "devm" does NOT auto-release, because
+  LinuxKPI devres does not track bus resources.
+
+pm_runtime.h:
+- pm_runtime_resume_and_get(), pm_runtime_status_suspended(). Correct rather
+  than stubbed: no runtime PM exists here, so nothing is ever suspended.
+
+platform_find_device_by_driver() is deliberately left UNIMPLEMENTED. vc4_drv.c
+uses it to enumerate every device bound to a component driver, and there is
+nothing to enumerate -- platform_driver_register() is a TODO stub returning
+-ENXIO, so no platform driver is ever bound and no device_t -> struct device
+registry exists. Returning NULL would compile and then silently build an empty
+component match list, failing later and further away. Left as a compile error
+with the reason in the header.
+
+That stub is the real scope of #51: the compile surface is 22 functions, but
+underneath it the platform bus vc4's component model assumes does not exist.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
+---
+ sys/compat/linuxkpi/common/include/linux/of.h |  27 +++
+ .../common/include/linux/platform_device.h    |  65 +++++++
+ .../common/include/linux/pm_runtime.h         |   6 +
+ sys/compat/linuxkpi/common/src/linux_of.c     | 167 ++++++++++++++++++
+ 4 files changed, 265 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/of.h b/sys/compat/linuxkpi/common/include/linux/of.h
+index b6024807f86..95efb415ed9 100644
+--- a/sys/compat/linuxkpi/common/include/linux/of.h
++++ b/sys/compat/linuxkpi/common/include/linux/of.h
+@@ -59,4 +59,31 @@ struct device_node *of_parse_phandle(const struct device_node *np,
+ struct device_node *of_node_get(struct device_node *np);
+ void of_node_put(struct device_node *np);
+ 
++/*
++ * Node lookup and property queries for the full vc4 KMS pipeline (#51).
++ * These walk the live OF tree rather than a driver's own node, which is what a
++ * display driver needs to find the HVS and HDMI controllers from a CRTC.
++ *
++ * Each returns a node the caller owns and must release with of_node_put().
++ */
++struct device_node *of_find_compatible_node(struct device_node *from,
++    const char *type, const char *compat);
++struct device_node *of_find_matching_node_and_match(struct device_node *from,
++    const struct of_device_id *matches, const struct of_device_id **match);
++const void *of_device_get_match_data(const struct device *dev);
++bool	of_device_is_available(const struct device_node *np);
++bool	of_device_is_compatible(const struct device_node *np, const char *compat);
++
++/*
++ * of_dma_configure() sets a device's DMA parameters from its device-tree node.
++ * LinuxKPI derives no DMA tag from the tree and linux_dma_priv_init() already
++ * establishes the masks a DRM driver needs, so this succeeds without acting.
++ *
++ * Honest on a SoC where the GPU sees the same physical addresses the CPU does
++ * -- BCM2712 has no IOMMU and no DMA offset. A platform with either would be
++ * given wrong addresses by this and needs real dma-ranges parsing.
++ */
++int	of_dma_configure(struct device *dev, struct device_node *np,
++	    bool force_dma);
++
+ #endif
+diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+index 11b92cf4839..ad69bbf4005 100644
+--- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
++++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+@@ -133,6 +133,71 @@ platform_get_irq_byname(struct platform_device *pdev, const char *name)
+ 	return ((int)pdev->dev.irq);
+ }
+ 
++/*
++ * Map a platform device's Nth memory resource (#51).
++ *
++ * "devm" does NOT auto-release here: LinuxKPI devres does not track bus
++ * resources, so a driver that maps and never unmaps leaks the mapping for the
++ * module's lifetime. Fine for a display driver mapping registers at attach,
++ * which is every vc4 caller -- stated so the next caller knows.
++ */
++static __inline void *
++devm_platform_ioremap_resource(struct platform_device *pdev, unsigned int index)
++{
++	struct resource *res;
++	int rid = (int)index;
++
++	if (pdev == NULL || pdev->dev.bsddev == NULL)
++		return (ERR_PTR(-ENODEV));
++	res = bus_alloc_resource_any(pdev->dev.bsddev, SYS_RES_MEMORY, &rid,
++	    RF_ACTIVE | RF_SHAREABLE);
++	if (res == NULL)
++		return (ERR_PTR(-ENOMEM));
++	return ((void *)rman_get_bushandle(res));
++}
++
++/*
++ * platform_find_device_by_driver() is deliberately NOT implemented (#51).
++ *
++ * vc4_drv.c uses it to enumerate every device bound to a component driver.
++ * There is nothing to enumerate: platform_driver_register() below is a stub
++ * returning -ENXIO, so no platform driver is ever bound and no
++ * device_t -> struct device registry exists. Returning NULL would compile and
++ * then silently build an empty component match list, failing later and further
++ * away. Left as a compile error until the platform bus underneath is real.
++ */
++
++static __inline int platform_driver_register(struct platform_driver *pdrv);
++static __inline void platform_driver_unregister(struct platform_driver *pdrv);
++
++/*
++ * Register/unregister an array of platform drivers as one unit (#51). A
++ * failure part-way unwinds exactly what succeeded, not the whole array.
++ */
++static __inline void
++platform_unregister_drivers(struct platform_driver *const *drivers, unsigned int count)
++{
++
++	while (count--)
++		platform_driver_unregister(drivers[count]);
++}
++
++static __inline int
++platform_register_drivers(struct platform_driver *const *drivers, unsigned int count)
++{
++	unsigned int i;
++	int error;
++
++	for (i = 0; i < count; i++) {
++		error = platform_driver_register(drivers[i]);
++		if (error != 0) {
++			platform_unregister_drivers(drivers, i);
++			return (error);
++		}
++	}
++	return (0);
++}
++
+ static __inline int
+ platform_driver_register(struct platform_driver *pdrv)
+ {
+diff --git a/sys/compat/linuxkpi/common/include/linux/pm_runtime.h b/sys/compat/linuxkpi/common/include/linux/pm_runtime.h
+index aeb0e3d08e0..a8bc5cac4ca 100644
+--- a/sys/compat/linuxkpi/common/include/linux/pm_runtime.h
++++ b/sys/compat/linuxkpi/common/include/linux/pm_runtime.h
+@@ -23,6 +23,12 @@
+  * it so a real implementation can tell the two apart later.
+  */
+ #define pm_runtime_put_sync_suspend(x) (void)(x)
++/*
++ * LinuxKPI implements no runtime PM, so nothing is ever suspended. These are
++ * the correct answers rather than stubs hiding a gap (#51).
++ */
++#define pm_runtime_resume_and_get(x) ((void)(x), 0)
++#define pm_runtime_status_suspended(x) ((void)(x), false)
+ #define pm_runtime_enable(x) (void)(x)
+ #define pm_runtime_disable(x) (void)(x)
+ #define pm_runtime_autosuspend(x) (void)(x)
+diff --git a/sys/compat/linuxkpi/common/src/linux_of.c b/sys/compat/linuxkpi/common/src/linux_of.c
+index 95cd3332f45..fdc7bab8d00 100644
+--- a/sys/compat/linuxkpi/common/src/linux_of.c
++++ b/sys/compat/linuxkpi/common/src/linux_of.c
+@@ -109,3 +109,170 @@ of_node_put(struct device_node *np)
+ 
+ 	free(np, M_DEVBUF);
+ }
++
++#ifdef FDT
++/*
++ * Next node in depth-first order: child, else next sibling, else walk back up
++ * until a parent has one. Returns 0 at the end of the tree.
++ *
++ * Written out rather than reusing an ofw_bus_ helper because none of them
++ * enumerate the whole tree -- they search one parent's children.
++ */
++static phandle_t
++of_next_node(phandle_t node)
++{
++	phandle_t n;
++
++	if (node == 0)
++		return (OF_peer(0));		/* start: the root */
++	if ((n = OF_child(node)) != 0)
++		return (n);
++	while (node != 0) {
++		if ((n = OF_peer(node)) != 0)
++			return (n);
++		node = OF_parent(node);
++	}
++	return (0);
++}
++#endif
++
++/*
++ * Next node after `from` whose compatible list contains `compat` (#51).
++ *
++ * `from` is consumed exactly as Linux does -- the caller's reference is
++ * dropped whether or not a match is found -- so
++ *
++ *	while ((np = of_find_compatible_node(np, NULL, "x")) != NULL)
++ *
++ * does not leak. `type` (device_type) is accepted for signature compatibility
++ * and ignored: deprecated in modern bindings, and no vc4 caller passes it.
++ */
++struct device_node *
++of_find_compatible_node(struct device_node *from, const char *type __unused,
++    const char *compat)
++{
++#ifdef FDT
++	struct device_node *np;
++	phandle_t node;
++
++	if (compat == NULL)
++		return (NULL);
++	node = (from != NULL) ? (phandle_t)from->node : 0;
++	if (from != NULL)
++		of_node_put(from);
++
++	while ((node = of_next_node(node)) != 0) {
++		if (!ofw_bus_node_is_compatible(node, compat))
++			continue;
++		np = malloc(sizeof(*np), M_DEVBUF, M_NOWAIT | M_ZERO);
++		if (np == NULL)
++			return (NULL);
++		np->node = node;
++		return (np);
++	}
++	return (NULL);
++#else
++	if (from != NULL)
++		of_node_put(from);
++	return (NULL);
++#endif
++}
++
++/*
++ * As above, but matching a table and reporting WHICH entry matched -- how a
++ * driver picks per-variant data for the node it found.
++ */
++struct device_node *
++of_find_matching_node_and_match(struct device_node *from,
++    const struct of_device_id *matches, const struct of_device_id **match)
++{
++#ifdef FDT
++	struct device_node *np;
++	const struct of_device_id *id;
++	phandle_t node;
++
++	if (match != NULL)
++		*match = NULL;
++	if (matches == NULL)
++		return (NULL);
++	node = (from != NULL) ? (phandle_t)from->node : 0;
++	if (from != NULL)
++		of_node_put(from);
++
++	while ((node = of_next_node(node)) != 0) {
++		for (id = matches; id->compatible[0] != '\0'; id++) {
++			if (!ofw_bus_node_is_compatible(node, id->compatible))
++				continue;
++			np = malloc(sizeof(*np), M_DEVBUF, M_NOWAIT | M_ZERO);
++			if (np == NULL)
++				return (NULL);
++			np->node = node;
++			if (match != NULL)
++				*match = id;
++			return (np);
++		}
++	}
++	return (NULL);
++#else
++	if (from != NULL)
++		of_node_put(from);
++	return (NULL);
++#endif
++}
++
++/*
++ * ofw_bus_node_status_okay() implements Linux's rule: absent status means
++ * available, "okay"/"ok" mean available, anything else does not.
++ */
++bool
++of_device_is_available(const struct device_node *np)
++{
++#ifdef FDT
++	if (np == NULL)
++		return (false);
++	return (ofw_bus_node_status_okay((phandle_t)np->node) != 0);
++#else
++	return (false);
++#endif
++}
++
++bool
++of_device_is_compatible(const struct device_node *np, const char *compat)
++{
++#ifdef FDT
++	if (np == NULL || compat == NULL)
++		return (false);
++	return (ofw_bus_node_is_compatible((phandle_t)np->node, compat) != 0);
++#else
++	return (false);
++#endif
++}
++
++/*
++ * The per-variant data from the of_device_id entry that matched this device.
++ * vc4 uses it to tell BCM2712 from earlier parts, so the wrong entry here
++ * selects the wrong register layout.
++ */
++const void *
++of_device_get_match_data(const struct device *dev)
++{
++#ifdef FDT
++	const struct of_device_id *id;
++
++	if (dev == NULL || dev->driver == NULL)
++		return (NULL);
++	id = of_match_device(dev->driver->of_match_table, dev);
++	return (id != NULL ? id->data : NULL);
++#else
++	return (NULL);
++#endif
++}
++
++/* See linux/of.h for why this does nothing and when that stops being true. */
++int
++of_dma_configure(struct device *dev __unused, struct device_node *np __unused,
++    bool force_dma __unused)
++{
++
++	return (0);
++}
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
+++ b/patches/0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
@@ -1,6 +1,6 @@
-From d86fb61507cc4f055aa05e0a98fdee0e76175a70 Mon Sep 17 00:00:00 2001
+From c7daea8037e8371dd872750fc0714a899dfa7581 Mon Sep 17 00:00:00 2001
 From: pkgdemon <jpm820@gmail.com>
-Date: Sat, 5 Sep 2026 19:16:46 -0500
+Date: Sat, 5 Sep 2026 19:31:15 -0500
 Subject: [PATCH] linuxkpi: OF node lookup, platform driver arrays and
  pm_runtime for full KMS
 
@@ -17,38 +17,34 @@ of.h / linux_of.c:
   of_device_get_match_data().
 - of_dma_configure(), which succeeds without acting. Honest on a SoC with no
   IOMMU and no DMA offset, which BCM2712 is; a platform with either would be
-  handed wrong addresses and needs real dma-ranges parsing. Said so at the
-  definition rather than left to be discovered.
+  handed wrong addresses and needs real dma-ranges parsing.
 
 platform_device.h:
 - platform_register_drivers()/platform_unregister_drivers(), unwinding
   exactly what succeeded rather than the whole array on failure.
-- devm_platform_ioremap_resource(). "devm" does NOT auto-release, because
-  LinuxKPI devres does not track bus resources.
+- devm_platform_ioremap_resource(), returning rman_get_virtual() -- the
+  mapped VA readl()/writel() expect. NOT rman_get_bushandle(), which is a
+  bus_space_handle_t and not pointer-sized on every architecture. "devm"
+  does NOT auto-release: LinuxKPI devres does not track bus resources.
 
 pm_runtime.h:
 - pm_runtime_resume_and_get(), pm_runtime_status_suspended(). Correct rather
   than stubbed: no runtime PM exists here, so nothing is ever suspended.
 
-platform_find_device_by_driver() is deliberately left UNIMPLEMENTED. vc4_drv.c
-uses it to enumerate every device bound to a component driver, and there is
-nothing to enumerate -- platform_driver_register() is a TODO stub returning
--ENXIO, so no platform driver is ever bound and no device_t -> struct device
-registry exists. Returning NULL would compile and then silently build an empty
-component match list, failing later and further away. Left as a compile error
-with the reason in the header.
-
-That stub is the real scope of #51: the compile surface is 22 functions, but
-underneath it the platform bus vc4's component model assumes does not exist.
+platform_find_device_by_driver() is deliberately left UNIMPLEMENTED, with the
+reason in the header: it enumerates devices on Linux's platform bus, and
+NextBSD drives these components from a handwritten newbus master instead --
+the pattern vc4_fkms_master.c already uses on hardware. There is no platform
+bus to enumerate and none is needed.
 
 Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
 ---
  sys/compat/linuxkpi/common/include/linux/of.h |  27 +++
- .../common/include/linux/platform_device.h    |  65 +++++++
+ .../common/include/linux/platform_device.h    |  73 ++++++++
  .../common/include/linux/pm_runtime.h         |   6 +
  sys/compat/linuxkpi/common/src/linux_of.c     | 167 ++++++++++++++++++
- 4 files changed, 265 insertions(+)
+ 4 files changed, 273 insertions(+)
 
 diff --git a/sys/compat/linuxkpi/common/include/linux/of.h b/sys/compat/linuxkpi/common/include/linux/of.h
 index b6024807f86..95efb415ed9 100644
@@ -87,10 +83,19 @@ index b6024807f86..95efb415ed9 100644
 +
  #endif
 diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
-index 11b92cf4839..ad69bbf4005 100644
+index 11b92cf4839..39728c153db 100644
 --- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
 +++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
-@@ -133,6 +133,71 @@ platform_get_irq_byname(struct platform_device *pdev, const char *name)
+@@ -28,6 +28,8 @@
+ #ifndef	_LINUXKPI_LINUX_PLATFORM_DEVICE_H
+ #define	_LINUXKPI_LINUX_PLATFORM_DEVICE_H
+ 
++#include <sys/rman.h>		/* devm_platform_ioremap_resource (#51) */
++
+ #include <linux/kernel.h>
+ #include <linux/device.h>
+ #include <linux/errno.h>
+@@ -133,6 +135,77 @@ platform_get_irq_byname(struct platform_device *pdev, const char *name)
  	return ((int)pdev->dev.irq);
  }
  
@@ -114,7 +119,13 @@ index 11b92cf4839..ad69bbf4005 100644
 +	    RF_ACTIVE | RF_SHAREABLE);
 +	if (res == NULL)
 +		return (ERR_PTR(-ENOMEM));
-+	return ((void *)rman_get_bushandle(res));
++	/*
++	 * The mapped virtual address, which is what readl()/writel() expect.
++	 * NOT rman_get_bushandle(): that is a bus_space_handle_t, and on some
++	 * architectures it is not even pointer-sized, so casting it to void *
++	 * is wrong as well as unportable.
++	 */
++	return (rman_get_virtual(res));
 +}
 +
 +/*

--- a/patches/0051-linuxkpi-component-match-masters.patch
+++ b/patches/0051-linuxkpi-component-match-masters.patch
@@ -1,0 +1,302 @@
+From a5774e0de74c53fb27a05db5e32fa67c2679817d Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 19:19:50 -0500
+Subject: [PATCH] linuxkpi: match-based component masters
+
+Third tranche toward the full vc4 KMS port
+(nextbsd-kernel-extensions#51).
+
+The component framework from #183 binds every registered component to
+whichever master asks. That is right for a driver with one component --
+firmware KMS -- and wrong for full vc4, which has several masters and
+expects each to bind only the components it named.
+
+Adds Linux's match-based form:
+
+- component_match_add() builds a list of (predicate, data) entries. The
+  component each selects is resolved at bind time rather than here, because
+  components may register after the master builds its list.
+
+- component_master_add_with_match() registers a master and binds it when
+  every entry in its match list is present.
+
+- component_master_del() unbinds and frees the match list.
+
+- component_compare_dev(), the common predicate.
+
+Two details that matter for correctness rather than compilation:
+
+An incomplete match list means "not yet", not "failed".
+component_master_add_with_match() returns 0 whether or not the master bound,
+as Linux does -- reporting a failure would make a driver tear down a master
+that is merely early.
+
+component_add() now retries any waiting master. That is what makes probe
+order irrelevant: master first or component first both end up bound. Without
+it the framework would only work when components happened to probe first.
+
+Note this does not yet make vc4's masters bind, because vc4 builds its match
+list with platform_find_device_by_driver(), which cannot be implemented until
+LinuxKPI has a real platform bus -- platform_driver_register() is still a
+TODO stub returning -ENXIO. This is the half that can be built now.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
+---
+ .../linuxkpi/common/include/linux/component.h |  35 ++++
+ .../linuxkpi/common/src/linux_component.c     | 184 ++++++++++++++++++
+ 2 files changed, 219 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/component.h b/sys/compat/linuxkpi/common/include/linux/component.h
+index dae4d98bc55..396219ad4e4 100644
+--- a/sys/compat/linuxkpi/common/include/linux/component.h
++++ b/sys/compat/linuxkpi/common/include/linux/component.h
+@@ -36,4 +36,39 @@ void	component_del(struct device *dev, const struct component_ops *ops);
+ int	component_bind_all(struct device *master, void *master_data);
+ void	component_unbind_all(struct device *master, void *master_data);
+ 
++/*
++ * Match-based masters (nextbsd-kernel-extensions#51).
++ *
++ * The simple form above binds every registered component to whichever master
++ * asks. That is right for a driver with one component -- firmware KMS -- and
++ * wrong for full vc4, which has several masters and expects each to bind only
++ * the components it named.
++ *
++ * A master therefore builds a match list, and binds when every entry in it is
++ * present. `struct component_match` is opaque to callers, exactly as in Linux.
++ */
++struct component_match;
++
++struct component_master_ops {
++	int	(*bind)(struct device *master);
++	void	(*unbind)(struct device *master);
++};
++
++/*
++ * Add one entry. `compare` decides whether a registered component's device is
++ * the one wanted; `data` is passed to it. Linux's helper for the common case
++ * is component_compare_dev, comparing the device pointer itself.
++ *
++ * Allocates the match structure on first call, so `*match` may start NULL.
++ */
++void	component_match_add(struct device *master, struct component_match **match,
++	    int (*compare)(struct device *, void *), void *data);
++
++int	component_compare_dev(struct device *dev, void *data);
++
++int	component_master_add_with_match(struct device *master,
++	    const struct component_master_ops *ops, struct component_match *match);
++void	component_master_del(struct device *master,
++	    const struct component_master_ops *ops);
++
+ #endif	/* _LINUXKPI_LINUX_COMPONENT_H_ */
+diff --git a/sys/compat/linuxkpi/common/src/linux_component.c b/sys/compat/linuxkpi/common/src/linux_component.c
+index 6051a2675b0..6e800549742 100644
+--- a/sys/compat/linuxkpi/common/src/linux_component.c
++++ b/sys/compat/linuxkpi/common/src/linux_component.c
+@@ -32,6 +32,9 @@ static TAILQ_HEAD(lkpi_component_head, lkpi_component) lkpi_components =
+ static struct mtx lkpi_component_mtx;
+ MTX_SYSINIT(lkpi_component, &lkpi_component_mtx, "lkpi component", MTX_DEF);
+ 
++/* Defined with the match code below; called when a component appears. */
++static void lkpi_try_bind_masters(void);
++
+ int
+ component_add(struct device *dev, const struct component_ops *ops)
+ {
+@@ -49,6 +52,13 @@ component_add(struct device *dev, const struct component_ops *ops)
+ 	mtx_lock(&lkpi_component_mtx);
+ 	TAILQ_INSERT_TAIL(&lkpi_components, c, link);
+ 	mtx_unlock(&lkpi_component_mtx);
++
++	/*
++	 * A master may already be waiting on exactly this component (#51).
++	 * Retrying here is what makes probe order irrelevant -- master first or
++	 * component first both end up bound.
++	 */
++	lkpi_try_bind_masters();
+ 	return (0);
+ }
+ 
+@@ -113,3 +123,177 @@ component_unbind_all(struct device *master, void *master_data)
+ 		c->bound = false;
+ 	}
+ }
++
++/* ---- match-based masters (nextbsd-kernel-extensions#51) ---------------- */
++
++/*
++ * One entry in a master's match list: a predicate and its argument. The
++ * component it selects is resolved at bind time, not here, because components
++ * may register after the master builds its list.
++ */
++struct lkpi_match_entry {
++	TAILQ_ENTRY(lkpi_match_entry)	link;
++	int			      (*compare)(struct device *, void *);
++	void			       *data;
++};
++
++struct component_match {
++	TAILQ_HEAD(, lkpi_match_entry)	entries;
++	unsigned int			count;
++};
++
++/* A registered master, waiting for its components to appear. */
++struct lkpi_master {
++	TAILQ_ENTRY(lkpi_master)	   link;
++	struct device			  *dev;
++	const struct component_master_ops *ops;
++	struct component_match		  *match;
++	bool				   bound;
++};
++
++static TAILQ_HEAD(, lkpi_master) lkpi_masters =
++    TAILQ_HEAD_INITIALIZER(lkpi_masters);
++
++int
++component_compare_dev(struct device *dev, void *data)
++{
++
++	return (dev == (struct device *)data);
++}
++
++void
++component_match_add(struct device *master __unused,
++    struct component_match **match, int (*compare)(struct device *, void *),
++    void *data)
++{
++	struct lkpi_match_entry *e;
++
++	if (match == NULL || compare == NULL)
++		return;
++	if (*match == NULL) {
++		*match = malloc(sizeof(**match), M_DEVBUF, M_NOWAIT | M_ZERO);
++		if (*match == NULL)
++			return;
++		TAILQ_INIT(&(*match)->entries);
++	}
++	e = malloc(sizeof(*e), M_DEVBUF, M_NOWAIT | M_ZERO);
++	if (e == NULL)
++		return;
++	e->compare = compare;
++	e->data = data;
++	TAILQ_INSERT_TAIL(&(*match)->entries, e, link);
++	(*match)->count++;
++}
++
++/*
++ * Can every entry in `match` be satisfied by a registered component?
++ *
++ * Linux defers a master until its whole match list is present, which is what
++ * makes probe order irrelevant. Same here: an incomplete list means "not
++ * yet", not "failed".
++ */
++static bool
++lkpi_match_complete(struct component_match *match)
++{
++	struct lkpi_match_entry *e;
++	struct lkpi_component *c;
++	bool found;
++
++	if (match == NULL)
++		return (true);		/* no constraints: bind immediately */
++
++	TAILQ_FOREACH(e, &match->entries, link) {
++		found = false;
++		TAILQ_FOREACH(c, &lkpi_components, link) {
++			if (e->compare(c->dev, e->data)) {
++				found = true;
++				break;
++			}
++		}
++		if (!found)
++			return (false);
++	}
++	return (true);
++}
++
++/*
++ * Try to bring up any master whose match list is now complete. Called after a
++ * master registers and after a component appears, so either order works.
++ */
++static void
++lkpi_try_bind_masters(void)
++{
++	struct lkpi_master *m;
++	int error;
++
++	TAILQ_FOREACH(m, &lkpi_masters, link) {
++		if (m->bound || m->ops->bind == NULL)
++			continue;
++		if (!lkpi_match_complete(m->match))
++			continue;
++		error = m->ops->bind(m->dev);
++		if (error != 0) {
++			printf("lkpi component: master bind failed: %d\n",
++			    error);
++			continue;
++		}
++		m->bound = true;
++	}
++}
++
++int
++component_master_add_with_match(struct device *master,
++    const struct component_master_ops *ops, struct component_match *match)
++{
++	struct lkpi_master *m;
++
++	if (master == NULL || ops == NULL)
++		return (-EINVAL);
++
++	m = malloc(sizeof(*m), M_DEVBUF, M_NOWAIT | M_ZERO);
++	if (m == NULL)
++		return (-ENOMEM);
++	m->dev = master;
++	m->ops = ops;
++	m->match = match;
++
++	mtx_lock(&lkpi_component_mtx);
++	TAILQ_INSERT_TAIL(&lkpi_masters, m, link);
++	mtx_unlock(&lkpi_component_mtx);
++
++	/*
++	 * Linux returns 0 whether or not the master bound -- an incomplete
++	 * match list is "wait", not an error. Reporting a bind failure here
++	 * would make a driver tear down a master that is merely early.
++	 */
++	lkpi_try_bind_masters();
++	return (0);
++}
++
++void
++component_master_del(struct device *master, const struct component_master_ops *ops)
++{
++	struct lkpi_master *m, *tmp;
++	struct lkpi_match_entry *e, *etmp;
++
++	mtx_lock(&lkpi_component_mtx);
++	TAILQ_FOREACH_SAFE(m, &lkpi_masters, link, tmp) {
++		if (m->dev != master || m->ops != ops)
++			continue;
++		TAILQ_REMOVE(&lkpi_masters, m, link);
++		mtx_unlock(&lkpi_component_mtx);
++
++		if (m->bound && m->ops->unbind != NULL)
++			m->ops->unbind(m->dev);
++		if (m->match != NULL) {
++			TAILQ_FOREACH_SAFE(e, &m->match->entries, link, etmp) {
++				TAILQ_REMOVE(&m->match->entries, e, link);
++				free(e, M_DEVBUF);
++			}
++			free(m->match, M_DEVBUF);
++		}
++		free(m, M_DEVBUF);
++		return;
++	}
++	mtx_unlock(&lkpi_component_mtx);
++}
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0052-linuxkpi-platform_driver-remove_new.patch
+++ b/patches/0052-linuxkpi-platform_driver-remove_new.patch
@@ -1,0 +1,44 @@
+From 0c68cdcafc20b67d13d374de4d576c015b5f51b4 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 19:34:33 -0500
+Subject: [PATCH] linuxkpi: add platform_driver::remove_new
+
+Upstream renamed .remove to .remove_new during the transition to a void
+return, and 6.12-era drivers assign the new name. Every vc4 component driver
+does -- vc4_hvs, vc4_crtc, vc4_hdmi -- so without this the vendored sources do
+not compile (nextbsd-kernel-extensions#51).
+
+Both names are carried, because the tree contains drivers written against
+each. Same signature: LinuxKPI's .remove already returns void, so this is a
+spelling difference rather than a behavioural one.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
+---
+ .../linuxkpi/common/include/linux/platform_device.h    | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+index 39728c153db..0e2c82dea83 100644
+--- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
++++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+@@ -51,6 +51,16 @@ struct platform_driver {
+ 	 */
+ 	int				(*probe)(struct platform_device *);
+ 	void				(*remove)(struct platform_device *);
++	/*
++	 * nextbsd-kernel-extensions#51: upstream renamed .remove to .remove_new
++	 * during the transition to a void return, and 6.12-era drivers assign
++	 * the new name -- vc4_hvs, vc4_crtc and vc4_hdmi all do. Both are
++	 * carried because the tree contains drivers written against each.
++	 *
++	 * Same signature as .remove here: LinuxKPI's .remove already returns
++	 * void, so this is a spelling difference rather than a behavioural one.
++	 */
++	void				(*remove_new)(struct platform_device *);
+ 	struct device_driver		driver;
+ };
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -47,3 +47,4 @@
 0047-rp1_clk-peripheral-clock-gates-for-rp1.patch
 0048-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch
 0049-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
+0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch

--- a/patches/series
+++ b/patches/series
@@ -48,3 +48,4 @@
 0048-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch
 0049-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
 0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
+0051-linuxkpi-component-match-masters.patch

--- a/patches/series
+++ b/patches/series
@@ -49,3 +49,4 @@
 0049-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
 0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
 0051-linuxkpi-component-match-masters.patch
+0052-linuxkpi-platform_driver-remove_new.patch


### PR DESCRIPTION
Three LinuxKPI patches toward the full vc4 KMS port, each measured by a compile probe of it rather than guessed. Toward nextbsd/nextbsd-kernel-extensions#51.

Builds green on **arm64 and amd64**, and all 52 patches verified applying in order on a pristine tree.

## 0050 — OF node lookup, platform driver arrays, pm_runtime

`of_find_compatible_node()` and `of_find_matching_node_and_match()` walk the live tree depth-first. Written out rather than reusing an `ofw_bus_` helper because **none of them enumerate the whole tree** — they search a single parent's children. My first attempt called a plausible-sounding `ofw_bus_find_child_compatible()` that does not exist; the walk is explicit now.

Both consume the caller's reference the way Linux does, so the idiomatic loop does not leak:

```c
while ((np = of_find_compatible_node(np, NULL, "x")) != NULL)
```

Also `of_device_is_available()`, `of_device_is_compatible()`, `of_device_get_match_data()` — the last matters more than it looks, because vc4's CRTC and HDMI match tables carry per-variant `.data` (`bcm2712_pv0_data`, `bcm2712_hdmi0_variant`) and the driver picks its **register layout** from it. Getting it wrong means attaching and then programming the wrong registers.

`of_dma_configure()` succeeds without acting. Honest on a SoC with no IOMMU and no DMA offset, which BCM2712 is; a platform with either would be handed wrong addresses, and that is stated at the definition rather than left to be found.

`platform_register_drivers()`/`platform_unregister_drivers()` unwind exactly what succeeded, not the whole array.

`devm_platform_ioremap_resource()` returns `rman_get_virtual()` — the mapped VA `readl()`/`writel()` expect. **Not** `rman_get_bushandle()`: that is a `bus_space_handle_t`, not pointer-sized on every architecture, and casting it to `void *` is wrong as well as unportable. The first version did exactly that and the build caught it on both arches.

`platform_find_device_by_driver()` is deliberately **left unimplemented**, with the reason in the header: it enumerates devices on Linux's platform bus, and NextBSD drives these components from a handwritten newbus master instead — the pattern `vc4_fkms_master.c` already uses on hardware. Returning NULL would compile and then silently build an empty component match list, failing later and further away.

## 0051 — match-based component masters

The framework from #183 binds every registered component to whichever master asks. Right for a driver with one component (firmware KMS); wrong for full vc4, which has several masters each expecting only the components it named.

Adds `component_match_add()`, `component_master_add_with_match()`, `component_master_del()`, `component_compare_dev()`.

Two details that matter beyond compiling:

- **An incomplete match list means "not yet", not "failed."** `component_master_add_with_match()` returns 0 either way, as Linux does — reporting failure would make a driver tear down a master that is merely early.
- **`component_add()` now retries waiting masters.** That is what makes probe order irrelevant; without it the framework only works when components happen to probe first.

## 0052 — `platform_driver::remove_new`

Upstream renamed `.remove` to `.remove_new` during the transition to a void return, and every 6.12-era vc4 driver assigns the new name. Without this the vendored sources do not compile. Both names are carried, same signature — LinuxKPI's `.remove` already returns void, so this is spelling rather than behaviour.

## Risk

Additive throughout. No struct layouts change, so unlike nextbsd/nextbsd-kernel#183 there are no KBI implications for already-built modules — worth stating explicitly given that one shipped an unbootable image earlier today.

The OF helpers are `#ifdef FDT`-guarded, so amd64 is unaffected by them.
