### PR TITLE
linuxkpi: fix multi-entry scatterlist DMA mapping (#206)

### DIFF
--- a/patches/0054-linuxkpi-map-scatterlist-entries-individually.patch
+++ b/patches/0054-linuxkpi-map-scatterlist-entries-individually.patch
@@ -1,0 +1,229 @@
+From 0ad48ad7aef898b3b9e5e567948d08def16ec70e Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 9 Sep 2026 14:13:06 -0500
+Subject: [PATCH] linuxkpi: map scatterlist entries individually
+
+linux_dma_map_sg_attrs() created one busdma map on the first S/G entry and
+loaded every entry into it. That cannot work on a platform whose busdma keeps
+a per-map sync list: alloc_dmamap() sizes the list by the tag's nsegments,
+which linux_dma_tag_init() sets to 1, and bounce_bus_dmamap_load_phys() does
+not reset map->sync_count between loads. The second physically discontiguous
+entry hits
+
+	if (map->sync_count == 0 || curaddr != sl_end) {
+		if (++map->sync_count > dmat->common.nsegments)
+			break;
+
+breaks with buflen != 0, and returns EFBIG. arm64 is such a platform; amd64
+does no cache maintenance for DMA and so never noticed.
+
+Measured on a Raspberry Pi 5 (BCM2712, non-coherent device, 16GB, no
+dma-ranges, 36-bit mask so no bouncing): a 1-entry scatterlist maps, and
+2 entries or more do not. Because the caller has no way to tell -- see the
+separate fix for dma_map_sgtable() -- a DRM driver got back a buffer that was
+never mapped and the GPU faulted on it with "write violation, pte invalid".
+
+Give each entry its own map and load one entry into each. struct scatterlist
+already carries a per-entry dma_map field, and each entry is a single
+physically contiguous run, so every map holds exactly one segment and its
+single-slot sync list is enough.
+
+linux_dma_unmap_sg_attrs() has to match, and its nents argument stops being
+__unused: the old whole-table unmap only ever touched sgl->dma_map, so
+leaving it alone would unload the first entry and leak the rest. Callers
+already pass the right count -- dma_unmap_sgtable() passes sgt->nents and
+dma_unmap_sg() passes its nents.
+
+Cost is N bus_dmamap_create() calls per table instead of 1. Correctness first;
+if that ever matters, the alternative is a larger nsegments on the tag, but
+linux_dma_map_phys_common()'s KASSERT(++nseg == 1) leans on the current
+nsegments semantics, so this is the safer shape.
+
+Refs nextbsd-kernel#206, nextbsd-kernel-extensions#72.
+---
+ sys/compat/linuxkpi/common/src/linux_pci.c | 129 ++++++++++++++-------
+ 1 file changed, 87 insertions(+), 42 deletions(-)
+
+diff --git a/sys/compat/linuxkpi/common/src/linux_pci.c b/sys/compat/linuxkpi/common/src/linux_pci.c
+index e593f92..d1488f1 100644
+--- a/sys/compat/linuxkpi/common/src/linux_pci.c
++++ b/sys/compat/linuxkpi/common/src/linux_pci.c
+@@ -2017,30 +2017,42 @@ linux_dma_map_sg_attrs(struct device *dev, struct scatterlist *sgl, int nents,
+     enum dma_data_direction direction, unsigned long attrs)
+ {
+ 	struct linux_dma_priv *priv;
+-	struct scatterlist *sg;
+-	int i, nseg;
++	struct scatterlist *sg, *sg2;
++	int i, j, nseg;
+ 	bus_dma_segment_t seg;
+ 
+ 	priv = dev->dma_priv;
+ 
+ 	DMA_PRIV_LOCK(priv);
+ 
+-	/* create common DMA map in the first S/G entry */
+-	if (bus_dmamap_create(priv->dmat, 0, &sgl->dma_map) != 0) {
+-		DMA_PRIV_UNLOCK(priv);
+-		return (0);
+-	}
+-
+-	/* load all S/G list entries */
++	/*
++	 * Give every S/G entry its own map, and load exactly one entry into
++	 * each.
++	 *
++	 * A single shared map cannot hold more than one entry on a platform
++	 * whose busdma keeps a per-map sync list. That list is sized by the
++	 * tag's nsegments -- 1, from linux_dma_tag_init() -- and is not reset
++	 * between loads, so the second physically discontiguous entry
++	 * overflows it and _bus_dmamap_load_phys() returns EFBIG. arm64 is
++	 * such a platform. amd64 does no cache maintenance for DMA and so
++	 * never noticed, which is why this went unseen for so long.
++	 *
++	 * struct scatterlist already carries a per-entry dma_map field.
++	 * linux_dma_unmap_sg_attrs() is updated to match, and the two must
++	 * stay symmetric: the old whole-table unmap only ever touched the
++	 * first entry's map.
++	 */
+ 	for_each_sg(sgl, sg, nents, i) {
++		if (bus_dmamap_create(priv->dmat, 0, &sg->dma_map) != 0)
++			goto fail;
++
+ 		nseg = -1;
+-		if (_bus_dmamap_load_phys(priv->dmat, sgl->dma_map,
++		if (_bus_dmamap_load_phys(priv->dmat, sg->dma_map,
+ 		    sg_phys(sg), sg->length, BUS_DMA_NOWAIT,
+ 		    &seg, &nseg) != 0) {
+-			bus_dmamap_unload(priv->dmat, sgl->dma_map);
+-			bus_dmamap_destroy(priv->dmat, sgl->dma_map);
+-			DMA_PRIV_UNLOCK(priv);
+-			return (0);
++			bus_dmamap_unload(priv->dmat, sg->dma_map);
++			bus_dmamap_destroy(priv->dmat, sg->dma_map);
++			goto fail;
+ 		}
+ 		KASSERT(nseg == 0,
+ 		    ("More than one segment (nseg=%d)", nseg + 1));
+@@ -2051,32 +2063,51 @@ linux_dma_map_sg_attrs(struct device *dev, struct scatterlist *sgl, int nents,
+ 	if ((attrs & DMA_ATTR_SKIP_CPU_SYNC) != 0)
+ 		goto skip_sync;
+ 
+-	switch (direction) {
+-	case DMA_BIDIRECTIONAL:
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_PREWRITE);
+-		break;
+-	case DMA_TO_DEVICE:
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_PREREAD);
+-		break;
+-	case DMA_FROM_DEVICE:
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_PREWRITE);
+-		break;
+-	default:
+-		break;
++	for_each_sg(sgl, sg, nents, i) {
++		switch (direction) {
++		case DMA_BIDIRECTIONAL:
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_PREWRITE);
++			break;
++		case DMA_TO_DEVICE:
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_PREREAD);
++			break;
++		case DMA_FROM_DEVICE:
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_PREWRITE);
++			break;
++		default:
++			break;
++		}
+ 	}
+ skip_sync:
+ 
+ 	DMA_PRIV_UNLOCK(priv);
+ 
+ 	return (nents);
++
++fail:
++	/* Undo the entries mapped before the one that failed. */
++	for_each_sg(sgl, sg2, nents, j) {
++		if (j >= i)
++			break;
++		bus_dmamap_unload(priv->dmat, sg2->dma_map);
++		bus_dmamap_destroy(priv->dmat, sg2->dma_map);
++	}
++	DMA_PRIV_UNLOCK(priv);
++
++	return (0);
+ }
+ 
+ void
+ linux_dma_unmap_sg_attrs(struct device *dev, struct scatterlist *sgl,
+-    int nents __unused, enum dma_data_direction direction,
++    int nents, enum dma_data_direction direction,
+     unsigned long attrs)
+ {
+ 	struct linux_dma_priv *priv;
++	struct scatterlist *sg;
++	int i;
+ 
+ 	priv = dev->dma_priv;
+ 
+@@ -2085,24 +2116,38 @@ linux_dma_unmap_sg_attrs(struct device *dev, struct scatterlist *sgl,
+ 	if ((attrs & DMA_ATTR_SKIP_CPU_SYNC) != 0)
+ 		goto skip_sync;
+ 
+-	switch (direction) {
+-	case DMA_BIDIRECTIONAL:
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_POSTREAD);
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_PREREAD);
+-		break;
+-	case DMA_TO_DEVICE:
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_POSTWRITE);
+-		break;
+-	case DMA_FROM_DEVICE:
+-		bus_dmamap_sync(priv->dmat, sgl->dma_map, BUS_DMASYNC_POSTREAD);
+-		break;
+-	default:
+-		break;
++	/*
++	 * Every entry carries its own map now, so sync and tear down all of
++	 * them. nents is no longer unused: it must be the count returned by
++	 * linux_dma_map_sg_attrs(), which is what dma_unmap_sgtable() and
++	 * dma_unmap_sg() already pass.
++	 */
++	for_each_sg(sgl, sg, nents, i) {
++		switch (direction) {
++		case DMA_BIDIRECTIONAL:
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_POSTREAD);
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_PREREAD);
++			break;
++		case DMA_TO_DEVICE:
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_POSTWRITE);
++			break;
++		case DMA_FROM_DEVICE:
++			bus_dmamap_sync(priv->dmat, sg->dma_map,
++			    BUS_DMASYNC_POSTREAD);
++			break;
++		default:
++			break;
++		}
+ 	}
+ skip_sync:
+ 
+-	bus_dmamap_unload(priv->dmat, sgl->dma_map);
+-	bus_dmamap_destroy(priv->dmat, sgl->dma_map);
++	for_each_sg(sgl, sg, nents, i) {
++		bus_dmamap_unload(priv->dmat, sg->dma_map);
++		bus_dmamap_destroy(priv->dmat, sg->dma_map);
++	}
+ 	DMA_PRIV_UNLOCK(priv);
+ }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0055-linuxkpi-treat-zero-from-dma_map_sg_attrs-as-failure.patch
+++ b/patches/0055-linuxkpi-treat-zero-from-dma_map_sg_attrs-as-failure.patch
@@ -1,0 +1,70 @@
+From cc5e061e232bc13fc8f162f47dfb0864b98033dc Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Wed, 9 Sep 2026 14:13:27 -0500
+Subject: [PATCH] linuxkpi: treat a zero return from dma_map_sg_attrs() as a
+ failure
+
+dma_map_sgtable() tested only for a negative return:
+
+	nents = dma_map_sg_attrs(dev, sgt->sgl, sgt->nents, dir, attrs);
+	if (nents < 0)
+		return (nents);
+	sgt->nents = nents;
+	return (0);
+
+but dma_map_sg_attrs() is linux_dma_map_sg_attrs(), which follows the legacy
+Linux convention: it returns 0 on failure and never a negative value. So
+nents < 0 can never fire, and a failed mapping was stored as sgt->nents = 0
+and reported as success. Callers then used a scatterlist that was never
+mapped, with nothing logged.
+
+Upstream Linux does not behave this way. Its dma_map_sgtable() calls
+__dma_map_sg_attrs(), which returns a negative errno, and the DMA API
+documentation states that dma_map_sgtable() converts a legacy zero return
+into an error. FreeBSD copied the wrapper's shape but wired it to a
+legacy-convention function; 4085bde9 ("Fix return value of dma_map_sgtable")
+introduced this check and deliberately let 0 through.
+
+Measured on a Raspberry Pi 5: drm_gem_shmem_get_pages_sgt_locked() saw
+ret == 0, stored the sgt, and DRM_IOCTL_V3D_CREATE_BO returned a handle for a
+buffer with zero DMA mappings. The GPU then faulted with "write violation,
+pte invalid" and nothing in the log pointed at the mapping.
+
+The preceding change fixes the mapping failure this exposed. This one is
+independent: it makes any remaining failure visible instead of silent.
+
+Note dma_map_sgtable() is a header inline, so this only takes effect in
+modules recompiled against it -- prebuilt kexts keep the old check until
+rebuilt.
+
+Refs nextbsd-kernel#206, nextbsd-kernel-extensions#72.
+---
+ .../linuxkpi/common/include/linux/dma-mapping.h      | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/sys/compat/linuxkpi/common/include/linux/dma-mapping.h b/sys/compat/linuxkpi/common/include/linux/dma-mapping.h
+index 82f1a30..1062870 100644
+--- a/sys/compat/linuxkpi/common/include/linux/dma-mapping.h
++++ b/sys/compat/linuxkpi/common/include/linux/dma-mapping.h
+@@ -524,6 +524,18 @@ dma_map_sgtable(struct device *dev, struct sg_table *sgt,
+ 	nents = dma_map_sg_attrs(dev, sgt->sgl, sgt->nents, dir, attrs);
+ 	if (nents < 0)
+ 		return (nents);
++	/*
++	 * dma_map_sg_attrs() is linux_dma_map_sg_attrs(), which follows the
++	 * legacy Linux convention and returns 0 on failure -- never a
++	 * negative value. Testing only for < 0 therefore recorded a failed
++	 * mapping as sgt->nents = 0 and reported success, handing the caller
++	 * a scatterlist that was never mapped.
++	 *
++	 * Upstream converts the legacy zero to an error here; see the DMA API
++	 * documentation for dma_map_sgtable().
++	 */
++	if (nents == 0)
++		return (-ENOMEM);
+ 	sgt->nents = nents;
+ 	return (0);
+ }
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/series
+++ b/patches/series
@@ -44,3 +44,5 @@
 0047-rp1_clk-peripheral-clock-gates-for-rp1.patch
 0048-rp1_gpio-implement-fdt-pinctrl-for-the-rp1-pin-mux.patch
 0049-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
