### PR TITLE
linuxkpi: keep sys/rman.h out of <linux/platform_device.h> (fixes drm-kmod build)

### DIFF
--- a/patches/0053-linuxkpi-rman-out-of-platform-device-h.patch
+++ b/patches/0053-linuxkpi-rman-out-of-platform-device-h.patch
@@ -1,0 +1,156 @@
+From 305bc01c830577f67e211309bbf0d5a12d9e5b6f Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Sat, 5 Sep 2026 21:39:36 -0500
+Subject: [PATCH] linuxkpi: keep sys/rman.h out of <linux/platform_device.h>
+
+Fixes a build regression from patch 0050, which added sys/rman.h to
+<linux/platform_device.h> so devm_platform_ioremap_resource() could be inline
+there.
+
+LinuxKPI declares its own struct resource in <linux/ioport.h> -- a different
+type, with different members, from FreeBSD's in sys/rman.h. Including
+sys/rman.h from platform_device.h put the FreeBSD definition ahead of the
+LinuxKPI one for every consumer of that header, so any driver that reached
+ioport.h afterwards failed with "redefinition of 'resource'". <linux/mfd/core.h>
+takes exactly that path -- it includes platform_device.h and then ioport.h --
+which broke the whole amdgpu build:
+
+  In file included from .../amdgpu.h:77:
+  In file included from .../amdgpu_acp.h:29:
+  In file included from .../linux/mfd/core.h:21:
+  .../linux/ioport.h:40:8: error: redefinition of 'resource'
+  .../sys/rman.h:102:8: note: previous definition is here
+
+The inline was unsound even where it compiled: "struct resource" inside it
+meant whichever of the two definitions was in scope at the call site.
+
+Move the body to linux_of.c, which includes sys/rman.h and deliberately does
+not include <linux/ioport.h>, and leave a declaration behind. The header no
+longer names a FreeBSD type.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01By8iBEpeLNRmud8GTFiSyc
+---
+ .../common/include/linux/platform_device.h    | 43 +++++++++++--------
+ sys/compat/linuxkpi/common/src/linux_of.c     | 35 +++++++++++++++
+ 2 files changed, 59 insertions(+), 19 deletions(-)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/platform_device.h b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+index 0e2c82dea83..18009290f0d 100644
+--- a/sys/compat/linuxkpi/common/include/linux/platform_device.h
++++ b/sys/compat/linuxkpi/common/include/linux/platform_device.h
+@@ -28,8 +28,6 @@
+ #ifndef	_LINUXKPI_LINUX_PLATFORM_DEVICE_H
+ #define	_LINUXKPI_LINUX_PLATFORM_DEVICE_H
+ 
+-#include <sys/rman.h>		/* devm_platform_ioremap_resource (#51) */
+-
+ #include <linux/kernel.h>
+ #include <linux/device.h>
+ #include <linux/errno.h>
+@@ -153,25 +151,32 @@ platform_get_irq_byname(struct platform_device *pdev, const char *name)
+  * module's lifetime. Fine for a display driver mapping registers at attach,
+  * which is every vc4 caller -- stated so the next caller knows.
+  */
+-static __inline void *
++/*
++ * Map a platform device's memory resource.
++ *
++ * The body is OUT OF LINE, in linux_of.c, and that is not a style choice.
++ *
++ * It needs FreeBSD's struct resource (sys/rman.h). LinuxKPI declares its OWN
++ * struct resource in <linux/ioport.h> -- a different type with different
++ * members. Pulling sys/rman.h in from this header put the FreeBSD definition
++ * ahead of the LinuxKPI one for every consumer, and any driver reaching
++ * ioport.h afterwards failed to build with "redefinition of 'resource'"; that
++ * is exactly the include path <linux/mfd/core.h> takes, so it broke all of
++ * amdgpu. Even where it compiled, "struct resource" inside an inline here
++ * would mean whichever definition happened to be in scope at the call site.
++ *
++ * Keeping the two definitions apart means keeping sys/rman.h out of this
++ * header. The return value is the mapped virtual address readl()/writel()
++ * expect, or an ERR_PTR().
++ */
++void	*lkpi_platform_ioremap_resource(struct platform_device *pdev,
++	    unsigned int index);
++
++static __inline void __iomem *
+ devm_platform_ioremap_resource(struct platform_device *pdev, unsigned int index)
+ {
+-	struct resource *res;
+-	int rid = (int)index;
+-
+-	if (pdev == NULL || pdev->dev.bsddev == NULL)
+-		return (ERR_PTR(-ENODEV));
+-	res = bus_alloc_resource_any(pdev->dev.bsddev, SYS_RES_MEMORY, &rid,
+-	    RF_ACTIVE | RF_SHAREABLE);
+-	if (res == NULL)
+-		return (ERR_PTR(-ENOMEM));
+-	/*
+-	 * The mapped virtual address, which is what readl()/writel() expect.
+-	 * NOT rman_get_bushandle(): that is a bus_space_handle_t, and on some
+-	 * architectures it is not even pointer-sized, so casting it to void *
+-	 * is wrong as well as unportable.
+-	 */
+-	return (rman_get_virtual(res));
++
++	return (lkpi_platform_ioremap_resource(pdev, index));
+ }
+ 
+ /*
+diff --git a/sys/compat/linuxkpi/common/src/linux_of.c b/sys/compat/linuxkpi/common/src/linux_of.c
+index fdc7bab8d00..59df8b3af82 100644
+--- a/sys/compat/linuxkpi/common/src/linux_of.c
++++ b/sys/compat/linuxkpi/common/src/linux_of.c
+@@ -18,9 +18,16 @@
+ #include <sys/param.h>
+ #include <sys/systm.h>
+ #include <sys/malloc.h>
++#include <sys/bus.h>
++#include <sys/rman.h>
++
++#include <machine/bus.h>
++#include <machine/resource.h>
+ 
+ #include <linux/device.h>
+ #include <linux/of.h>
++#include <linux/platform_device.h>
++#include <linux/err.h>
+ 
+ #ifdef FDT
+ #include <dev/ofw/openfirm.h>
+@@ -276,3 +283,31 @@ of_dma_configure(struct device *dev __unused, struct device_node *np __unused,
+ 
+ 	return (0);
+ }
++
++/*
++ * Body of devm_platform_ioremap_resource(); see the comment on its declaration
++ * in <linux/platform_device.h> for why it cannot be inline there.
++ *
++ * "struct resource" in this file is FreeBSD's, from sys/rman.h -- this
++ * translation unit deliberately does not include <linux/ioport.h>, which
++ * declares an unrelated type of the same name.
++ */
++void *
++lkpi_platform_ioremap_resource(struct platform_device *pdev, unsigned int index)
++{
++	struct resource *res;
++	int rid = (int)index;
++
++	if (pdev == NULL || pdev->dev.bsddev == NULL)
++		return (ERR_PTR(-ENODEV));
++	res = bus_alloc_resource_any(pdev->dev.bsddev, SYS_RES_MEMORY, &rid,
++	    RF_ACTIVE | RF_SHAREABLE);
++	if (res == NULL)
++		return (ERR_PTR(-ENOMEM));
++	/*
++	 * NOT rman_get_bushandle(): that is a bus_space_handle_t, which on some
++	 * architectures is not pointer-sized, so casting it to void * is wrong
++	 * as well as unportable.
++	 */
++	return (rman_get_virtual(res));
++}
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -50,3 +50,4 @@
 0050-linuxkpi-of-lookup-platform-arrays-pm-runtime.patch
 0051-linuxkpi-component-match-masters.patch
 0052-linuxkpi-platform_driver-remove_new.patch
