### PR TITLE
patch: fix the linsysfs boot panic on multi-PCIe-domain arm64 (#209)

### DIFF
--- a/boot.log
+++ b/boot.log
@@ -1,2 +1,0 @@
-spawn qemu-system-aarch64 -machine virt -accel tcg -cpu max -m 4096 -smp 2 -drive if=pflash,format=raw,unit=0,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd -drive if=pflash,format=raw,unit=1,file=vars.fd -drive if=none,id=hd0,format=raw,file=disk.img -device virtio-blk-device,drive=hd0 -netdev user,id=net0 -device virtio-net-device,netdev=net0 -display none -serial stdio
-qemu-system-aarch64: -drive if=pflash,format=raw,unit=0,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd: Could not open '/usr/share/AAVMF/AAVMF_CODE.fd': No such file or directory

--- a/patches/0056-pseudofs-create-the-vnode-cache-before-the-filesystems.patch
+++ b/patches/0056-pseudofs-create-the-vnode-cache-before-the-filesystems.patch
@@ -1,0 +1,98 @@
+From 3da5cf1109e66ca86e5296bbbc084aaf0eebb44e Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Thu, 10 Sep 2026 22:59:11 -0500
+Subject: [PATCH 1/2] pseudofs: create the vnode cache before the filesystems
+ that use it (#209)
+
+pfs_purge() walks pfs_vncache_hashtbl[] and locks pfs_vncache_mutex. Both are
+set up by pfs_vncache_load(), called from pseudofs' MOD_LOAD handler, which
+DECLARE_MODULE places at SI_SUB_EXEC (0x7400000). Every statically compiled
+pseudofs filesystem registers from VFS_SET() at SI_SUB_VFS (0x4000000) --
+three subsystems earlier -- and vfs_register() calls vfs_init(), and so
+pfs_init(), eagerly at registration time. MODULE_DEPEND() orders kldload, not
+SYSINITs, so it does not cover the compiled-in case.
+
+Any pfs_create_*() failure during a filesystem's pi_init() therefore reaches
+pfs_destroy() -> pfs_purge() with the hash table still NULL and the mutex
+still zeroed. pfs_vncache_hash is 0 at that point too, so the loop runs
+exactly once and reads *(void **)NULL.
+
+Measured on a Raspberry Pi 500+ (BCM2712) with LINSYSFS compiled in. The board
+has two PCIe host bridges, so linsysfs -- which names every node from a
+hardcoded "0000" domain prefix -- renders both root ports as 0000:00:00.0 and
+pfs_add_node() rejects the second:
+
+  pfs_add_node: homonymous siblings: 'pci0000:00/0000:00:00.0' type 2
+  Fatal data abort:
+    far: 0x0000000000000000
+    esr: 0x0000000096000004
+     lr: 0xffff00000043ecec
+    elr: 0xffff000000440180
+  panic: vm_fault failed: 0xffff000000440180 error 1
+  Uptime: 1s
+
+esr 0x96000004 is a level-0 translation fault on a read (WnR=0), far is zero
+exactly, and elr/lr resolve to the SLIST_FIRST(&pfs_vncache_hashtbl[i]) load
+in pfs_purge() called from pfs_destroy(). This is the boot-panic form of
+FreeBSD PR 278234, which D52038/D52157 turned from a pfs_add_node() panic
+into a graceful EEXIST -- graceful only if the teardown path survives.
+
+Moving the module to SI_SUB_VFS/SI_ORDER_FIRST is the fix: SI_ORDER_FIRST
+sorts before VFS_SET's SI_ORDER_MIDDLE at the same subsystem. Everything
+pfs_vncache_load() touches is ready by then -- hashinit() needs SI_SUB_KMEM
+(0x1800000) and maxproc, which init_param2() sets from initarm()/init386()
+before mi_startup() runs any SYSINIT, and EVENTHANDLER_REGISTER() needs
+SI_SUB_EVENTHANDLER (0x1C00000). Shutdown ordering improves as a side effect:
+module_shutdown runs in reverse registration order, so pfs_vncache_unload()
+now happens after its consumers rather than before them. kldload is unchanged.
+
+The NULL check in pfs_purge() is not redundant with the reordering; it states
+the invariant locally and keeps the teardown path safe for any future caller
+that runs earlier still. It has to precede the mtx_lock(), because the mutex
+is uninitialised on exactly the same paths as the table.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_014m6xNAWMJF6p7xPeGJKsJQ
+---
+ sys/fs/pseudofs/pseudofs.c         | 10 +++++++++-
+ sys/fs/pseudofs/pseudofs_vncache.c |  8 ++++++++
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/sys/fs/pseudofs/pseudofs.c b/sys/fs/pseudofs/pseudofs.c
+index 7a4e674..4151f73 100644
+--- a/sys/fs/pseudofs/pseudofs.c
++++ b/sys/fs/pseudofs/pseudofs.c
+@@ -550,5 +550,13 @@ static moduledata_t pseudofs_data = {
+ 	pfs_modevent,
+ 	NULL
+ };
+-DECLARE_MODULE(pseudofs, pseudofs_data, SI_SUB_EXEC, SI_ORDER_FIRST);
++/*
++ * The vnode cache must exist before any statically compiled pseudofs
++ * filesystem is registered. VFS_SET() declares those at SI_SUB_VFS /
++ * SI_ORDER_MIDDLE and vfs_register() calls pfs_init() eagerly, so a
++ * pfs_create_*() failure there reaches pfs_destroy() -> pfs_purge()
++ * while pfs_vncache_hashtbl is still NULL. MODULE_DEPEND() orders
++ * kldload, not SYSINITs, so it does not help the compiled-in case.
++ */
++DECLARE_MODULE(pseudofs, pseudofs_data, SI_SUB_VFS, SI_ORDER_FIRST);
+ MODULE_VERSION(pseudofs, 1);
+diff --git a/sys/fs/pseudofs/pseudofs_vncache.c b/sys/fs/pseudofs/pseudofs_vncache.c
+index e58aced..34bccc3 100644
+--- a/sys/fs/pseudofs/pseudofs_vncache.c
++++ b/sys/fs/pseudofs/pseudofs_vncache.c
+@@ -303,6 +303,14 @@ pfs_purge(struct pfs_node *pn)
+ 	struct vnode *vnp;
+ 	u_long i, removed;
+ 
++	/*
++	 * Nothing can be cached before pfs_vncache_load() has run, and
++	 * pfs_vncache_mutex is not initialised yet either -- so this test
++	 * has to come before the lock, not after it.
++	 */
++	if (pfs_vncache_hashtbl == NULL)
++		return;
++
+ 	mtx_lock(&pfs_vncache_mutex);
+ restart:
+ 	removed = 0;

--- a/patches/0057-linsysfs-drop-the-duplicated-pfs_create_dir.patch
+++ b/patches/0057-linsysfs-drop-the-duplicated-pfs_create_dir.patch
@@ -1,0 +1,51 @@
+From cd77003f8b5e37ba6399737cc7efffec6967da91 Mon Sep 17 00:00:00 2001
+From: pkgdemon <jpm820@gmail.com>
+Date: Thu, 10 Sep 2026 22:59:11 -0500
+Subject: [PATCH 2/2] linsysfs: drop the duplicated pfs_create_dir for each PCI
+ device (#209)
+
+linsysfs_run_bus() creates each PCI device's directory twice:
+
+	error = pfs_create_dir(dir, &dir, device, NULL, NULL, NULL, 0);
+	if (error != 0)
+		goto out;
+	pfs_create_dir(dir, &dir, device, NULL, NULL, NULL, 0);
+
+The second call is a rebase artifact, not intent. cc70c7989bfb (D52038) added
+one error-checked `dir = pfs_create_dir(...)' under the old pointer-returning
+API; the coccinelle conversion in a2f08d0ddc29 (D52157) converted that call
+and emitted a second copy of it, visible directly in that commit's diff.
+
+Because the first call reassigns dir to the node it just made, the second one
+nests an identically named directory inside it. Every PCI device therefore
+appears as
+
+	/sys/devices/pci0000:00/0000:00:00.0/0000:00:00.0/vendor
+
+instead of one level, children of a bridge nest under the doubled directory,
+and the scsi_host `device' links dangle -- they are built from new_path, which
+appends the device name only once.
+
+This is platform independent; amd64 has been shipping the doubled layout since
+15.0. Removing the stray call restores the pre-D52157 single-level tree. The
+surviving call keeps its error check.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_014m6xNAWMJF6p7xPeGJKsJQ
+---
+ sys/compat/linsysfs/linsysfs.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/sys/compat/linsysfs/linsysfs.c b/sys/compat/linsysfs/linsysfs.c
+index 5a41c51..44ac472 100644
+--- a/sys/compat/linsysfs/linsysfs.c
++++ b/sys/compat/linsysfs/linsysfs.c
+@@ -298,8 +298,6 @@ linsysfs_run_bus(device_t dev, struct pfs_node *dir, struct pfs_node *scsi,
+ 				    NULL, NULL, NULL, 0);
+ 				if (error != 0)
+ 					goto out;
+-				pfs_create_dir(dir, &dir, device, NULL, NULL,
+-				    NULL, 0);
+ 				pfs_create_file(dir, &cur_file, "vendor",
+ 				    &linsysfs_fill_vendor, NULL, NULL, NULL,
+ 				    PFS_RD);

--- a/patches/series
+++ b/patches/series
@@ -46,3 +46,5 @@
 0049-rp1_pwm-driver-for-the-rp1-pwm-blocks.patch
 0054-linuxkpi-map-scatterlist-entries-individually.patch
 0055-linuxkpi-treat-zero-from-dma_map_sg_attrs-as-failure.patch
+0056-pseudofs-create-the-vnode-cache-before-the-filesystems.patch
+0057-linsysfs-drop-the-duplicated-pfs_create_dir.patch


### PR DESCRIPTION
Fixes #209.

The Pi 500+ stopped booting on current `main`. #208 compiled `LINSYSFS` into arm64 for the first time and `config/NEXTBSD-RPI5` does `include NEXTBSD`, so the Pi inherited it — the first time `linsysfs_init()` has ever run on arm64 hardware.

```
pfs_add_node: homonymous siblings: 'pci0000:00/0000:00:00.0' type 2
Fatal data abort:
  far: 0x0000000000000000
  esr: 0x0000000096000004
panic: vm_fault failed: 0xffff000000440180 error 1
Uptime: 1s
```

`esr 0x96000004` = level-0 translation fault on a **read**, `far` zero exactly. `elr`/`lr` resolve to `SLIST_FIRST(&pfs_vncache_hashtbl[i])` in `pfs_purge()` called from `pfs_destroy()` — pinned two ways against the CI `kernel.full`, both agreeing on a local symbol delta of `0x60`.

### Root cause

linsysfs names PCI nodes from a hardcoded `"0000"` domain prefix (`linsysfs.c:542`, `:290-294`), so the board's two PCIe host bridges — NVMe on pcie1, RP1 on pcie2, per patch 0013 — both render their root port as `0000:00:00.0`. `pfs_add_node()` correctly returns `EEXIST`; `pfs_create_dir()`'s error path then calls `pfs_destroy()` → `pfs_purge()`, which walks `pfs_vncache_hashtbl[]`. That table is allocated at `SI_SUB_EXEC` (0x7400000), but every statically compiled pseudofs filesystem registers from `VFS_SET()` at `SI_SUB_VFS` (0x4000000) and `vfs_register()` calls `pfs_init()` eagerly. `MODULE_DEPEND()` orders kldload, not SYSINITs.

### Patches

**0056 — pseudofs: create the vnode cache before the filesystems that use it.** Moves `DECLARE_MODULE` to `SI_SUB_VFS, SI_ORDER_FIRST` and adds a NULL guard in `pfs_purge()` *before* the `mtx_lock` (the mutex is uninitialised on the same paths). Preconditions verified: `hashinit()` needs SI_SUB_KMEM and `maxproc`, both set by `init_param2()` before `mi_startup()` runs any SYSINIT; `EVENTHANDLER_REGISTER()` needs SI_SUB_EVENTHANDLER. Shutdown ordering improves as a side effect.

**0057 — linsysfs: drop the duplicated `pfs_create_dir`.** Unrelated upstream rebase artifact found while reading the same function: `cc70c7989bfb` added one error-checked call, and the coccinelle conversion in `a2f08d0ddc29` converted it *and emitted a second copy*. Every PCI device directory is created twice and nested (`.../0000:00:00.0/0000:00:00.0/vendor`) and the `scsi_host` links dangle. **amd64 has been shipping this since 15.0.**

Also drops `boot.log`, a local qemu dry-run committed by accident in #208.

### Deliberately not fixed here

The second domain's subtree is still *omitted* rather than crashing, with `linsysfs_run_bus: ... omitted from sysfs tree, error 17` on the console. That is upstream's designed degradation and it is visible, not silent. Making linsysfs domain-aware is the fast-follow tracked in #209.

### Upstream

This is the boot-panic form of FreeBSD **PR 278234** (open since 2024, Graviton, domains 3 and 11). Both patches are written to go upstream verbatim and are MFC/errata material for releng/15.0.

### Testing

- Both patches `git apply --check` clean against pristine releng/15.0 and produce the intended result.
- **Not yet booted on hardware.** CI cannot cover this: qemu has no BCM2712 model, and the arm64 boot job runs `-M virt`, which has a single PCI domain and so cannot reproduce a multi-domain collision. Needs a `kernel8.img` swap on the Pi before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6xNAWMJF6p7xPeGJKsJQ