+0054-linuxkpi-map-scatterlist-entries-individually.patch
+0055-linuxkpi-treat-zero-from-dma_map_sg_attrs-as-failure.patch


### PR DESCRIPTION
Fixes #206. Two patches, kept separate so they can be bisected and reverted independently.

**Not verified on hardware yet.** The equivalent change verified at the call site (nextbsd-kernel-extensions#74) makes the Pi 5 GPU render, but this is the base-KPI version of the same fix and has not been booted. See "Verification still outstanding" below.

## 0054 — map scatterlist entries individually (the load-bearing half)

`linux_dma_map_sg_attrs()` created one busdma map on the first S/G entry and loaded every entry into it. That cannot work where busdma keeps a per-map sync list:

- `alloc_dmamap()` sizes the list by the tag's `nsegments` (`arm64/busdma_bounce.c:368`), and `linux_dma_tag_init()` sets that to 1.
- `bounce_bus_dmamap_load_phys()` does not reset `map->sync_count` between loads; it resumes at `sl = map->slist + map->sync_count - 1` (`:744`).
- The second physically discontiguous entry hits `if (++map->sync_count > dmat->common.nsegments) break;` (`:769`), breaks with `buflen != 0`, and returns `EFBIG` (`:795`).

Note the tag's `nsegments = 1` is **not** a segment-count limit here — `_bus_dmamap_addseg()` accepts the first segment unconditionally when `*segp == -1` (`subr_busdma_bounce.c:473`), and each entry is one contiguous run. It is the sync-list capacity that overflows.

**This is why amd64 never saw it**: its busdma does no cache maintenance, so N sequential loads into one map succeed. i915 and amdgpu call the same KPI on amd64 and are unaffected in practice.

`linux_dma_unmap_sg_attrs()` has to match, and its `nents` argument stops being `__unused` — the old whole-table unmap only ever touched `sgl->dma_map`, so leaving it would unload the first entry and leak the rest. Callers already pass the right count.

## 0055 — treat a zero return as a failure

```c
	nents = dma_map_sg_attrs(dev, sgt->sgl, sgt->nents, dir, attrs);
	if (nents < 0)
		return (nents);
```

`dma_map_sg_attrs()` is `linux_dma_map_sg_attrs()`, which follows the legacy Linux convention: 0 on failure, never negative. So `nents < 0` can never fire, and a failed mapping was stored as `sgt->nents = 0` and reported as success.

Upstream Linux calls `__dma_map_sg_attrs()`, which returns a negative errno, and the [DMA API docs](https://docs.kernel.org/core-api/dma-api.html) say `dma_map_sgtable()` converts a legacy zero into an error. FreeBSD copied the wrapper's shape but wired it to a legacy-convention function; `4085bde9` introduced this check and deliberately let 0 through.

## Ordering matters

**0054 is the one that fixes things.** It is a real function in `linux_pci.c`, so it repairs every caller in every module **with no rebuilds** — including drm-kmod's eight call sites (`drm_prime.c:699`, `amdgpu_ttm.c:821`, `amdgpu_dma_buf.c:188`, `radeon_ttm.c:370`, `i915_gem_dmabuf.c:56`, `i915_gem_ttm.c:229/:565`, `i915_gem_gtt.c:31`), which no module-side change can reach.

**0055 is a header inline**, so it only takes effect in modules recompiled against it. A prebuilt `drm.ko` from the current `continuous` keeps the old check until rebuilt. It is worth having — it makes any remaining failure visible — but on its own it fixes nothing already built.

## Risk

`dma_map_sg_attrs()` is shared by DRM (i915/amdgpu/radeon via drm-kmod), LinuxKPI wifi, and OFED. Two mitigating facts from the audit in #206:

- **iwlwifi cannot currently reach the multi-entry case**: lkpi-80211 linearizes mbufs into a flat skb (`linux_80211.c:5767, :5799`), so `nr_frags = 0` and every table is 1 entry.
- **OFED already checks `<= 0`** (`ib_umem.c:201`, `mlx4_icm.c`, `mthca_memfree.c`), so it fails loudly rather than silently on any affected platform.

0055 will surface latent failures elsewhere that are currently silent. That is the intent, but expect errors where there used to be quiet corruption.

Cost: N `bus_dmamap_create()` calls per table instead of 1. Correctness first. Raising `nsegments` on the tag would also give the sync list room, but `linux_dma_map_phys_common()`'s `KASSERT(++nseg == 1)` (`linux_pci.c:1653`) leans on the current semantics, so per-entry maps is the safer shape.

## House rules

- Kernel-worthy under the `linuxkpi-changes` skill: allocator plumbing needing state private to `linux_pci.c`, same category as 0012/0038/0043.
- No struct layout changes, no new `sys/*.h` includes in a LinuxKPI header, no new non-static functions.
- Numbers 0054/0055 because 0040/0041/0045 and 0050–0053 are burned holes from #203/#204, and the skill still cites 0040 and 0050 as the historical breakers.
- Verified the whole linuxkpi portion of the series applies in order on a clean `releng/15.1` checkout: 0012, 0038, 0039, 0043, 0044, 0054, 0055 all apply, and both changes are present in the result.

## Verification still outstanding

- [ ] amd64 kernel build + smoke boot (CI covers this)
- [ ] arm64 kernel build (CI); **no arm64 boot test exists**, so the platform this actually fixes is not covered
- [ ] `drm-kmod build` in nextbsd-kernel-extensions — cannot run until this merges and `publish continuous` completes
- [ ] Pi 5: `CREATE_BO` sweep clean and the v3d PoC rendering, with nextbsd-kernel-extensions#74 **reverted**, to prove the base fix stands alone
- [ ] amd64 hardware with i915 or amdgpu — the highest-risk consumer and the one CI's qemu boot does not exercise

The last two are the ones that matter. Until #74 is reverted and the Pi still renders, this is unproven as a standalone fix.

Refs #206, nextbsd-kernel-extensions#72, nextbsd-kernel-extensions#74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LPTBK4VWunhgu98NNGsXb