+0053-linuxkpi-rman-out-of-platform-device-h.patch


### PR DESCRIPTION
Build-breakage fix. `main` currently cannot build drm-kmod.

## What broke

Patch 0050 (merged 25 minutes ago in #198) added `#include <sys/rman.h>` to `<linux/platform_device.h>` so `devm_platform_ioremap_resource()` could be inline there.

LinuxKPI declares its **own** `struct resource` in `<linux/ioport.h>` — a different type with different members from FreeBSD's in `sys/rman.h`. Including `sys/rman.h` from `platform_device.h` puts the FreeBSD definition ahead of the LinuxKPI one for *every consumer of that header*, so any driver that reaches `ioport.h` afterwards fails to compile. `<linux/mfd/core.h>` takes exactly that path — it includes `platform_device.h` and then `ioport.h` — so all of amdgpu went down:

```
In file included from .../amdgpu.h:77:
In file included from .../amdgpu_acp.h:29:
In file included from .../linux/mfd/core.h:21:
.../linux/ioport.h:40:8: error: redefinition of 'resource'
.../sys/rman.h:102:8: note: previous definition is here
```

The inline was unsound even where it happened to compile: `struct resource` inside it meant whichever of the two definitions was in scope at the call site.

## The fix

Move the body to `linux_of.c` — which includes `sys/rman.h` and deliberately does *not* include `<linux/ioport.h>` — and leave a declaration behind. The header no longer names a FreeBSD type, and the two `struct resource`s stay apart.

## Why CI missed it

Kernel CI builds the kernel, and the kernel doesn't reach `ioport.h` on that path, so #198 went green. The collision only surfaces in **nextbsd-kernel-extensions**, which builds drm-kmod against these headers from a different repository — a gap worth filing separately.

## Blast radius

Nothing was published from the broken headers: last successful kexts build 01:49Z, packages 21:49Z, image 22:01Z, all before the 02:14Z merge.