### PR TITLE
linuxkpi: restore request_irq for non-PCI devices (0044)

### DIFF
--- a/patches/0044-linuxkpi-request_irq-for-non-pci-devices.patch
+++ b/patches/0044-linuxkpi-request_irq-for-non-pci-devices.patch
@@ -1,0 +1,84 @@
+From 907fe19aabac7883b9abdafc7e51aa7873da1f3f Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Fri, 4 Sep 2026 16:26:54 -0500
+Subject: [PATCH] linuxkpi: let request_irq() work for a device that is not PCI
+
+lkpi_request_irq() resolves the device by searching the PCI device list:
+
+	dev = lkpi_pci_find_irq_dev(irq);
+	if (dev == NULL)
+		return -ENXIO;
+
+so a driver on any other bus fails before the interrupt is looked at, and
+request_irq() returns -ENXIO however the interrupt is wired.
+
+Measured on a Raspberry Pi 5 bringing up vc4_firmware_kms
+(nextbsd-kernel#176). With the L2 interrupt controller from #186 in place the
+interrupt was arriving correctly and counting entirely as stray, because
+nothing could register a handler:
+
+	gic0,s238:-_l2intc0            59678   16/s
+	bcm2712_l2intc0,19:            59678   16/s
+	stray bcm2712_l2intc0,19:      59678   16/s
+
+line 19 being exactly the firmwarekms node's interrupts = <19>.
+
+Such a driver passes its own device as xdev, which carries everything needed:
+bsddev to allocate against, and rid 0 -- the PCI rid mapping lkpi_irq_rid()
+performs is meaningless off that bus. Fall back to it when the PCI lookup
+finds nothing. The PCI path is unchanged.
+
+This is the third piece of LinuxKPI machinery to assume PCI, after
+to_platform_device() returning NULL (#184) and dev->dma_priv being set only by
+the PCI attach path (#187).
+
+Refs nextbsd-kernel#176.
+---
+ .../linuxkpi/common/src/linux_interrupt.c     | 31 ++++++++++++++++---
+ 1 file changed, 26 insertions(+), 5 deletions(-)
+
+diff --git a/sys/compat/linuxkpi/common/src/linux_interrupt.c b/sys/compat/linuxkpi/common/src/linux_interrupt.c
+index 378088246f2..15502f0f2c9 100644
+--- a/sys/compat/linuxkpi/common/src/linux_interrupt.c
++++ b/sys/compat/linuxkpi/common/src/linux_interrupt.c
+@@ -122,11 +122,32 @@ lkpi_request_irq(struct device *xdev, unsigned int irq,
+ 	int rid;
+ 
+ 	dev = lkpi_pci_find_irq_dev(irq);
+-	if (dev == NULL)
+-		return -ENXIO;
+-	if (xdev != NULL && xdev != dev)
+-		return -ENXIO;
+-	rid = lkpi_irq_rid(dev, irq);
++	if (dev == NULL) {
++		/*
++		 * nextbsd-kernel#176: not a device LinuxKPI attached over PCI.
++		 *
++		 * lkpi_pci_find_irq_dev() searches the PCI device list, so a
++		 * driver on any other bus fails here before the interrupt is
++		 * even looked at -- request_irq() returns -ENXIO no matter how
++		 * the interrupt is wired. Measured on a device tree device
++		 * whose interrupt was arriving correctly at its controller and
++		 * counting as stray, because nothing could ever register a
++		 * handler for it.
++		 *
++		 * Such a driver passes its own device as xdev, which is exactly
++		 * what is needed: bsddev to allocate against, and rid 0, since
++		 * the PCI rid mapping lkpi_irq_rid() performs is meaningless
++		 * off that bus. The PCI path below is untouched.
++		 */
++		if (xdev == NULL || xdev->bsddev == NULL)
++			return (-ENXIO);
++		dev = xdev;
++		rid = 0;
++	} else {
++		if (xdev != NULL && xdev != dev)
++			return -ENXIO;
++		rid = lkpi_irq_rid(dev, irq);
++	}
+ 	resflags = RF_ACTIVE;
+ 	if ((flags & IRQF_SHARED) != 0)
+ 		resflags |= RF_SHAREABLE;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -39,6 +39,7 @@
 0039-linuxkpi-dma_mmap_wc-get_sgtable-and-vm_flags_mod.patch
 0042-bcm2712-l2-interrupt-controller.patch
 0043-linuxkpi-dma_priv-init-for-non-pci-devices.patch
+0044-linuxkpi-request_irq-for-non-pci-devices.patch
 0046-clk_fixed-skip-disabled-nodes.patch
 0047-rp1_clk-peripheral-clock-gates-for-rp1.patch
 0048-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch


### PR DESCRIPTION
Reinstates patch **0044**, dropped in #204. Dropping it was wrong, and it would have silently degraded the only display driver that currently works.

## What broke

`lkpi_request_irq()` begins with `lkpi_pci_find_irq_dev()`, which searches the PCI device list. Without 0044, that returning NULL ends the function:

```c
dev = lkpi_pci_find_irq_dev(irq);
if (dev == NULL)
        return -ENXIO;
```

So **no device-tree device can register an interrupt.** `vc4_firmware_kms.c` calls `devm_request_irq()` at `:2014` and `:2024` and only logs on failure —

```c
if (ret)
        DRM_ERROR("Oh dear, failed to register IRQ\n");
```

— so firmware KMS would still attach and still publish `/dev/dri/card0`, just **with no vblank interrupt**. A silent degradation on a driver whose cursor behaviour is already under investigation, which is considerably worse to diagnose than a clean failure.

## Why no CI caught it

Three independent reasons, all of which report healthy:

- **It links.** `lkpi_request_irq` still exists; only its behaviour for non-PCI devices changed. The kext-resolution gate passes.
- **`kext PoC`** loads Nmdm/IntelWiFi and binds BochsGraphics in a VM — no device-tree device is involved.
- **Nothing in either repository exercises an FDT interrupt path.**

Only hardware would have shown it, which is why it is going back before the Pi test rather than after.

## Why this one belongs in the kernel

`request_irq()` lives in `linux_interrupt.c` and owns the `irq_ent` list and the devres integration; a module cannot reach either without reimplementing interrupt handling for the driver that works.

More importantly, the branch this adds executes **only** when `lkpi_pci_find_irq_dev()` returns NULL — only for a device LinuxKPI did not attach over PCI. i915, amdgpu and radeonkms are PCI devices and **structurally cannot reach it**. The isolation the rest of this work was about is not weakened by keeping it.

The PCI path is untouched.

## Testing

Series applies clean at 46 patches; the non-PCI branch is present in the built tree.

Refs nextbsd/nextbsd-kernel-extensions#51, #204