### PR TITLE
linuxkpi: bind components in match order, and unbind with a real master

### DIFF
--- a/patches/0053-linuxkpi-rman-out-of-platform-device-h.patch
+++ b/patches/0053-linuxkpi-rman-out-of-platform-device-h.patch
@@ -1,0 +1,156 @@
+From 305bc01c830577f67e211309bbf0d5a12d9e5b6f Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 21:39:36 -0500
+Subject: [PATCH] linuxkpi: keep sys/rman.h out of <linux/platform_device.h>
+
+Fixes a build regression from patch 0050, which added sys/rman.h to
+<linux/platform_device.h> so devm_platform_ioremap_resource() could be inline
+there.
+
+LinuxKPI declares its own struct resource in <linux/ioport.h> -- a different
+type, with different members, from FreeBSD's in sys/rman.h. Including
+sys/rman.h from platform_device.h put the FreeBSD definition ahead of the
+LinuxKPI one for every consumer of that header, so any driver that reached
+ioport.h afterwards failed with "redefinition of 'resource'". <linux/mfd/core.h>
+takes exactly that path -- it includes platform_device.h and then ioport.h --
+which broke the whole amdgpu build:
+
+  In file included from .../amdgpu.h:77:
+  In file included from .../amdgpu_acp.h:29:
+  In file included from .../linux/mfd/core.h:21:
+  .../linux/ioport.h:40:8: error: redefinition of 'resource'
+  .../sys/rman.h:102:8: note: previous definition is here
+
+The inline was unsound even where it compiled: "struct resource" inside it
+meant whichever of the two definitions was in scope at the call site.
+
+Move the body to linux_of.c, which includes sys/rman.h and deliberately does
+not include <linux/ioport.h>, and leave a declaration behind. The header no
+longer names a FreeBSD type.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
+---
+ .../common/include/linux/platform_device.h    | 43 +++++++++++--------
+ sys/compat/linuxkpi/common/src/linux_of.c     | 35 +++++++++++++++
+ 2 files changed, 59 insertions(+), 19 deletions(-)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+index 0e2c82dea83..18009290f0d 100644
+--- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
++++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+@@ -28,8 +28,6 @@
+ #ifndef	_LINUXKPI_LINUX_PLATFORM_DEVICE_H
+ #define	_LINUXKPI_LINUX_PLATFORM_DEVICE_H
+ 
+-#include <sys/rman.h>		/* devm_platform_ioremap_resource (#51) */
+-
+ #include <linux/kernel.h>
+ #include <linux/device.h>
+ #include <linux/errno.h>
+@@ -153,25 +151,32 @@ platform_get_irq_byname(struct platform_device *pdev, const char *name)
+  * module's lifetime. Fine for a display driver mapping registers at attach,
+  * which is every vc4 caller -- stated so the next caller knows.
+  */
+-static __inline void *
++/*
++ * Map a platform device's memory resource.
++ *
++ * The body is OUT OF LINE, in linux_of.c, and that is not a style choice.
++ *
++ * It needs FreeBSD's struct resource (sys/rman.h). LinuxKPI declares its OWN
++ * struct resource in <linux/ioport.h> -- a different type with different
++ * members. Pulling sys/rman.h in from this header put the FreeBSD definition
++ * ahead of the LinuxKPI one for every consumer, and any driver reaching
++ * ioport.h afterwards failed to build with "redefinition of 'resource'"; that
++ * is exactly the include path <linux/mfd/core.h> takes, so it broke all of
++ * amdgpu. Even where it compiled, "struct resource" inside an inline here
++ * would mean whichever definition happened to be in scope at the call site.
++ *
++ * Keeping the two definitions apart means keeping sys/rman.h out of this
++ * header. The return value is the mapped virtual address readl()/writel()
++ * expect, or an ERR_PTR().
++ */
++void	*lkpi_platform_ioremap_resource(struct platform_device *pdev,
++	    unsigned int index);
++
++static __inline void __iomem *
+ devm_platform_ioremap_resource(struct platform_device *pdev, unsigned int index)
+ {
+-	struct resource *res;
+-	int rid = (int)index;
+-
+-	if (pdev == NULL || pdev->dev.bsddev == NULL)
+-		return (ERR_PTR(-ENODEV));
+-	res = bus_alloc_resource_any(pdev->dev.bsddev, SYS_RES_MEMORY, &rid,
+-	    RF_ACTIVE | RF_SHAREABLE);
+-	if (res == NULL)
+-		return (ERR_PTR(-ENOMEM));
+-	/*
+-	 * The mapped virtual address, which is what readl()/writel() expect.
+-	 * NOT rman_get_bushandle(): that is a bus_space_handle_t, and on some
+-	 * architectures it is not even pointer-sized, so casting it to void *
+-	 * is wrong as well as unportable.
+-	 */
+-	return (rman_get_virtual(res));
++
++	return (lkpi_platform_ioremap_resource(pdev, index));
+ }
+ 
+ /*
+diff --git a/sys/compat/linuxkpi/common/src/linux_of.c b/sys/compat/linuxkpi/common/src/linux_of.c
+index fdc7bab8d00..59df8b3af82 100644
+--- a/sys/compat/linuxkpi/common/src/linux_of.c
++++ b/sys/compat/linuxkpi/common/src/linux_of.c
+@@ -18,9 +18,16 @@
+ #include <sys/param.h>
+ #include <sys/systm.h>
+ #include <sys/malloc.h>
++#include <sys/bus.h>
++#include <sys/rman.h>
++
++#include <machine/bus.h>
++#include <machine/resource.h>
+ 
+ #include <linux/device.h>
+ #include <linux/of.h>
++#include <linux/platform_device.h>
++#include <linux/err.h>
+ 
+ #ifdef FDT
+ #include <dev/ofw/openfirm.h>
+@@ -276,3 +283,31 @@ of_dma_configure(struct device *dev __unused, struct device_node *np __unused,
+ 
+ 	return (0);
+ }
++
++/*
++ * Body of devm_platform_ioremap_resource(); see the comment on its declaration
++ * in <linux/platform_device.h> for why it cannot be inline there.
++ *
++ * "struct resource" in this file is FreeBSD's, from sys/rman.h -- this
++ * translation unit deliberately does not include <linux/ioport.h>, which
++ * declares an unrelated type of the same name.
++ */
++void *
++lkpi_platform_ioremap_resource(struct platform_device *pdev, unsigned int index)
++{
++	struct resource *res;
++	int rid = (int)index;
++
++	if (pdev == NULL || pdev->dev.bsddev == NULL)
++		return (ERR_PTR(-ENODEV));
++	res = bus_alloc_resource_any(pdev->dev.bsddev, SYS_RES_MEMORY, &rid,
++	    RF_ACTIVE | RF_SHAREABLE);
++	if (res == NULL)
++		return (ERR_PTR(-ENOMEM));
++	/*
++	 * NOT rman_get_bushandle(): that is a bus_space_handle_t, which on some
++	 * architectures is not pointer-sized, so casting it to void * is wrong
++	 * as well as unportable.
++	 */
++	return (rman_get_virtual(res));
++}
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0054-linuxkpi-component-bind-in-match-order.patch
+++ b/patches/0054-linuxkpi-component-bind-in-match-order.patch
@@ -1,0 +1,279 @@
+From f7a3809d9619478e6813e101d7a1597a0a1e4578 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 21:50:01 -0500
+Subject: [PATCH] linuxkpi: bind components in match order, and unbind with a
+ real master
+
+Two fixes in the component framework, both needed by the vc4 KMS port.
+
+1. component_bind_all() walked the global component list, so components bound
+   in device-tree order rather than the order the master asked for. Upstream
+   Linux indexes the match array instead (drivers/base/component.c, "Bind
+   components in match order"), and vc4 depends on it.
+
+   The failure is silent. vc4_crtc_bind() calls vc4_set_crtc_possible_masks(),
+   which walks the encoders ALREADY REGISTERED and sets
+   encoder->possible_crtcs; nothing revisits it. If a pixelvalve binds before
+   the HDMI encoders exist, those encoders keep possible_crtcs == 0, DRM has no
+   CRTC able to drive the HDMI connectors, fbdev finds no usable CRTC, and every
+   modeset fails while the driver reports a successful load.
+
+   bcm2712's device tree is in exactly that order: pixelvalves at 0x7c410000
+   and 0x7c411000 come before the HDMI controllers at 0x7ef00700 and 0x7ef05700,
+   so registration order puts both CRTCs ahead of both encoders on every boot.
+
+   component_unbind_all() mirrors it in reverse. A master with no match list
+   keeps the old registration-order walk -- the single-component firmware KMS
+   case this framework was written for.
+
+2. component_del() called unbind(dev, NULL, NULL). Unbind callbacks read the
+   master: vc4_hvs_unbind() calls dev_get_drvdata(master) as its first
+   statement, so kldunload of a bound pipeline was a NULL dereference rather
+   than a teardown. Components now record the master and master data they were
+   bound with, and component_del() passes them.
+
+Refs nextbsd/nextbsd-kernel-extensions#51
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
+---
+ .../linuxkpi/common/src/linux_component.c     | 177 ++++++++++++++----
+ 1 file changed, 141 insertions(+), 36 deletions(-)
+
+diff --git a/sys/compat/linuxkpi/common/src/linux_component.c b/sys/compat/linuxkpi/common/src/linux_component.c
+index 6e800549742..dfa612748c1 100644
+--- a/sys/compat/linuxkpi/common/src/linux_component.c
++++ b/sys/compat/linuxkpi/common/src/linux_component.c
+@@ -21,6 +21,15 @@ struct lkpi_component {
+ 	struct device			*dev;
+ 	const struct component_ops	*ops;
+ 	bool				bound;
++	/*
++	 * Which master this component is bound to, and the data it was bound
++	 * with. Recorded at bind because component_del() has to be able to
++	 * unbind, and unbind callbacks read the master: vc4_hvs_unbind() calls
++	 * dev_get_drvdata(master) as its first statement, so passing NULL
++	 * there is a panic on kldunload, not a degraded teardown.
++	 */
++	struct device		*master;
++	void			*master_data;
+ };
+ 
+ /*
+@@ -35,6 +44,35 @@ MTX_SYSINIT(lkpi_component, &lkpi_component_mtx, "lkpi component", MTX_DEF);
+ /* Defined with the match code below; called when a component appears. */
+ static void lkpi_try_bind_masters(void);
+ 
++/*
++ * One entry in a master's match list: a predicate and its argument. The
++ * component it selects is resolved at bind time, not here, because components
++ * may register after the master builds its list.
++ */
++struct lkpi_match_entry {
++	TAILQ_ENTRY(lkpi_match_entry)	link;
++	int			      (*compare)(struct device *, void *);
++	void			       *data;
++};
++
++struct component_match {
++	TAILQ_HEAD(lkpi_match_head, lkpi_match_entry)	entries;
++	unsigned int			count;
++};
++
++/* A registered master, waiting for its components to appear. */
++struct lkpi_master {
++	TAILQ_ENTRY(lkpi_master)	   link;
++	struct device			  *dev;
++	const struct component_master_ops *ops;
++	struct component_match		  *match;
++	bool				   bound;
++};
++
++static TAILQ_HEAD(, lkpi_master) lkpi_masters =
++    TAILQ_HEAD_INITIALIZER(lkpi_masters);
++
++
+ int
+ component_add(struct device *dev, const struct component_ops *ops)
+ {
+@@ -74,7 +112,7 @@ component_del(struct device *dev, const struct component_ops *ops)
+ 		TAILQ_REMOVE(&lkpi_components, c, link);
+ 		mtx_unlock(&lkpi_component_mtx);
+ 		if (c->bound && c->ops->unbind != NULL)
+-			c->ops->unbind(c->dev, NULL, NULL);
++			c->ops->unbind(c->dev, c->master, c->master_data);
+ 		free(c, M_DEVBUF);
+ 		return;
+ 	}
+@@ -94,66 +132,133 @@ component_del(struct device *dev, const struct component_ops *ops)
+  * immediately, which matches Linux -- the master is expected to tear down.
+  */
+ int
++/*
++ * Find the master registered for this device, if it has one, so bind order can
++ * follow its match list. Caller must hold nothing; the master list is only
++ * mutated under lkpi_component_mtx and this is a read.
++ */
++static struct lkpi_master *
++lkpi_master_for(struct device *dev)
++{
++	struct lkpi_master *m;
++
++	TAILQ_FOREACH(m, &lkpi_masters, link) {
++		if (m->dev == dev)
++			return (m);
++	}
++	return (NULL);
++}
++
++/*
++ * Bind this master's components.
++ *
++ * ORDER MATTERS, and it must follow the master's MATCH LIST rather than the
++ * order components happened to register. Upstream Linux does the same --
++ * drivers/base/component.c indexes the match array with the comment "Bind
++ * components in match order" -- and vc4 depends on it.
++ *
++ * Concretely, from the vc4 port (nextbsd-kernel-extensions#51):
++ * vc4_crtc_bind() calls vc4_set_crtc_possible_masks(), which walks the
++ * encoders ALREADY REGISTERED on the drm_device and sets
++ * encoder->possible_crtcs. If a pixelvalve (CRTC) binds before the HDMI
++ * encoders exist, that walk finds nothing, nothing revisits it, and the HDMI
++ * encoders keep possible_crtcs == 0 -- DRM then has no CRTC able to drive the
++ * HDMI connectors, fbdev finds no usable CRTC, and every modeset fails. The
++ * driver loads "successfully" and the display is silently dead.
++ *
++ * That is not hypothetical on a Pi 5: bcm2712's device tree lists the
++ * pixelvalves (0x7c410000, 0x7c411000) before the HDMI controllers
++ * (0x7ef00700, 0x7ef05700), so registration order puts both CRTCs ahead of
++ * both encoders on every boot.
++ *
++ * A master with no match list keeps the old behaviour -- bind everything in
++ * registration order -- which is the single-component case this framework was
++ * originally written for.
++ */
++int
+ component_bind_all(struct device *master, void *master_data)
+ {
++	struct lkpi_master *m;
++	struct lkpi_match_entry *e;
+ 	struct lkpi_component *c;
+ 	int error;
+ 
+-	TAILQ_FOREACH(c, &lkpi_components, link) {
+-		if (c->bound)
+-			continue;
+-		error = c->ops->bind(c->dev, master, master_data);
+-		if (error != 0)
+-			return (error);
+-		c->bound = true;
++	m = lkpi_master_for(master);
++	if (m == NULL || m->match == NULL) {
++		/* No match list: legacy path, registration order. */
++		TAILQ_FOREACH(c, &lkpi_components, link) {
++			if (c->bound)
++				continue;
++			error = c->ops->bind(c->dev, master, master_data);
++			if (error != 0)
++				return (error);
++			c->bound = true;
++			c->master = master;
++			c->master_data = master_data;
++		}
++		return (0);
++	}
++
++	TAILQ_FOREACH(e, &m->match->entries, link) {
++		TAILQ_FOREACH(c, &lkpi_components, link) {
++			if (c->bound || !e->compare(c->dev, e->data))
++				continue;
++			error = c->ops->bind(c->dev, master, master_data);
++			if (error != 0)
++				return (error);
++			c->bound = true;
++			c->master = master;
++			c->master_data = master_data;
++			break;		/* one component per match entry */
++		}
+ 	}
+ 	return (0);
+ }
+ 
++/*
++ * The mirror of component_bind_all(): unbind in reverse of the order used to
++ * bind. Walking registration order backwards would tear down in an order
++ * unrelated to how things were brought up once a match list is in play.
++ */
+ void
+ component_unbind_all(struct device *master, void *master_data)
+ {
++	struct lkpi_master *m;
++	struct lkpi_match_entry *e;
+ 	struct lkpi_component *c;
+ 
++	m = lkpi_master_for(master);
++	if (m != NULL && m->match != NULL) {
++		TAILQ_FOREACH_REVERSE(e, &m->match->entries,
++		    lkpi_match_head, link) {
++			TAILQ_FOREACH(c, &lkpi_components, link) {
++				if (!c->bound || !e->compare(c->dev, e->data))
++					continue;
++				if (c->ops->unbind != NULL)
++					c->ops->unbind(c->dev, master,
++					    master_data);
++				c->bound = false;
++				c->master = NULL;
++				c->master_data = NULL;
++				break;
++			}
++		}
++		return;
++	}
++
+ 	TAILQ_FOREACH_REVERSE(c, &lkpi_components, lkpi_component_head, link) {
+ 		if (!c->bound)
+ 			continue;
+ 		if (c->ops->unbind != NULL)
+ 			c->ops->unbind(c->dev, master, master_data);
+ 		c->bound = false;
++		c->master = NULL;
++		c->master_data = NULL;
+ 	}
+ }
+ 
+ /* ---- match-based masters (nextbsd-kernel-extensions#51) ---------------- */
+ 
+-/*
+- * One entry in a master's match list: a predicate and its argument. The
+- * component it selects is resolved at bind time, not here, because components
+- * may register after the master builds its list.
+- */
+-struct lkpi_match_entry {
+-	TAILQ_ENTRY(lkpi_match_entry)	link;
+-	int			      (*compare)(struct device *, void *);
+-	void			       *data;
+-};
+-
+-struct component_match {
+-	TAILQ_HEAD(, lkpi_match_entry)	entries;
+-	unsigned int			count;
+-};
+-
+-/* A registered master, waiting for its components to appear. */
+-struct lkpi_master {
+-	TAILQ_ENTRY(lkpi_master)	   link;
+-	struct device			  *dev;
+-	const struct component_master_ops *ops;
+-	struct component_match		  *match;
+-	bool				   bound;
+-};
+-
+-static TAILQ_HEAD(, lkpi_master) lkpi_masters =
+-    TAILQ_HEAD_INITIALIZER(lkpi_masters);
+-
+ int
+ component_compare_dev(struct device *dev, void *data)
+ {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -50,3 +50,4 @@
 0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
 0051-linuxkpi-component-match-masters.patch
 0052-linuxkpi-platform_driver-remove_new.patch
+0053-linuxkpi-rman-out-of-platform-device-h.patch

--- a/patches/series
+++ b/patches/series
@@ -51,3 +51,4 @@
 0051-linuxkpi-component-match-masters.patch
 0052-linuxkpi-platform_driver-remove_new.patch
 0053-linuxkpi-rman-out-of-platform-device-h.patch
+0054-linuxkpi-component-bind-in-match-order.patch


### PR DESCRIPTION
Two fixes in the component framework, both needed by the vc4 KMS port (nextbsd/nextbsd-kernel-extensions#51). Both were found by an adversarial review of the vc4 newbus shims rather than by a failing build — neither produces an error message.

## 1. Bind in match order

`component_bind_all()` walked the global component list, so components bound in the order they registered — for FDT drivers, device-tree order. Upstream Linux binds by indexing the match array instead (`drivers/base/component.c`, *"Bind components in match order"*).

The failure is silent. `vc4_crtc_bind()` calls `vc4_set_crtc_possible_masks()` (`vc4_crtc.c:1373-1397`), which walks the encoders **already registered** on the `drm_device` and sets `encoder->possible_crtcs`. Nothing revisits it. If a pixelvalve binds before the HDMI encoders exist, those encoders keep `possible_crtcs == 0` — DRM has no CRTC able to drive the HDMI connectors, fbdev finds no usable CRTC, and every modeset fails while the driver reports a successful load.

bcm2712's device tree is in exactly that order: pixelvalves at `0x7c410000` / `0x7c411000` come before the HDMI controllers at `0x7ef00700` / `0x7ef05700`, so registration order puts both CRTCs ahead of both encoders on every boot.

`component_unbind_all()` mirrors it in reverse. A master with no match list keeps the old registration-order walk — the single-component firmware-KMS case this framework was written for.

### What this is *not*

vc4's `component_drivers[]` is annotated *"The HDMI driver needs to be bound after the HVS so that we can lookup the HVS maximum core clock rate"*. That constraint is **stale** on `rpi-6.12.y`: the 4kp60 decision moved into `vc4_hvs_bind()` (`vc4_hvs.c:2125-2135`), which asks the firmware mailbox directly, and every remaining `vc4->hvs` use in `vc4_hdmi.c` is a runtime callback that cannot run before `drm_dev_register()`. Ordering matters here for `possible_crtcs`, not for the clock lookup.

## 2. Unbind with a real master

`component_del()` called `unbind(dev, NULL, NULL)`. Unbind callbacks read the master — `vc4_hvs_unbind()` (`vc4_hvs.c:2217-2220`) calls `dev_get_drvdata(master)` as its first statement — so `kldunload` of a bound pipeline was a NULL dereference rather than a teardown.

Components now record the master and master data they were bound with, and `component_del()` passes them.

## Testing

Full series applies clean; kernel builds on both arches. The runtime effect of (1) can't be observed until `vc4_kms.ko` links (nextbsd/nextbsd-kernel-extensions#51) — the ordering claim was verified against the vendored `bcm2712.dtsi` and a DTB read off the Pi 500+.